### PR TITLE
Decouple footer Reddit and socials feature switches

### DIFF
--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.903",
+  "version": "1.9.904",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.9.903",
+      "version": "1.9.904",
       "dependencies": {
         "@angular/animations": "^21.0.6",
         "@angular/cdk": "^21.0.5",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.903",
+  "version": "1.9.904",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/src/app/app.component.html
+++ b/cultpodcasts/src/app/app.component.html
@@ -53,35 +53,35 @@
       <img src="/assets/bluesky.svg" alt="Bluesky" class="socialPreviewIcon">
       }
     </button>
+
+    <mat-menu #socialLinksMenu="matMenu" [overlapTrigger]="true" xPosition="after" yPosition="above" class="social-links-menu-panel">
+      @if (featureSwtichService.IsEnabled(FeatureSwitch.reddit)) {
+      <a href="https://reddit.com/r/cultpodcasts" mat-menu-item>
+        <mat-icon svgIcon="reddit"></mat-icon>
+        <span>Reddit</span>
+      </a>
+      }
+      @if (featureSwtichService.IsEnabled(FeatureSwitch.socials)) {
+      <a href="https://github.com/cultpodcasts" mat-menu-item>
+        <mat-icon svgIcon="github"></mat-icon>
+        <span>GitHub</span>
+      </a>
+      <a href="https://github.com/cultpodcasts/website/releases" mat-menu-item>
+        <mat-icon svgIcon="android"></mat-icon>
+        <span>Android</span>
+      </a>
+      <a href="https://twitter.com/cultpodcasts" mat-menu-item>
+        <mat-icon svgIcon="twitter"></mat-icon>
+        <span>Twitter</span>
+      </a>
+      <a href="https://bsky.app/profile/cultpodcasts.bsky.social" mat-menu-item>
+        <mat-icon svgIcon="bluesky"></mat-icon>
+        <span>Bluesky</span>
+      </a>
+      }
+    </mat-menu>
     }
 
     <a [routerLink]="[]" fragment="top" id="goTop" (click)="goTop($event)">Go to top<mat-icon>arrow_upward</mat-icon></a>
   </footer>
-
-  <mat-menu #socialLinksMenu="matMenu" [overlapTrigger]="true" xPosition="after" yPosition="above" class="social-links-menu-panel">
-    @if (featureSwtichService.IsEnabled(FeatureSwitch.reddit)) {
-    <a href="https://reddit.com/r/cultpodcasts" mat-menu-item>
-      <mat-icon svgIcon="reddit"></mat-icon>
-      <span>Reddit</span>
-    </a>
-    }
-    @if (featureSwtichService.IsEnabled(FeatureSwitch.socials)) {
-    <a href="https://github.com/cultpodcasts" mat-menu-item>
-      <mat-icon svgIcon="github"></mat-icon>
-      <span>GitHub</span>
-    </a>
-    <a href="https://github.com/cultpodcasts/website/releases" mat-menu-item>
-      <mat-icon svgIcon="android"></mat-icon>
-      <span>Android</span>
-    </a>
-    <a href="https://twitter.com/cultpodcasts" mat-menu-item>
-      <mat-icon svgIcon="twitter"></mat-icon>
-      <span>Twitter</span>
-    </a>
-    <a href="https://bsky.app/profile/cultpodcasts.bsky.social" mat-menu-item>
-      <mat-icon svgIcon="bluesky"></mat-icon>
-      <span>Bluesky</span>
-    </a>
-    }
-  </mat-menu>
 </section>

--- a/cultpodcasts/src/app/feature-switch-service.ts
+++ b/cultpodcasts/src/app/feature-switch-service.ts
@@ -10,7 +10,9 @@ export class FeatureSwtichService {
             case FeatureSwitch.socials:
                 return true;
             case FeatureSwitch.reddit:
-                return true;
+                return false;
+            case FeatureSwitch.redditPost:
+                return false;
             default:
                 return false;
         }

--- a/cultpodcasts/src/app/feature-switch.enum.ts
+++ b/cultpodcasts/src/app/feature-switch.enum.ts
@@ -1,5 +1,6 @@
 export enum FeatureSwitch {
     auth0 = 1,
     socials= 2,
-    reddit= 3
+    reddit= 3,
+    redditPost= 4
 }

