### PR TITLE
Fix: URL drag-and-drop overlay and podcast page drop targets

### DIFF
--- a/cultpodcasts/src/app/app.component.html
+++ b/cultpodcasts/src/app/app.component.html
@@ -1,14 +1,36 @@
 <div id="top"></div>
 @if (isDragOver) {
 <div class="drop-overlay" aria-hidden="true">
-  <p>Drop episode link to submit</p>
+  @if (isOnPodcastPage) {
+  <div class="drop-targets">
+    <div class="drop-target"
+      [class.drop-target-active]="activeDropTarget === 'general'"
+      (dragenter)="onTargetDragEnter('general', $event)"
+      (dragleave)="onTargetDragLeave($event)"
+      (dragover)="onDragOver($event)"
+      (drop)="onDropGeneral($event)">
+      <mat-icon>link</mat-icon>
+      <p class="drop-target-title">Submit episode link</p>
+      <p class="drop-target-desc">Add as a general submission — Cult Podcasts will match the podcast automatically.</p>
+    </div>
+    <div class="drop-target"
+      [class.drop-target-active]="activeDropTarget === 'podcast'"
+      (dragenter)="onTargetDragEnter('podcast', $event)"
+      (dragleave)="onTargetDragLeave($event)"
+      (dragover)="onDragOver($event)"
+      (drop)="onDropForPodcast($event)">
+      <mat-icon>podcasts</mat-icon>
+      <p class="drop-target-title">Submit to {{ podcastPageName }}</p>
+      <p class="drop-target-desc">Link this episode to the podcast shown on this page.</p>
+    </div>
+  </div>
+  } @else {
+  <p class="drop-overlay-message">Drop episode link to submit</p>
+  }
 </div>
 }
 <section id="body"
-  [class.drop-target-active]="isDragOver"
-  (dragenter)="onDragEnter($event)"
   (dragover)="onDragOver($event)"
-  (dragleave)="onDragLeave($event)"
   (drop)="onDrop($event)">
   <app-toolbar></app-toolbar>
   <app-search-bar></app-search-bar>

--- a/cultpodcasts/src/app/app.component.sass
+++ b/cultpodcasts/src/app/app.component.sass
@@ -13,10 +13,6 @@
     scroll-snap-align: start
     scroll-snap-stop: always
 
