### PR TITLE
Fix: URL drag overlay drop handling and cancel reset

### DIFF
--- a/cultpodcasts/src/app/app.component.html
+++ b/cultpodcasts/src/app/app.component.html
@@ -1,6 +1,8 @@
 <div id="top"></div>
 @if (isDragOver) {
-<div class="drop-overlay" aria-hidden="true">
+<div class="drop-overlay" aria-hidden="true"
+  (dragover)="onDragOver($event)"
+  (drop)="onDrop($event)">
   @if (isOnPodcastPage) {
   <div class="drop-targets">
     <div class="drop-target"

--- a/cultpodcasts/src/app/app.component.html
+++ b/cultpodcasts/src/app/app.component.html
@@ -3,7 +3,7 @@
 <div class="drop-overlay" aria-hidden="true"
   (dragover)="onDragOver($event)"
   (drop)="onDrop($event)">
-  @if (isOnPodcastPage) {
+  @if (isOnPodcastPage && canSubmitUrlForPodcast) {
   <div class="drop-targets">
     <div class="drop-target"
       [class.drop-target-active]="activeDropTarget === 'general'"
@@ -15,7 +15,6 @@
       <p class="drop-target-title">Submit episode link</p>
       <p class="drop-target-desc">Add as a general submission — Cult Podcasts will match the podcast automatically.</p>
     </div>
-    @if (canSubmitUrlForPodcast) {
     <div class="drop-target"
       [class.drop-target-active]="activeDropTarget === 'podcast'"
       (dragenter)="onTargetDragEnter('podcast', $event)"
@@ -26,7 +25,6 @@
       <p class="drop-target-title">Submit to {{ podcastPageName }}</p>
       <p class="drop-target-desc">Link this episode to the podcast shown on this page.</p>
     </div>
-    }
   </div>
   } @else {
   <p class="drop-overlay-message">Drop episode link to submit</p>

--- a/cultpodcasts/src/app/app.component.html
+++ b/cultpodcasts/src/app/app.component.html
@@ -15,6 +15,7 @@
       <p class="drop-target-title">Submit episode link</p>
       <p class="drop-target-desc">Add as a general submission — Cult Podcasts will match the podcast automatically.</p>
     </div>
+    @if (canSubmitUrlForPodcast) {
     <div class="drop-target"
       [class.drop-target-active]="activeDropTarget === 'podcast'"
       (dragenter)="onTargetDragEnter('podcast', $event)"
@@ -25,6 +26,7 @@
       <p class="drop-target-title">Submit to {{ podcastPageName }}</p>
       <p class="drop-target-desc">Link this episode to the podcast shown on this page.</p>
     </div>
+    }
   </div>
   } @else {
   <p class="drop-overlay-message">Drop episode link to submit</p>

--- a/cultpodcasts/src/app/app.component.html
+++ b/cultpodcasts/src/app/app.component.html
@@ -1,14 +1,36 @@
 <div id="top"></div>
 @if (isDragOver) {
 <div class="drop-overlay" aria-hidden="true">
-  <p>Drop episode link to submit</p>
+  @if (isOnPodcastPage) {
+  <div class="drop-targets">
+    <div class="drop-target"
+      [class.drop-target-active]="activeDropTarget === 'general'"
+      (dragenter)="onTargetDragEnter('general', $event)"
+      (dragleave)="onTargetDragLeave($event)"
+      (dragover)="onDragOver($event)"
+      (drop)="onDropGeneral($event)">
+      <mat-icon>link</mat-icon>
+      <p class="drop-target-title">Submit episode link</p>
+      <p class="drop-target-desc">Add as a general submission — Cult Podcasts will match the podcast automatically.</p>
+    </div>
+    <div class="drop-target"
+      [class.drop-target-active]="activeDropTarget === 'podcast'"
+      (dragenter)="onTargetDragEnter('podcast', $event)"
+      (dragleave)="onTargetDragLeave($event)"
+      (dragover)="onDragOver($event)"
+      (drop)="onDropForPodcast($event)">
+      <mat-icon>podcasts</mat-icon>
+      <p class="drop-target-title">Submit to {{ podcastPageName }}</p>
+      <p class="drop-target-desc">Link this episode to the podcast shown on this page.</p>
+    </div>
+  </div>
+  } @else {
+  <p class="drop-overlay-message">Drop episode link to submit</p>
+  }
 </div>
 }
 <section id="body"
-  [class.drop-target-active]="isDragOver"
-  (dragenter)="onDragEnter($event)"
   (dragover)="onDragOver($event)"
-  (dragleave)="onDragLeave($event)"
   (drop)="onDrop($event)">
   <app-toolbar></app-toolbar>
   <app-search-bar></app-search-bar>

--- a/cultpodcasts/src/app/app.component.sass
+++ b/cultpodcasts/src/app/app.component.sass
@@ -13,10 +13,6 @@
     scroll-snap-align: start
     scroll-snap-stop: always
 
-#body.drop-target-active
-    outline: 2px dashed var(--mat-sys-primary, #8ab4f8)
-    outline-offset: -2px
-
 .drop-overlay
     position: fixed
     inset: 0
@@ -24,16 +20,50 @@
     display: flex
     align-items: center
     justify-content: center
-    pointer-events: none
+    padding: 16px
     background-color: rgba(0, 0, 0, 0.45)
-    p
+
+.drop-overlay-message
+    margin: 0
+    padding: 16px 24px
+    border-radius: 12px
+    background-color: rgba(0, 0, 0, 0.7)
+    font-size: 1.1em
+    font-weight: 600
+
+.drop-targets
+    display: flex
+    flex-direction: column
+    gap: 16px
+    width: 100%
+    max-width: 480px
+
+.drop-target
+    display: flex
+    flex-direction: column
+    align-items: center
+    gap: 8px
+    padding: 24px 20px
+    border-radius: 12px
+    background-color: rgba(0, 0, 0, 0.7)
+    border: 2px solid rgba(255, 255, 255, 0.2)
+    text-align: center
+    cursor: copy
+    mat-icon
+        font-size: 32px
+        width: 32px
+        height: 32px
+    .drop-target-title
         margin: 0
-        padding: 16px 24px
-        border: 2px dashed var(--mat-sys-primary, #8ab4f8)
-        border-radius: 12px
-        background-color: rgba(0, 0, 0, 0.7)
         font-size: 1.1em
         font-weight: 600
+    .drop-target-desc
+        margin: 0
+        font-size: 0.9em
+        opacity: 0.85
+    &.drop-target-active
+        border-color: var(--mat-sys-primary, #8ab4f8)
+        background-color: rgba(0, 0, 0, 0.85)
 
 #results, #homepage
     margin-top: 5px

--- a/cultpodcasts/src/app/app.component.ts
+++ b/cultpodcasts/src/app/app.component.ts
@@ -33,6 +33,7 @@ export class AppComponent implements OnDestroy {
   protected FeatureSwitch = FeatureSwitch;
   isDragOver: boolean = false;
   activeDropTarget: 'general' | 'podcast' | null = null;
+  authRoles: string[] = [];
   private ignoreDragUntilEnd = false;
 
   @ViewChild(ToolbarComponent)
@@ -72,6 +73,7 @@ export class AppComponent implements OnDestroy {
     this.addDragListeners();
     navigator.serviceWorker.addEventListener('message', this.onSwMessage.bind(this));
     this.profileService.roles.subscribe(async roles => {
+      this.authRoles = roles;
       if (roles.includes("Admin")) {
         var handled = await this.webPushService.subscribeToNotifications();
         if (!handled) {
@@ -104,6 +106,10 @@ export class AppComponent implements OnDestroy {
     return this.resolvePodcastNameFromRoute();
   }
 
+  get canSubmitUrlForPodcast(): boolean {
+    return this.authRoles.includes('Curator');
+  }
+
   onDragOver(event: DragEvent) {
     if (!this.isBrowser || !this.hasDroppableUrl(event)) {
       return;
@@ -115,7 +121,7 @@ export class AppComponent implements OnDestroy {
   }
 
   onTargetDragEnter(target: 'general' | 'podcast', event: DragEvent) {
-    if (!this.isBrowser || !this.hasDroppableUrl(event)) {
+    if (!this.isBrowser || !this.hasDroppableUrl(event) || !this.isDropTargetEnabled(target)) {
       return;
     }
     event.preventDefault();
@@ -253,6 +259,9 @@ export class AppComponent implements OnDestroy {
     if (!this.isBrowser) {
       return;
     }
+    if (forPodcast && !this.canSubmitUrlForPodcast) {
+      return;
+    }
     event.preventDefault();
     this.resetDragState();
 
@@ -279,6 +288,13 @@ export class AppComponent implements OnDestroy {
       podcastName: forPodcast ? this.podcastPageName : undefined,
       shareMode: ShareMode.Text
     });
+  }
+
+  private isDropTargetEnabled(target: 'general' | 'podcast'): boolean {
+    if (target === 'podcast') {
+      return this.canSubmitUrlForPodcast;
+    }
+    return true;
   }
 
   private hasDroppableUrl(event: DragEvent): boolean {

--- a/cultpodcasts/src/app/app.component.ts
+++ b/cultpodcasts/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject, PLATFORM_ID, ViewChild } from '@angular/core';
+import { Component, Inject, OnDestroy, PLATFORM_ID, ViewChild } from '@angular/core';
 import { Router, RouterLink, RouterOutlet } from '@angular/router';
 import { ShareMode } from "./share-mode.enum";
 import { isPlatformBrowser } from '@angular/common';
@@ -28,11 +28,11 @@ import {
   imports: [RouterOutlet, RouterLink, MatIconModule, MatMenuModule, ToolbarComponent, SearchBarComponent]
 })
 
-export class AppComponent {
+export class AppComponent implements OnDestroy {
   isBrowser: boolean;
   protected FeatureSwitch = FeatureSwitch;
   isDragOver: boolean = false;
-  private dragDepth: number = 0;
+  activeDropTarget: 'general' | 'podcast' | null = null;
 
   @ViewChild(ToolbarComponent)
   private toolbar!: ToolbarComponent;
@@ -61,7 +61,14 @@ export class AppComponent {
     }
   }
 
+  ngOnDestroy(): void {
+    if (this.isBrowser) {
+      this.removeDragListeners();
+    }
+  }
+
   initialiseBrowser() {
+    this.addDragListeners();
     navigator.serviceWorker.addEventListener('message', this.onSwMessage.bind(this));
     this.profileService.roles.subscribe(async roles => {
       if (roles.includes("Admin")) {
@@ -88,6 +95,14 @@ export class AppComponent {
     }
   }
 
+  get isOnPodcastPage(): boolean {
+    return this.podcastPageName !== undefined;
+  }
+
+  get podcastPageName(): string | undefined {
+    return this.resolvePodcastNameFromRoute();
+  }
+
   onDragOver(event: DragEvent) {
     if (!this.isBrowser || !this.hasDroppableUrl(event)) {
       return;
@@ -98,33 +113,95 @@ export class AppComponent {
     }
   }
 
-  onDragEnter(event: DragEvent) {
+  onTargetDragEnter(target: 'general' | 'podcast', event: DragEvent) {
     if (!this.isBrowser || !this.hasDroppableUrl(event)) {
       return;
     }
     event.preventDefault();
-    this.dragDepth++;
-    this.isDragOver = true;
+    event.stopPropagation();
+    this.activeDropTarget = target;
   }
 
-  onDragLeave(event: DragEvent) {
-    if (!this.isBrowser || !this.hasDroppableUrl(event)) {
-      return;
+  onTargetDragLeave(event: DragEvent) {
+    const related = event.relatedTarget as Node | null;
+    const currentTarget = event.currentTarget as Node | null;
+    if (!related || !currentTarget?.contains(related)) {
+      this.activeDropTarget = null;
     }
-    event.preventDefault();
-    this.dragDepth = Math.max(0, this.dragDepth - 1);
-    if (this.dragDepth === 0) {
-      this.isDragOver = false;
-    }
+  }
+
+  async onDropGeneral(event: DragEvent) {
+    event.stopPropagation();
+    await this.handleDrop(event, false);
+  }
+
+  async onDropForPodcast(event: DragEvent) {
+    event.stopPropagation();
+    await this.handleDrop(event, true);
   }
 
   async onDrop(event: DragEvent) {
+    if (this.isOnPodcastPage) {
+      event.preventDefault();
+      this.resetDragState();
+      return;
+    }
+    await this.handleDrop(event, false);
+  }
+
+  private addDragListeners(): void {
+    document.addEventListener('dragenter', this.onDocumentDragEnter);
+    document.addEventListener('dragover', this.onDocumentDragOver);
+    document.addEventListener('dragend', this.onDocumentDragEnd);
+    window.addEventListener('blur', this.onWindowBlur);
+  }
+
+  private removeDragListeners(): void {
+    document.removeEventListener('dragenter', this.onDocumentDragEnter);
+    document.removeEventListener('dragover', this.onDocumentDragOver);
+    document.removeEventListener('dragend', this.onDocumentDragEnd);
+    window.removeEventListener('blur', this.onWindowBlur);
+  }
+
+  private readonly onDocumentDragEnter = (event: DragEvent) => {
+    if (!this.hasDroppableUrl(event)) {
+      return;
+    }
+    event.preventDefault();
+    this.isDragOver = true;
+  };
+
+  private readonly onDocumentDragOver = (event: DragEvent) => {
+    if (!this.hasDroppableUrl(event)) {
+      return;
+    }
+    event.preventDefault();
+    if (event.dataTransfer) {
+      event.dataTransfer.dropEffect = 'copy';
+    }
+  };
+
+  private readonly onDocumentDragEnd = () => {
+    this.resetDragState();
+  };
+
+  private readonly onWindowBlur = () => {
+    if (this.isDragOver) {
+      this.resetDragState();
+    }
+  };
+
+  private resetDragState(): void {
+    this.isDragOver = false;
+    this.activeDropTarget = null;
+  }
+
+  private async handleDrop(event: DragEvent, forPodcast: boolean) {
     if (!this.isBrowser) {
       return;
     }
     event.preventDefault();
-    this.dragDepth = 0;
-    this.isDragOver = false;
+    this.resetDragState();
 
     const dataTransfer = event.dataTransfer;
     if (!dataTransfer) {
@@ -146,7 +223,7 @@ export class AppComponent {
     await this.toolbar.sendPodcast({
       url,
       podcastId: undefined,
-      podcastName: this.resolvePodcastNameFromRoute(),
+      podcastName: forPodcast ? this.podcastPageName : undefined,
       shareMode: ShareMode.Text
     });
   }

--- a/cultpodcasts/src/app/app.component.ts
+++ b/cultpodcasts/src/app/app.component.ts
@@ -148,7 +148,7 @@ export class AppComponent implements OnDestroy {
   }
 
   async onDrop(event: DragEvent) {
-    if (this.isOnPodcastPage) {
+    if (this.isOnPodcastPage && this.canSubmitUrlForPodcast) {
       event.preventDefault();
       this.resetDragState();
       return;

--- a/cultpodcasts/src/app/app.component.ts
+++ b/cultpodcasts/src/app/app.component.ts
@@ -33,6 +33,7 @@ export class AppComponent implements OnDestroy {
   protected FeatureSwitch = FeatureSwitch;
   isDragOver: boolean = false;
   activeDropTarget: 'general' | 'podcast' | null = null;
+  private ignoreDragUntilEnd = false;
 
   @ViewChild(ToolbarComponent)
   private toolbar!: ToolbarComponent;
@@ -152,19 +153,31 @@ export class AppComponent implements OnDestroy {
   private addDragListeners(): void {
     document.addEventListener('dragenter', this.onDocumentDragEnter);
     document.addEventListener('dragover', this.onDocumentDragOver);
+    document.addEventListener('dragleave', this.onDocumentDragLeave);
     document.addEventListener('dragend', this.onDocumentDragEnd);
+    document.addEventListener('drop', this.onDocumentDrop);
+    document.addEventListener('keydown', this.onKeyDown);
+    document.addEventListener('visibilitychange', this.onVisibilityChange);
     window.addEventListener('blur', this.onWindowBlur);
+    window.addEventListener('mouseup', this.onPointerUp);
+    window.addEventListener('pointerup', this.onPointerUp);
   }
 
   private removeDragListeners(): void {
     document.removeEventListener('dragenter', this.onDocumentDragEnter);
     document.removeEventListener('dragover', this.onDocumentDragOver);
+    document.removeEventListener('dragleave', this.onDocumentDragLeave);
     document.removeEventListener('dragend', this.onDocumentDragEnd);
+    document.removeEventListener('drop', this.onDocumentDrop);
+    document.removeEventListener('keydown', this.onKeyDown);
+    document.removeEventListener('visibilitychange', this.onVisibilityChange);
     window.removeEventListener('blur', this.onWindowBlur);
+    window.removeEventListener('mouseup', this.onPointerUp);
+    window.removeEventListener('pointerup', this.onPointerUp);
   }
 
   private readonly onDocumentDragEnter = (event: DragEvent) => {
-    if (!this.hasDroppableUrl(event)) {
+    if (this.ignoreDragUntilEnd || !this.hasDroppableUrl(event)) {
       return;
     }
     event.preventDefault();
@@ -181,19 +194,59 @@ export class AppComponent implements OnDestroy {
     }
   };
 
+  private readonly onDocumentDragLeave = (event: DragEvent) => {
+    if (!this.isDragOver) {
+      return;
+    }
+    const related = event.relatedTarget as Node | null;
+    if (related && document.documentElement.contains(related)) {
+      return;
+    }
+    this.resetDragState(true);
+  };
+
   private readonly onDocumentDragEnd = () => {
+    this.ignoreDragUntilEnd = false;
     this.resetDragState();
+  };
+
+  private readonly onDocumentDrop = () => {
+    this.resetDragState();
+  };
+
+  private readonly onKeyDown = (event: KeyboardEvent) => {
+    if (event.key === 'Escape' && this.isDragOver) {
+      this.resetDragState(true);
+    }
+  };
+
+  private readonly onVisibilityChange = () => {
+    if (document.hidden && this.isDragOver) {
+      this.resetDragState(true);
+    }
   };
 
   private readonly onWindowBlur = () => {
     if (this.isDragOver) {
-      this.resetDragState();
+      this.resetDragState(true);
     }
   };
 
-  private resetDragState(): void {
+  private readonly onPointerUp = () => {
+    if (!this.isDragOver) {
+      return;
+    }
+    window.setTimeout(() => {
+      if (this.isDragOver) {
+        this.resetDragState(true);
+      }
+    }, 0);
+  };
+
+  private resetDragState(fromCancel = false): void {
     this.isDragOver = false;
     this.activeDropTarget = null;
+    this.ignoreDragUntilEnd = fromCancel;
   }
 
   private async handleDrop(event: DragEvent, forPodcast: boolean) {


### PR DESCRIPTION
## Summary

- Adds dragover and drop handlers on .drop-overlay in app.component.html so drops on non-podcast pages call submit-url instead of letting the browser navigate to the dropped URL.
- Fixes overlay staying visible after cancelling a URL drag (Esc, drag out of window, tab switch): listens for document dragleave and visibilitychange, and ignores stray dragenter events until dragend via ignoreDragUntilEnd.
- Gates the dual-target podcast overlay on Curator role (authRoles.includes('Curator')); non-Curator users on podcast pages see the same single-message overlay and general submit-url drop as non-podcast pages.
- Follow-up to #405, which merged the broader drag-and-drop overlay work.

## Test plan

- [ ] On a non-podcast page (e.g. homepage), drag an episode URL over the app until the full-screen overlay appears.
- [ ] Drop the URL on the overlay and confirm submission runs (no browser navigation to the URL).
- [ ] On a podcast page as a Curator, confirm dual drop targets work for general vs podcast-specific submission.
- [ ] On a podcast page without Curator role, confirm single "Drop episode link to submit" overlay (not dual targets) and drop submits general submit-url.
- [ ] Cancel drag with Esc, release outside the window, or drag out of the page — overlay should dismiss reliably.
- [ ] Switch tabs while dragging — overlay should dismiss when the tab is hidden.
