### PR TITLE
Fix: clampable text layout shift when expanding descriptions

### DIFF
--- a/cultpodcasts/src/app/clampable-text/clampable-text.component.html
+++ b/cultpodcasts/src/app/clampable-text/clampable-text.component.html
@@ -1,11 +1,15 @@
 <div class="clampable-text">
-  <div class="clampable-text__body" [class.is-clamped]="!expanded && showToggle">
+  <div class="clampable-text__body">
     @if (html) {
-    <div #content class="clampable-text__content" [class.is-clamped]="!expanded" [style.--clamp-lines]="maxLines"
-      [innerHTML]="html"></div>
+    <div class="clampable-text__content">
+      <div #content class="clampable-text__clamp" [class.is-clamped]="!expanded" [style.--clamp-lines]="maxLines"
+        [innerHTML]="html"></div>
+    </div>
     } @else {
-    <div #content class="clampable-text__content" [class.is-clamped]="!expanded" [style.--clamp-lines]="maxLines">
-      <ng-content></ng-content>
+    <div class="clampable-text__content">
+      <div #content class="clampable-text__clamp" [class.is-clamped]="!expanded" [style.--clamp-lines]="maxLines">
+        <ng-content></ng-content>
+      </div>
     </div>
     }
     @if (showToggle) {

--- a/cultpodcasts/src/app/clampable-text/clampable-text.component.sass
+++ b/cultpodcasts/src/app/clampable-text/clampable-text.component.sass
@@ -5,16 +5,16 @@
     width: 100%
 
 .clampable-text__clamp
-    &.is-clamped
-        display: -webkit-box
-        -webkit-box-orient: vertical
-        -webkit-line-clamp: var(--clamp-lines)
-        overflow: hidden
-        width: 100%
+    display: block
+    width: 100%
+    margin: 0
 
-        > p
-            display: contents
-            margin: 0
+    p
+        margin: 0
+
+    &.is-clamped
+        overflow: hidden
+        max-height: calc(var(--clamp-lines) * 1.3em)
 
 .clampable-text__toggle
     position: absolute

--- a/cultpodcasts/src/app/clampable-text/clampable-text.component.sass
+++ b/cultpodcasts/src/app/clampable-text/clampable-text.component.sass
@@ -1,16 +1,20 @@
 .clampable-text__body
     position: relative
 
-    &.is-clamped .clampable-text__content
-        padding-right: 2rem
-        padding-bottom: 0.25rem
-
 .clampable-text__content
+    width: 100%
+
+.clampable-text__clamp
     &.is-clamped
         display: -webkit-box
         -webkit-box-orient: vertical
         -webkit-line-clamp: var(--clamp-lines)
         overflow: hidden
+        width: 100%
+
+        > p
+            display: contents
+            margin: 0
 
 .clampable-text__toggle
     position: absolute

--- a/cultpodcasts/src/app/homepage-api/homepage-api.component.html
+++ b/cultpodcasts/src/app/homepage-api/homepage-api.component.html
@@ -39,9 +39,7 @@
       </mat-card-header>
       <mat-card-content>
         <app-episode-image [searchResult]="item" [linksOverlay]="true"></app-episode-image>
-        <app-clampable-text [maxLines]="10">
-          <p>{{item.episodeDescription}}</p>
-        </app-clampable-text>
+        <app-clampable-text [maxLines]="10">{{item.episodeDescription}}</app-clampable-text>
       </mat-card-content>
       <mat-card-actions>
         <app-episode-links [episode]="item"></app-episode-links>


### PR DESCRIPTION
## Summary
- Fix layout shift when expanding/collapsing episode descriptions on the homepage and discovery pages.
- Collapsed text now uses the same container width and top-left origin as the expanded view.
- Line-clamp styling is applied to an inner element so the outer content box stays full-width; removed collapsed-only padding that narrowed the text.

## Test plan
- [ ] Open the homepage and find an episode with a long description and a show-more toggle.
- [ ] Confirm collapsed text aligns with the expanded text at the same left edge and width.
- [ ] Click expand and verify text does not jump or reflow horizontally.
- [ ] Click collapse and confirm layout stays stable.
- [ ] Repeat on the discovery page (discovery-item cards with showDescription and resultdescription).

Made with [Cursor](https://cursor.com)