--- a/cultpodcasts/src/app/post-episode-dialog/post-episode-dialog.component.html
+++ b/cultpodcasts/src/app/post-episode-dialog/post-episode-dialog.component.html
@@ -8,10 +8,12 @@
     } @else {
     <form id="post" [formGroup]="form!" (ngSubmit)="onSubmit()">
         <div class="flags">
+            @if (featureSwtichService.IsEnabled(FeatureSwitch.redditPost)) {
             <label>
                 <span>Post:</span>
                 <mat-checkbox [formControl]="form!.controls.post"/>
             </label>
+            }
             <label>
                 <span>Tweet:</span>
                 <mat-checkbox [formControl]="form!.controls.tweet"/>

--- a/cultpodcasts/src/app/post-episode-dialog/post-episode-dialog.component.ts
+++ b/cultpodcasts/src/app/post-episode-dialog/post-episode-dialog.component.ts
@@ -15,6 +15,8 @@ import { EpisodePublishResponse } from '../episode-publish-response.interface';
 import { TextFieldModule } from '@angular/cdk/text-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatCheckboxModule } from '@angular/material/checkbox';
+import { FeatureSwitch } from '../feature-switch.enum';
+import { FeatureSwtichService } from '../feature-switch-service';
 
 @Component({
   selector: 'app-post-episode-dialog',
@@ -32,6 +34,7 @@ import { MatCheckboxModule } from '@angular/material/checkbox';
   styleUrl: './post-episode-dialog.component.sass'
 })
 export class PostEpisodeDialogComponent {
+  protected FeatureSwitch = FeatureSwitch;
   isInError: boolean = false;
   isSending: boolean = true;
   form: FormGroup<PostForm> | undefined;
@@ -44,6 +47,7 @@ export class PostEpisodeDialogComponent {
 
   constructor(private auth: AuthServiceWrapper,
     private http: HttpClient,
+    protected featureSwtichService: FeatureSwtichService,
     private dialogRef: MatDialogRef<PostEpisodeDialogComponent, any>,
     @Inject(MAT_DIALOG_DATA) public data: { podcastIdentifier: string, episodeId: string }) {
     this.podcastIdentifier = data.podcastIdentifier;
@@ -74,15 +78,17 @@ export class PostEpisodeDialogComponent {
             this.hasTweeted = resp.tweeted;
             this.hasBlueskyPosted = resp.bluesky == true;
             this.podcastId = resp.podcastId!;
-            if (this.hasPosted) {
-              this.form?.controls.post.disable();
-            } else {
-              if (!resp.ignored && !resp.removed &&
-                ((!resp.youTubePodcast || resp.urls.youtube) &&
-                  (!resp.applePodcast || resp.urls.apple) &&
-                  (!resp.spotifyPodcast || resp.urls.spotify)
-                )) {
-                this.form?.controls.post.setValue(true);
+            if (this.featureSwtichService.IsEnabled(FeatureSwitch.redditPost)) {
+              if (this.hasPosted) {
+                this.form?.controls.post.disable();
+              } else {
+                if (!resp.ignored && !resp.removed &&
+                  ((!resp.youTubePodcast || resp.urls.youtube) &&
+                    (!resp.applePodcast || resp.urls.apple) &&
+                    (!resp.spotifyPodcast || resp.urls.spotify)
+                  )) {
+                  this.form?.controls.post.setValue(true);
+                }
               }
             }
             const readyForSocial: boolean = !resp.ignored && !resp.removed &&
@@ -103,7 +109,8 @@ export class PostEpisodeDialogComponent {
                 this.form?.controls.blueskyPost.setValue(true);
               }
             }
-            if (this.hasTweeted && this.hasPosted && this.hasBlueskyPosted) {
+            const redditPostComplete = !this.featureSwtichService.IsEnabled(FeatureSwitch.redditPost) || this.hasPosted;
+            if (this.hasTweeted && redditPostComplete && this.hasBlueskyPosted) {
               this.dialogRef.close({ noChange: true });
             }
           },
@@ -129,7 +136,8 @@ export class PostEpisodeDialogComponent {
       change = true;
       model.tweet = true;
     }
-    if (!this.hasPosted && this.form?.controls.post.value) {
+    if (this.featureSwtichService.IsEnabled(FeatureSwitch.redditPost) &&
+      !this.hasPosted && this.form?.controls.post.value) {
       change = true;
       model.post = true;
     }


### PR DESCRIPTION
## Summary

- **Social button**: shown when \FeatureSwitch.reddit || FeatureSwitch.socials\ (either switch on).
- **Reddit preview icon + menu link**: gated only by \FeatureSwitch.reddit\.
- **GitHub / Android / Twitter / Bluesky preview icons + menu links**: gated only by \FeatureSwitch.socials\.
- **Social menu**: rendered inside the shared visibility guard so button and menu disappear together when both switches are off.
- **Service layer**: \FeatureSwitch.reddit\ and \FeatureSwitch.socials\ remain independent toggles in \eature-switch-service.ts\ (no cross-switch coupling).

Replaces the earlier empty-diff branch history (remove-reddit attempt + service config flip) with a single focused template change.

## Behavior matrix

| reddit | socials | Result |
|--------|---------|--------|
| on | on | Social button visible; Reddit + all other social icons/links |
| on | off | Social button visible; Reddit only |
| off | on | Social button visible; other socials only (no Reddit) |
| off | off | Social button hidden |

## Test plan

- [ ] With **socials** on and **reddit** off: social button visible; no Reddit icon or menu link.
- [ ] With **reddit** on and **socials** off: social button visible; Reddit icon and link only.
- [ ] With both on: all social links and icons appear.
- [ ] With both off: social button and menu hidden.