-#body.drop-target-active
-    outline: 2px dashed var(--mat-sys-primary, #8ab4f8)
-    outline-offset: -2px
-
 .drop-overlay
     position: fixed
     inset: 0
@@ -24,16 +20,50 @@
     display: flex
     align-items: center
     justify-content: center
-    pointer-events: none
+    padding: 16px
     background-color: rgba(0, 0, 0, 0.45)
-    p
+
+.drop-overlay-message
+    margin: 0
+    padding: 16px 24px
+    border-radius: 12px
+    background-color: rgba(0, 0, 0, 0.7)
+    font-size: 1.1em
+    font-weight: 600
+
+.drop-targets
+    display: flex
+    flex-direction: column
+    gap: 16px
+    width: 100%
+    max-width: 480px
+
+.drop-target
+    display: flex
+    flex-direction: column
+    align-items: center
+    gap: 8px
+    padding: 24px 20px
+    border-radius: 12px
+    background-color: rgba(0, 0, 0, 0.7)
+    border: 2px solid rgba(255, 255, 255, 0.2)
+    text-align: center
+    cursor: copy
+    mat-icon
+        font-size: 32px
+        width: 32px
+        height: 32px
+    .drop-target-title
         margin: 0
-        padding: 16px 24px
-        border: 2px dashed var(--mat-sys-primary, #8ab4f8)
-        border-radius: 12px
-        background-color: rgba(0, 0, 0, 0.7)
         font-size: 1.1em
         font-weight: 600
+    .drop-target-desc
+        margin: 0
+        font-size: 0.9em
+        opacity: 0.85
+    &.drop-target-active
+        border-color: var(--mat-sys-primary, #8ab4f8)
+        background-color: rgba(0, 0, 0, 0.85)
 
 #results, #homepage
     margin-top: 5px

--- a/cultpodcasts/src/app/app.component.ts
+++ b/cultpodcasts/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject, PLATFORM_ID, ViewChild } from '@angular/core';
+import { Component, Inject, OnDestroy, PLATFORM_ID, ViewChild } from '@angular/core';
 import { Router, RouterLink, RouterOutlet } from '@angular/router';
 import { ShareMode } from "./share-mode.enum";
 import { isPlatformBrowser } from '@angular/common';
@@ -28,11 +28,11 @@ import {
   imports: [RouterOutlet, RouterLink, MatIconModule, MatMenuModule, ToolbarComponent, SearchBarComponent]
 })
 
-export class AppComponent {
+export class AppComponent implements OnDestroy {
   isBrowser: boolean;
   protected FeatureSwitch = FeatureSwitch;
   isDragOver: boolean = false;
-  private dragDepth: number = 0;
+  activeDropTarget: 'general' | 'podcast' | null = null;
 
   @ViewChild(ToolbarComponent)
   private toolbar!: ToolbarComponent;
@@ -61,7 +61,14 @@ export class AppComponent {
     }
   }
 
+  ngOnDestroy(): void {
+    if (this.isBrowser) {
+      this.removeDragListeners();
+    }
+  }
+
   initialiseBrowser() {
+    this.addDragListeners();
     navigator.serviceWorker.addEventListener('message', this.onSwMessage.bind(this));
     this.profileService.roles.subscribe(async roles => {
       if (roles.includes("Admin")) {
@@ -88,6 +95,14 @@ export class AppComponent {
     }
   }
 
+  get isOnPodcastPage(): boolean {
+    return this.podcastPageName !== undefined;
+  }
+
+  get podcastPageName(): string | undefined {
+    return this.resolvePodcastNameFromRoute();
+  }
+
   onDragOver(event: DragEvent) {
     if (!this.isBrowser || !this.hasDroppableUrl(event)) {
       return;
@@ -98,33 +113,95 @@ export class AppComponent {
     }
   }
 
-  onDragEnter(event: DragEvent) {
+  onTargetDragEnter(target: 'general' | 'podcast', event: DragEvent) {
     if (!this.isBrowser || !this.hasDroppableUrl(event)) {
       return;
     }
     event.preventDefault();
-    this.dragDepth++;
-    this.isDragOver = true;
+    event.stopPropagation();
+    this.activeDropTarget = target;
   }
 
-  onDragLeave(event: DragEvent) {
-    if (!this.isBrowser || !this.hasDroppableUrl(event)) {
-      return;
+  onTargetDragLeave(event: DragEvent) {
+    const related = event.relatedTarget as Node | null;
+    const currentTarget = event.currentTarget as Node | null;
+    if (!related || !currentTarget?.contains(related)) {
+      this.activeDropTarget = null;
     }
-    event.preventDefault();
-    this.dragDepth = Math.max(0, this.dragDepth - 1);
-    if (this.dragDepth === 0) {
-      this.isDragOver = false;
-    }
+  }
+
+  async onDropGeneral(event: DragEvent) {
+    event.stopPropagation();
+    await this.handleDrop(event, false);
+  }
+
+  async onDropForPodcast(event: DragEvent) {
+    event.stopPropagation();
+    await this.handleDrop(event, true);
   }
 
   async onDrop(event: DragEvent) {
+    if (this.isOnPodcastPage) {
+      event.preventDefault();
+      this.resetDragState();
+      return;
+    }
+    await this.handleDrop(event, false);
+  }
+
+  private addDragListeners(): void {
+    document.addEventListener('dragenter', this.onDocumentDragEnter);
+    document.addEventListener('dragover', this.onDocumentDragOver);
+    document.addEventListener('dragend', this.onDocumentDragEnd);
+    window.addEventListener('blur', this.onWindowBlur);
+  }
+
+  private removeDragListeners(): void {
+    document.removeEventListener('dragenter', this.onDocumentDragEnter);
+    document.removeEventListener('dragover', this.onDocumentDragOver);
+    document.removeEventListener('dragend', this.onDocumentDragEnd);
+    window.removeEventListener('blur', this.onWindowBlur);
+  }
+
+  private readonly onDocumentDragEnter = (event: DragEvent) => {
+    if (!this.hasDroppableUrl(event)) {
+      return;
+    }
+    event.preventDefault();
+    this.isDragOver = true;
+  };
+
+  private readonly onDocumentDragOver = (event: DragEvent) => {
+    if (!this.hasDroppableUrl(event)) {
+      return;
+    }
+    event.preventDefault();
+    if (event.dataTransfer) {
+      event.dataTransfer.dropEffect = 'copy';
+    }
+  };
+
+  private readonly onDocumentDragEnd = () => {
+    this.resetDragState();
+  };
+
+  private readonly onWindowBlur = () => {
+    if (this.isDragOver) {
+      this.resetDragState();
+    }
+  };
+
+  private resetDragState(): void {
+    this.isDragOver = false;
+    this.activeDropTarget = null;
+  }
+
+  private async handleDrop(event: DragEvent, forPodcast: boolean) {
     if (!this.isBrowser) {
       return;
     }
     event.preventDefault();
-    this.dragDepth = 0;
-    this.isDragOver = false;
+    this.resetDragState();
 
     const dataTransfer = event.dataTransfer;
     if (!dataTransfer) {
@@ -146,7 +223,7 @@ export class AppComponent {
     await this.toolbar.sendPodcast({
       url,
       podcastId: undefined,
-      podcastName: this.resolvePodcastNameFromRoute(),
+      podcastName: forPodcast ? this.podcastPageName : undefined,
       shareMode: ShareMode.Text
     });
   }


### PR DESCRIPTION
## Summary
- Fix stuck drag overlay by using document-level drag listeners and resetting state on dragend and window blur instead of nested dragenter/dragleave depth counting.
- Remove the dashed outline on the main content area during drag; keep feedback in the overlay only.
- On podcast pages, show two drop targets (general episode submit vs submit tied to the current podcast) with distinct drop handlers.

## Test plan
- [ ] Drag a URL over the site from outside the browser; confirm overlay appears and clears when drag is cancelled or the pointer leaves the window.
- [ ] On a non-podcast page, drop a valid episode URL on the overlay/body and confirm submission opens with no podcast pre-selected.
- [ ] Open a podcast detail page, drag a URL, and confirm two targets appear with correct labels.
- [ ] Drop on each target and verify general vs podcast-scoped submission behavior.
- [ ] Confirm no dashed border around the page body while dragging.
