### PR TITLE
Add People register dialogs and guests UI

### DIFF
--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.905",
+  "version": "1.9.906",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.9.905",
+      "version": "1.9.906",
       "dependencies": {
         "@angular/animations": "^21.0.6",
         "@angular/cdk": "^21.0.5",

--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.904",
+  "version": "1.9.905",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.9.904",
+      "version": "1.9.905",
       "dependencies": {
         "@angular/animations": "^21.0.6",
         "@angular/cdk": "^21.0.5",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.905",
+  "version": "1.9.906",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.904",
+  "version": "1.9.905",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/src/app/add-episode-dialog/add-episode-dialog.component.html
+++ b/cultpodcasts/src/app/add-episode-dialog/add-episode-dialog.component.html
@@ -155,13 +155,55 @@
             </mat-tab>
             <mat-tab label="Guests">
                 <label>
-                    <span>Twitter handles:</span>
-                    <input type="text" [formControl]="form!.controls.twitterHandles" matInput>
+                    <span>Guests:</span>
+                    <mat-select [formControl]="form!.controls.guests" multiple [sortComparator]="noCompareFunction"
+                        (selectionChange)="onGuestsSelectionChange()"
+                        (openedChange)="onGuestsDropdownOpenChange($event)"
+                        (keydown)="onGuestsDropdownKeydown($event)">
+                        @if (enableDesktopSubjectTypingFilter && guestsFilterTerm.length > 0) {
+                        <mat-option disabled>{{guestsFilterTerm}}</mat-option>
+                        <mat-divider></mat-divider>
+                        }
+                        @if (selectedGuests.length > 0) {
+                        @for (person of selectedGuests; track person.id) {
+                        <mat-option [value]="person.name">{{personLabel(person)}}</mat-option>
+                        }
+                        }
+                        @if (otherPeople.length > 0) {
+                        @if (selectedGuests.length > 0) {
+                        <mat-divider></mat-divider>
+                        }
+                        @for (person of otherPeople; track person.id) {
+                        <mat-option [value]="person.name">{{personLabel(person)}}</mat-option>
+                        }
+                        }
+                    </mat-select>
                 </label>
-                <label>
-                    <span>Bluesky handles:</span>
-                    <input type="text" [formControl]="form!.controls.blueskyHandles" matInput>
-                </label>
+                <div class="guest-actions">
+                    <button type="button" mat-button (click)="openAddPerson()">Add person</button>
+                </div>
+                @if (selectedGuests.length > 0) {
+                <div class="guest-suggestions">
+                    <span>Selected:</span>
+                    @for (person of selectedGuests; track person.id) {
+                    <div class="guest-row">
+                        <span>{{personLabel(person)}}</span>
+                        <button type="button" mat-button (click)="openEditPerson(person)">Edit</button>
+                    </div>
+                    }
+                </div>
+                }
+                @if (guestSuggestions.length > 0) {
+                <div class="guest-suggestions">
+                    <span>Suggested from title/description:</span>
+                    @for (suggestion of guestSuggestions; track suggestion.person.id) {
+                    <div class="guest-row">
+                        <span>{{personLabel(suggestion.person)}} ({{suggestion.matchResults[0]?.term}})</span>
+                        <button type="button" mat-button (click)="addSuggestedGuest(suggestion.person.name)">Add</button>
+                    </div>
+                    }
+                </div>
+                }
             </mat-tab>
         </mat-tab-group>
     </form>

--- a/cultpodcasts/src/app/add-episode-dialog/add-episode-dialog.component.sass
+++ b/cultpodcasts/src/app/add-episode-dialog/add-episode-dialog.component.sass
@@ -13,3 +13,12 @@
         label
             span
                 display: inline
+    .guest-actions
+        margin: 8px 0
+    .guest-suggestions
+        margin-top: 10px
+        .guest-row
+            display: flex
+            align-items: center
+            gap: 8px
+            margin-top: 4px

--- a/cultpodcasts/src/app/add-episode-dialog/add-episode-dialog.component.ts
+++ b/cultpodcasts/src/app/add-episode-dialog/add-episode-dialog.component.ts
@@ -28,6 +28,7 @@ import { MatDividerModule } from '@angular/material/divider';
 import { filterKeepingSelectedInOrder } from '../subject-filter.util';
 import { buildEpisodeLanguageOptions } from '../language-options.util';
 import { EditPersonDialogComponent } from '../edit-person-dialog/edit-person-dialog.component';
+import { comparePeopleBySortKey } from '../person-sort';
 
 @Component({
   selector: 'app-add-episode-dialog',
@@ -153,7 +154,7 @@ export class AddEpisodeDialogComponent {
         lang: new FormControl(resp.episode.lang || "unset"),
         guests: new FormControl<string[]>(resp.episode.guests ?? [], { nonNullable: true })
       });
-      this.allPeople = resp.people.sort((a, b) => a.name.localeCompare(b.name));
+      this.allPeople = resp.people.sort(comparePeopleBySortKey);
       this.guestSuggestions = resp.episode.guestSuggestions ?? [];
       this.regroupGuests(resp.episode.guests ?? []);
       this.subjects = resp.episode.subjects.concat(resp.subjects.filter(x => !resp.episode.subjects.includes(x.name)).map(x => x.name));
@@ -437,14 +438,14 @@ export class AddEpisodeDialogComponent {
           catchError(err => err?.status === 404 ? of([] as Person[]) : throwError(() => err))
         )
       );
-      this.allPeople = people.sort((a, b) => a.name.localeCompare(b.name));
+      this.allPeople = people.sort(comparePeopleBySortKey);
       if (created && !this.allPeople.some(x => x.name === created.name)) {
-        this.allPeople = [...this.allPeople, created].sort((a, b) => a.name.localeCompare(b.name));
+        this.allPeople = [...this.allPeople, created].sort(comparePeopleBySortKey);
       }
     } catch {
       if (created) {
         this.allPeople = [...this.allPeople.filter(x => x.name !== created.name), created]
-          .sort((a, b) => a.name.localeCompare(b.name));
+          .sort(comparePeopleBySortKey);
       }
     }
 

--- a/cultpodcasts/src/app/add-episode-dialog/add-episode-dialog.component.ts
+++ b/cultpodcasts/src/app/add-episode-dialog/add-episode-dialog.component.ts
@@ -2,10 +2,12 @@ import { Component, Inject } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef, MatDialogModule, MatDialog } from '@angular/material/dialog';
 import { AuthServiceWrapper } from '../auth-service-wrapper.class';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
-import { firstValueFrom, forkJoin } from 'rxjs';
+import { firstValueFrom, forkJoin, catchError, of, throwError } from 'rxjs';
 import { environment } from './../../environments/environment';
 import { ApiEpisode } from '../api-episode.interface';
 import { Subject } from '../subject.interface';
+import { Person } from '../person.interface';
+import { PersonMatch } from '../person-match.interface';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatButtonModule } from '@angular/material/button';
 import { FormBuilder, FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
@@ -25,6 +27,7 @@ import { Podcast } from '../podcast.interface';
 import { MatDividerModule } from '@angular/material/divider';
 import { filterKeepingSelectedInOrder } from '../subject-filter.util';
 import { buildEpisodeLanguageOptions } from '../language-options.util';
+import { EditPersonDialogComponent } from '../edit-person-dialog/edit-person-dialog.component';
 
 @Component({
   selector: 'app-add-episode-dialog',
@@ -64,6 +67,11 @@ export class AddEpisodeDialogComponent {
   hoistedSubjects: string[] = [];
   otherSubjects: string[] = [];
   subjectsFilterTerm: string = '';
+  allPeople: Person[] = [];
+  selectedGuests: Person[] = [];
+  otherPeople: Person[] = [];
+  guestsFilterTerm: string = '';
+  guestSuggestions: PersonMatch[] = [];
   languages: { [key: string]: string } = {};
 
   form: FormGroup<EpisodeForm> | undefined;
@@ -95,12 +103,16 @@ export class AddEpisodeDialogComponent {
       headers = headers.set("Authorization", "Bearer " + token);
       const episodeEndpoint = new URL(`/episode/${this.podcastId}/${this.episodeId}`, environment.api).toString();
       const subjectsEndpoint = new URL("/subjects", environment.api).toString();
+      const peopleEndpoint = new URL("/people", environment.api).toString();
       const languagesEndpoint = new URL("/languages", environment.api).toString();
 
       var resp = await firstValueFrom(forkJoin(
         {
           episode: this.http.get<ApiEpisode>(episodeEndpoint, { headers: headers }),
           subjects: this.http.get<Subject[]>(subjectsEndpoint, { headers: headers }),
+          people: this.http.get<Person[]>(peopleEndpoint, { headers: headers }).pipe(
+            catchError(err => err?.status === 404 ? of([] as Person[]) : throwError(() => err))
+          ),
           languages: this.http.get<{ [key: string]: string }>(languagesEndpoint, { headers: headers })
         }
       ));
@@ -139,9 +151,11 @@ export class AddEpisodeDialogComponent {
         subjects: new FormControl(resp.episode.subjects, { nonNullable: true }),
         searchTerms: new FormControl(resp.episode.searchTerms || null),
         lang: new FormControl(resp.episode.lang || "unset"),
-        twitterHandles: new FormControl<string[]>(resp.episode.twitterHandles ?? [], { nonNullable: true }),
-        blueskyHandles: new FormControl<string[]>(resp.episode.blueskyHandles ?? [], { nonNullable: true })
+        guests: new FormControl<string[]>(resp.episode.guests ?? [], { nonNullable: true })
       });
+      this.allPeople = resp.people.sort((a, b) => a.name.localeCompare(b.name));
+      this.guestSuggestions = resp.episode.guestSuggestions ?? [];
+      this.regroupGuests(resp.episode.guests ?? []);
       this.subjects = resp.episode.subjects.concat(resp.subjects.filter(x => !resp.episode.subjects.includes(x.name)).map(x => x.name));
       this.allSubjects = this.unique(this.subjects.concat(this.podcastDefaultSubject ? [this.podcastDefaultSubject] : []));
       this.regroupSubjects(resp.episode.subjects);
@@ -190,8 +204,7 @@ export class AddEpisodeDialogComponent {
         subjects: this.form!.controls.subjects.value,
         searchTerms: this.form!.controls.searchTerms.value,
         lang: this.form!.controls.lang.value || "unset",
-        twitterHandles: this.translateForEntityA(this.form!.controls.twitterHandles),
-        blueskyHandles: this.translateForEntityA(this.form!.controls.blueskyHandles)
+        guests: this.form!.controls.guests.value,
       };
       if (this.form!.controls.spotify.value) {
         update.urls.spotify = new URL(this.form!.controls.spotify.value);
@@ -298,9 +311,148 @@ export class AddEpisodeDialogComponent {
     if (!this.areEqual(prev.images?.youtube, now.images?.youtube)) changes.images!.youtube = now.images?.youtube ?? "";
     if (!this.areEqual(prev.images?.other, now.images?.other)) changes.images!.other = now.images?.other ?? "";
     if (!this.areEqual(prev.lang ?? "unset", now.lang ?? "unset")) changes.lang = now.lang == "unset" ? "" : now.lang ?? "";
-    if (!this.isSameA(prev.twitterHandles, now.twitterHandles)) changes.twitterHandles = now.twitterHandles;
-    if (!this.isSameA(prev.blueskyHandles, now.blueskyHandles)) changes.blueskyHandles = now.blueskyHandles;
+    if (!this.isSameA(prev.guests, now.guests)) changes.guests = now.guests;
     return changes;
+  }
+
+  personLabel(person: Person): string {
+    const handles = [person.twitterHandle, person.blueskyHandle].filter(x => !!x).join(' ');
+    return handles ? `${person.name} (${handles})` : person.name;
+  }
+
+  onGuestsSelectionChange() {
+    this.regroupGuests(this.form?.controls.guests.value);
+  }
+
+  onGuestsDropdownOpenChange(opened: boolean) {
+    if (!opened) {
+      this.guestsFilterTerm = '';
+      this.regroupGuests(this.form?.controls.guests.value);
+    }
+  }
+
+  onGuestsDropdownKeydown(event: KeyboardEvent) {
+    if (!this.enableDesktopSubjectTypingFilter) {
+      return;
+    }
+    if (event.ctrlKey || event.altKey || event.metaKey) {
+      return;
+    }
+
+    if (event.key === 'Backspace') {
+      if (this.guestsFilterTerm.length > 0) {
+        this.guestsFilterTerm = this.guestsFilterTerm.substring(0, this.guestsFilterTerm.length - 1);
+        this.regroupGuests(this.form?.controls.guests.value);
+      }
+      event.preventDefault();
+      return;
+    }
+
+    if (event.key === 'Escape') {
+      this.guestsFilterTerm = '';
+      this.regroupGuests(this.form?.controls.guests.value);
+      event.preventDefault();
+      return;
+    }
+
+    if (event.key.length === 1) {
+      this.guestsFilterTerm += event.key;
+      this.regroupGuests(this.form?.controls.guests.value);
+      event.preventDefault();
+    }
+  }
+
+  regroupGuests(selected: string[] | null | undefined) {
+    const selectedNames = [...new Set(selected ?? [])];
+    const selectedSet = new Set(selectedNames);
+    const episodeGuests = this.originalEpisode?.guestPeople ?? [];
+    const peopleByName = new Map(this.allPeople.map(x => [x.name, x]));
+    for (const guest of episodeGuests) {
+      peopleByName.set(guest.name, guest);
+    }
+    this.selectedGuests = selectedNames
+      .map(name => peopleByName.get(name))
+      .filter((x): x is Person => !!x);
+
+    const otherNames = this.allPeople
+      .map(person => person.name)
+      .filter(name => !selectedSet.has(name));
+    const filteredOtherNames = filterKeepingSelectedInOrder(otherNames, this.guestsFilterTerm, selectedSet);
+    this.otherPeople = filteredOtherNames
+      .map(name => peopleByName.get(name))
+      .filter((x): x is Person => !!x);
+  }
+
+  addSuggestedGuest(personName: string) {
+    const current = this.form?.controls.guests.value ?? [];
+    if (current.includes(personName)) {
+      return;
+    }
+    this.form?.controls.guests.setValue([...current, personName]);
+    this.guestSuggestions = this.guestSuggestions.filter(x => x.person.name !== personName);
+    this.regroupGuests(this.form?.controls.guests.value);
+  }
+
+  openAddPerson() {
+    const dialogRef = this.dialog.open(EditPersonDialogComponent, {
+      data: { create: true, personName: this.guestsFilterTerm || undefined },
+      disableClose: true,
+      autoFocus: true,
+      width: '90%'
+    });
+    dialogRef.afterClosed().subscribe(async result => {
+      if (result?.updated && result.personName) {
+        await this.refreshPeopleAndSelect(result.personName, result.person);
+      }
+    });
+  }
+
+  openEditPerson(person: Person) {
+    const dialogRef = this.dialog.open(EditPersonDialogComponent, {
+      data: { create: false, personName: person.name },
+      disableClose: true,
+      autoFocus: true,
+      width: '90%'
+    });
+    dialogRef.afterClosed().subscribe(async result => {
+      if (result?.updated) {
+        await this.refreshPeopleAndSelect(person.name);
+      }
+    });
+  }
+
+  private async refreshPeopleAndSelect(personName: string, created?: Person) {
+    try {
+      const token = await firstValueFrom(this.auth.authService.getAccessTokenSilently({
+        authorizationParams: {
+          audience: `https://api.cultpodcasts.com/`,
+          scope: 'curate'
+        }
+      }));
+      let headers: HttpHeaders = new HttpHeaders();
+      headers = headers.set("Authorization", "Bearer " + token);
+      const peopleEndpoint = new URL("/people", environment.api).toString();
+      const people = await firstValueFrom(
+        this.http.get<Person[]>(peopleEndpoint, { headers: headers }).pipe(
+          catchError(err => err?.status === 404 ? of([] as Person[]) : throwError(() => err))
+        )
+      );
+      this.allPeople = people.sort((a, b) => a.name.localeCompare(b.name));
+      if (created && !this.allPeople.some(x => x.name === created.name)) {
+        this.allPeople = [...this.allPeople, created].sort((a, b) => a.name.localeCompare(b.name));
+      }
+    } catch {
+      if (created) {
+        this.allPeople = [...this.allPeople.filter(x => x.name !== created.name), created]
+          .sort((a, b) => a.name.localeCompare(b.name));
+      }
+    }
+
+    const current = this.form?.controls.guests.value ?? [];
+    if (!current.includes(personName)) {
+      this.form?.controls.guests.setValue([...current, personName]);
+    }
+    this.regroupGuests(this.form?.controls.guests.value);
   }
 
   areEqual(url1: URL | null | undefined | string, url2: URL | null | undefined | string): boolean {
@@ -434,18 +586,5 @@ export class AddEpisodeDialogComponent {
   isEpisodeLanguageUnset(): boolean {
     const lang = this.form?.controls.lang.value;
     return lang == null || lang === '' || lang === 'unset';
-  }
-
-  translateForEntityA(x: FormControl<string[] | undefined | null>): string[] | undefined {
-    if (x.value) {
-      const valueS: any = x.value;
-      if (valueS.push) {
-        return x.value;
-      } else if (valueS.split) {
-        const valueSt: string = valueS;
-        return valueSt.split(",");
-      }
-    };
-    return [];
   }
 }

--- a/cultpodcasts/src/app/api-episode.interface.ts
+++ b/cultpodcasts/src/app/api-episode.interface.ts
@@ -1,5 +1,7 @@
 import { EpisodeImageUrls } from "./episode-image-urls.interface";
 import { EpisodeUrls } from "./episode-urls.interface";
+import { Person } from "./person.interface";
+import { PersonMatch } from "./person-match.interface";
 
 export interface ApiEpisode {
     id: string;
@@ -29,6 +31,7 @@ export interface ApiEpisode {
     image?: URL;
     lang?: string | null;
     knownTerms?: string[] | undefined;
-    twitterHandles?: string[] | undefined;
-    blueskyHandles?: string[] | undefined;
+    guests?: string[] | undefined;
+    guestPeople?: Person[] | undefined;
+    guestSuggestions?: PersonMatch[] | undefined;
 }

--- a/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.html
+++ b/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.html
@@ -155,13 +155,55 @@
             </mat-tab>
             <mat-tab label="Guests">
                 <label>
-                    <span>Twitter handles:</span>
-                    <input type="text" [formControl]="form!.controls.twitterHandles" matInput>
+                    <span>Guests:</span>
+                    <mat-select [formControl]="form!.controls.guests" multiple [sortComparator]="noCompareFunction"
+                        (selectionChange)="onGuestsSelectionChange()"
+                        (openedChange)="onGuestsDropdownOpenChange($event)"
+                        (keydown)="onGuestsDropdownKeydown($event)">
+                        @if (enableDesktopSubjectTypingFilter && guestsFilterTerm.length > 0) {
+                        <mat-option disabled>{{guestsFilterTerm}}</mat-option>
+                        <mat-divider></mat-divider>
+                        }
+                        @if (selectedGuests.length > 0) {
+                        @for (person of selectedGuests; track person.id) {
+                        <mat-option [value]="person.name">{{personLabel(person)}}</mat-option>
+                        }
+                        }
+                        @if (otherPeople.length > 0) {
+                        @if (selectedGuests.length > 0) {
+                        <mat-divider></mat-divider>
+                        }
+                        @for (person of otherPeople; track person.id) {
+                        <mat-option [value]="person.name">{{personLabel(person)}}</mat-option>
+                        }
+                        }
+                    </mat-select>
                 </label>
-                <label>
-                    <span>Bluesky handles:</span>
-                    <input type="text" [formControl]="form!.controls.blueskyHandles" matInput>
-                </label>
+                <div class="guest-actions">
+                    <button type="button" mat-button (click)="openAddPerson()">Add person</button>
+                </div>
+                @if (selectedGuests.length > 0) {
+                <div class="guest-suggestions">
+                    <span>Selected:</span>
+                    @for (person of selectedGuests; track person.id) {
+                    <div class="guest-row">
+                        <span>{{personLabel(person)}}</span>
+                        <button type="button" mat-button (click)="openEditPerson(person)">Edit</button>
+                    </div>
+                    }
+                </div>
+                }
+                @if (guestSuggestions.length > 0) {
+                <div class="guest-suggestions">
+                    <span>Suggested from title/description:</span>
+                    @for (suggestion of guestSuggestions; track suggestion.person.id) {
+                    <div class="guest-row">
+                        <span>{{personLabel(suggestion.person)}} ({{suggestion.matchResults[0]?.term}})</span>
+                        <button type="button" mat-button (click)="addSuggestedGuest(suggestion.person.name)">Add</button>
+                    </div>
+                    }
+                </div>
+                }
             </mat-tab>
         </mat-tab-group>
     </form>

--- a/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.sass
+++ b/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.sass
@@ -13,3 +13,12 @@
         label
             span
                 display: inline
+    .guest-actions
+        margin: 8px 0
+    .guest-suggestions
+        margin-top: 10px
+        .guest-row
+            display: flex
+            align-items: center
+            gap: 8px
+            margin-top: 4px

--- a/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.ts
+++ b/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.ts
@@ -4,10 +4,12 @@ import { MatInputModule } from '@angular/material/input';
 import { MAT_DIALOG_DATA, MatDialogRef, MatDialogModule, MatDialog } from '@angular/material/dialog';
 import { AuthServiceWrapper } from '../auth-service-wrapper.class';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
-import { firstValueFrom, forkJoin } from 'rxjs';
+import { firstValueFrom, forkJoin, catchError, of, throwError } from 'rxjs';
 import { environment } from './../../environments/environment';
 import { ApiEpisode } from '../api-episode.interface';
 import { Subject } from '../subject.interface';
+import { Person } from '../person.interface';
+import { PersonMatch } from '../person-match.interface';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatButtonModule } from '@angular/material/button';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
@@ -26,6 +28,7 @@ import { Podcast } from '../podcast.interface';
 import { MatDividerModule } from '@angular/material/divider';
 import { filterKeepingSelectedInOrder } from '../subject-filter.util';
 import { buildEpisodeLanguageOptions } from '../language-options.util';
+import { EditPersonDialogComponent } from '../edit-person-dialog/edit-person-dialog.component';
 
 @Component({
   selector: 'app-edit-episode-dialog',
@@ -64,6 +67,11 @@ export class EditEpisodeDialogComponent {
   hoistedSubjects: string[] = [];
   otherSubjects: string[] = [];
   subjectsFilterTerm: string = '';
+  allPeople: Person[] = [];
+  selectedGuests: Person[] = [];
+  otherPeople: Person[] = [];
+  guestsFilterTerm: string = '';
+  guestSuggestions: PersonMatch[] = [];
   languages: { [key: string]: string } = {};
 
   form: FormGroup<EpisodeForm> | undefined;
@@ -94,12 +102,16 @@ export class EditEpisodeDialogComponent {
       headers = headers.set("Authorization", "Bearer " + token);
       const episodeEndpoint = new URL(`/episode/${encodeURIComponent(this.podcastIdentifier)}/${this.episodeId}`, environment.api).toString();
       const subjectsEndpoint = new URL("/subjects", environment.api).toString();
+      const peopleEndpoint = new URL("/people", environment.api).toString();
       const languagesEndpoint = new URL("/languages", environment.api).toString();
 
       var resp = await firstValueFrom(forkJoin(
         {
           episode: this.http.get<ApiEpisode>(episodeEndpoint, { headers: headers }),
           subjects: this.http.get<Subject[]>(subjectsEndpoint, { headers: headers }),
+          people: this.http.get<Person[]>(peopleEndpoint, { headers: headers }).pipe(
+            catchError(err => err?.status === 404 ? of([] as Person[]) : throwError(() => err))
+          ),
           languages: this.http.get<{ [key: string]: string }>(languagesEndpoint, { headers: headers })
         }
       ));
@@ -138,9 +150,11 @@ export class EditEpisodeDialogComponent {
         subjects: new FormControl(resp.episode.subjects, { nonNullable: true }),
         searchTerms: new FormControl(resp.episode.searchTerms || null),
         lang: new FormControl(resp.episode.lang || "unset"),
-        twitterHandles: new FormControl<string[]>(resp.episode.twitterHandles ?? [], { nonNullable: true }),
-        blueskyHandles: new FormControl<string[]>(resp.episode.blueskyHandles ?? [], { nonNullable: true })
+        guests: new FormControl<string[]>(resp.episode.guests ?? [], { nonNullable: true })
       });
+      this.allPeople = resp.people.sort((a, b) => a.name.localeCompare(b.name));
+      this.guestSuggestions = resp.episode.guestSuggestions ?? [];
+      this.regroupGuests(resp.episode.guests ?? []);
       this.subjects = resp.episode.subjects.concat(resp.subjects.filter(x => !resp.episode.subjects.includes(x.name)).map(x => x.name));
       this.allSubjects = this.unique(this.subjects.concat(this.podcastDefaultSubject ? [this.podcastDefaultSubject] : []));
       this.regroupSubjects(resp.episode.subjects);
@@ -183,8 +197,7 @@ export class EditEpisodeDialogComponent {
         subjects: this.form!.controls.subjects.value,
         searchTerms: this.form!.controls.searchTerms.value,
         lang: this.form!.controls.lang.value,
-        twitterHandles: this.translateForEntityA(this.form!.controls.twitterHandles),
-        blueskyHandles: this.translateForEntityA(this.form!.controls.blueskyHandles),
+        guests: this.form!.controls.guests.value,
       };
       if (this.form!.controls.spotify.value) {
         update.urls.spotify = new URL(this.form!.controls.spotify.value);
@@ -264,9 +277,148 @@ export class EditEpisodeDialogComponent {
     if (!this.areEqual(prev.images?.youtube, now.images?.youtube)) changes.images!.youtube = now.images?.youtube ?? "";
     if (!this.areEqual(prev.images?.other, now.images?.other)) changes.images!.other = now.images?.other ?? "";
     if (!this.areEqual(prev.lang ?? "unset", now.lang ?? "unset")) changes.lang = now.lang == "unset" ? "" : now.lang ?? "";
-    if (!this.isSameA(prev.twitterHandles, now.twitterHandles)) changes.twitterHandles = now.twitterHandles;
-    if (!this.isSameA(prev.blueskyHandles, now.blueskyHandles)) changes.blueskyHandles = now.blueskyHandles;
+    if (!this.isSameA(prev.guests, now.guests)) changes.guests = now.guests;
     return changes;
+  }
+
+  personLabel(person: Person): string {
+    const handles = [person.twitterHandle, person.blueskyHandle].filter(x => !!x).join(' ');
+    return handles ? `${person.name} (${handles})` : person.name;
+  }
+
+  onGuestsSelectionChange() {
+    this.regroupGuests(this.form?.controls.guests.value);
+  }
+
+  onGuestsDropdownOpenChange(opened: boolean) {
+    if (!opened) {
+      this.guestsFilterTerm = '';
+      this.regroupGuests(this.form?.controls.guests.value);
+    }
+  }
+
+  onGuestsDropdownKeydown(event: KeyboardEvent) {
+    if (!this.enableDesktopSubjectTypingFilter) {
+      return;
+    }
+    if (event.ctrlKey || event.altKey || event.metaKey) {
+      return;
+    }
+
+    if (event.key === 'Backspace') {
+      if (this.guestsFilterTerm.length > 0) {
+        this.guestsFilterTerm = this.guestsFilterTerm.substring(0, this.guestsFilterTerm.length - 1);
+        this.regroupGuests(this.form?.controls.guests.value);
+      }
+      event.preventDefault();
+      return;
+    }
+
+    if (event.key === 'Escape') {
+      this.guestsFilterTerm = '';
+      this.regroupGuests(this.form?.controls.guests.value);
+      event.preventDefault();
+      return;
+    }
+
+    if (event.key.length === 1) {
+      this.guestsFilterTerm += event.key;
+      this.regroupGuests(this.form?.controls.guests.value);
+      event.preventDefault();
+    }
+  }
+
+  regroupGuests(selected: string[] | null | undefined) {
+    const selectedNames = [...new Set(selected ?? [])];
+    const selectedSet = new Set(selectedNames);
+    const episodeGuests = this.originalEpisode?.guestPeople ?? [];
+    const peopleByName = new Map(this.allPeople.map(x => [x.name, x]));
+    for (const guest of episodeGuests) {
+      peopleByName.set(guest.name, guest);
+    }
+    this.selectedGuests = selectedNames
+      .map(name => peopleByName.get(name))
+      .filter((x): x is Person => !!x);
+
+    const otherNames = this.allPeople
+      .map(person => person.name)
+      .filter(name => !selectedSet.has(name));
+    const filteredOtherNames = filterKeepingSelectedInOrder(otherNames, this.guestsFilterTerm, selectedSet);
+    this.otherPeople = filteredOtherNames
+      .map(name => peopleByName.get(name))
+      .filter((x): x is Person => !!x);
+  }
+
+  addSuggestedGuest(personName: string) {
+    const current = this.form?.controls.guests.value ?? [];
+    if (current.includes(personName)) {
+      return;
+    }
+    this.form?.controls.guests.setValue([...current, personName]);
+    this.guestSuggestions = this.guestSuggestions.filter(x => x.person.name !== personName);
+    this.regroupGuests(this.form?.controls.guests.value);
+  }
+
+  openAddPerson() {
+    const dialogRef = this.dialog.open(EditPersonDialogComponent, {
+      data: { create: true, personName: this.guestsFilterTerm || undefined },
+      disableClose: true,
+      autoFocus: true,
+      width: '90%'
+    });
+    dialogRef.afterClosed().subscribe(async result => {
+      if (result?.updated && result.personName) {
+        await this.refreshPeopleAndSelect(result.personName, result.person);
+      }
+    });
+  }
+
+  openEditPerson(person: Person) {
+    const dialogRef = this.dialog.open(EditPersonDialogComponent, {
+      data: { create: false, personName: person.name },
+      disableClose: true,
+      autoFocus: true,
+      width: '90%'
+    });
+    dialogRef.afterClosed().subscribe(async result => {
+      if (result?.updated) {
+        await this.refreshPeopleAndSelect(person.name);
+      }
+    });
+  }
+
+  private async refreshPeopleAndSelect(personName: string, created?: Person) {
+    try {
+      const token = await firstValueFrom(this.auth.authService.getAccessTokenSilently({
+        authorizationParams: {
+          audience: `https://api.cultpodcasts.com/`,
+          scope: 'curate'
+        }
+      }));
+      let headers: HttpHeaders = new HttpHeaders();
+      headers = headers.set("Authorization", "Bearer " + token);
+      const peopleEndpoint = new URL("/people", environment.api).toString();
+      const people = await firstValueFrom(
+        this.http.get<Person[]>(peopleEndpoint, { headers: headers }).pipe(
+          catchError(err => err?.status === 404 ? of([] as Person[]) : throwError(() => err))
+        )
+      );
+      this.allPeople = people.sort((a, b) => a.name.localeCompare(b.name));
+      if (created && !this.allPeople.some(x => x.name === created.name)) {
+        this.allPeople = [...this.allPeople, created].sort((a, b) => a.name.localeCompare(b.name));
+      }
+    } catch {
+      if (created) {
+        this.allPeople = [...this.allPeople.filter(x => x.name !== created.name), created]
+          .sort((a, b) => a.name.localeCompare(b.name));
+      }
+    }
+
+    const current = this.form?.controls.guests.value ?? [];
+    if (!current.includes(personName)) {
+      this.form?.controls.guests.setValue([...current, personName]);
+    }
+    this.regroupGuests(this.form?.controls.guests.value);
   }
 
   areEqual(url1: URL | null | undefined | string, url2: URL | null | undefined | string): boolean {
@@ -395,18 +547,5 @@ export class EditEpisodeDialogComponent {
 
   unique(values: string[]) {
     return [...new Set(values)];
-  }
-
-  translateForEntityA(x: FormControl<string[] | undefined | null>): string[] | undefined {
-    if (x.value) {
-      const valueS: any = x.value;
-      if (valueS.push) {
-        return x.value;
-      } else if (valueS.split) {
-        const valueSt: string = valueS;
-        return valueSt.split(",");
-      }
-    };
-    return [];
   }
 }

--- a/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.ts
+++ b/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.ts
@@ -29,6 +29,7 @@ import { MatDividerModule } from '@angular/material/divider';
 import { filterKeepingSelectedInOrder } from '../subject-filter.util';
 import { buildEpisodeLanguageOptions } from '../language-options.util';
 import { EditPersonDialogComponent } from '../edit-person-dialog/edit-person-dialog.component';
+import { comparePeopleBySortKey } from '../person-sort';
 
 @Component({
   selector: 'app-edit-episode-dialog',
@@ -152,7 +153,7 @@ export class EditEpisodeDialogComponent {
         lang: new FormControl(resp.episode.lang || "unset"),
         guests: new FormControl<string[]>(resp.episode.guests ?? [], { nonNullable: true })
       });
-      this.allPeople = resp.people.sort((a, b) => a.name.localeCompare(b.name));
+      this.allPeople = resp.people.sort(comparePeopleBySortKey);
       this.guestSuggestions = resp.episode.guestSuggestions ?? [];
       this.regroupGuests(resp.episode.guests ?? []);
       this.subjects = resp.episode.subjects.concat(resp.subjects.filter(x => !resp.episode.subjects.includes(x.name)).map(x => x.name));
@@ -403,14 +404,14 @@ export class EditEpisodeDialogComponent {
           catchError(err => err?.status === 404 ? of([] as Person[]) : throwError(() => err))
         )
       );
-      this.allPeople = people.sort((a, b) => a.name.localeCompare(b.name));
+      this.allPeople = people.sort(comparePeopleBySortKey);
       if (created && !this.allPeople.some(x => x.name === created.name)) {
-        this.allPeople = [...this.allPeople, created].sort((a, b) => a.name.localeCompare(b.name));
+        this.allPeople = [...this.allPeople, created].sort(comparePeopleBySortKey);
       }
     } catch {
       if (created) {
         this.allPeople = [...this.allPeople.filter(x => x.name !== created.name), created]
-          .sort((a, b) => a.name.localeCompare(b.name));
+          .sort(comparePeopleBySortKey);
       }
     }
 

--- a/cultpodcasts/src/app/edit-person-dialog/edit-person-dialog.component.html
+++ b/cultpodcasts/src/app/edit-person-dialog/edit-person-dialog.component.html
@@ -1,0 +1,38 @@
+<h2 mat-dialog-title>{{create?"Add":"Edit"}} Person</h2>
+
+<mat-dialog-content>
+    @if (isLoading) {
+    <mat-spinner style="margin:0 auto;" mode="indeterminate"></mat-spinner>
+    } @else if (isInError) {
+    <p id="error">An error occurred</p>
+    } @else {
+    <form id="edit" [formGroup]="form!" (ngSubmit)="onSubmit()">
+        <label>
+            <span>Name:</span>
+            <input type="text" [formControl]="form!.controls.name" [readonly]="!create" matInput>
+        </label>
+        <div class="search-actions">
+            <button type="button" mat-button (click)="searchX()" [disabled]="!searchTerm()">Search X</button>
+            <button type="button" mat-button (click)="searchBluesky()" [disabled]="!searchTerm()">Search Bluesky</button>
+        </div>
+        <label>
+            <span>Aliases:</span>
+            <textarea [formControl]="form!.controls.aliases" matInput cdkTextareaAutosize
+                placeholder="Comma-separated aliases"></textarea>
+        </label>
+        <label>
+            <span>Twitter / X handle:</span>
+            <input type="text" [formControl]="form!.controls.twitterHandle" matInput placeholder="@handle">
+        </label>
+        <label>
+            <span>Bluesky handle:</span>
+            <input type="text" [formControl]="form!.controls.blueskyHandle" matInput placeholder="handle.bsky.social">
+        </label>
+    </form>
+    }
+</mat-dialog-content>
+
+<mat-dialog-actions>
+    <button mat-raised-button (click)="close()">Close</button>
+    <button mat-raised-button [disabled]="!form || !form.valid" (click)="onSubmit()">Submit</button>
+</mat-dialog-actions>

--- a/cultpodcasts/src/app/edit-person-dialog/edit-person-dialog.component.html
+++ b/cultpodcasts/src/app/edit-person-dialog/edit-person-dialog.component.html
@@ -16,6 +16,15 @@
             <button type="button" mat-button (click)="searchBluesky()" [disabled]="!searchTerm()">Search Bluesky</button>
         </div>
         <label>
+            <span>Sort name:</span>
+            <input type="text" [formControl]="form!.controls.sortName" matInput
+                placeholder="Suggested from name — edit to override">
+        </label>
+        <p class="sorts-as-hint">Sorts as: {{ sortsAsHint }}</p>
+        <mat-checkbox [formControl]="useFullNameForSorting">
+            Organization / use full name for sorting
+        </mat-checkbox>
+        <label>
             <span>Aliases:</span>
             <textarea [formControl]="form!.controls.aliases" matInput cdkTextareaAutosize
                 placeholder="Comma-separated aliases"></textarea>

--- a/cultpodcasts/src/app/edit-person-dialog/edit-person-dialog.component.sass
+++ b/cultpodcasts/src/app/edit-person-dialog/edit-person-dialog.component.sass
@@ -1,0 +1,15 @@
+#error
+    font-size: 1em
+#edit
+    label
+        display: block
+        margin-bottom: 10px
+        margin-top: 10px
+        span
+            display: block
+        input[type=text], textarea
+            width: 96%
+    .search-actions
+        margin-bottom: 10px
+        button
+            margin-right: 8px

--- a/cultpodcasts/src/app/edit-person-dialog/edit-person-dialog.component.sass
+++ b/cultpodcasts/src/app/edit-person-dialog/edit-person-dialog.component.sass
@@ -13,3 +13,7 @@
         margin-bottom: 10px
         button
             margin-right: 8px
+    .sorts-as-hint
+        margin: 0 0 10px
+        opacity: 0.75
+        font-size: 0.9em

--- a/cultpodcasts/src/app/edit-person-dialog/edit-person-dialog.component.ts
+++ b/cultpodcasts/src/app/edit-person-dialog/edit-person-dialog.component.ts
@@ -4,6 +4,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MAT_DIALOG_DATA, MatDialog, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatCheckboxModule } from '@angular/material/checkbox';
 import { PersonForm } from '../person-form.interface';
 import { Person } from '../person.interface';
 import { AuthServiceWrapper } from '../auth-service-wrapper.class';
@@ -13,6 +14,12 @@ import { environment } from './../../environments/environment';
 import { EditPersonSendComponent } from '../edit-person-send/edit-person-send.component';
 import { CdkTextareaAutosize, TextFieldModule } from '@angular/cdk/text-field';
 import { MatInputModule } from '@angular/material/input';
+import {
+  getEffectiveSortKey,
+  guessSortName,
+  looksLikeOrganization,
+  sortNameForPersist
+} from '../person-sort';
 
 @Component({
   selector: 'app-edit-person-dialog',
@@ -24,7 +31,8 @@ import { MatInputModule } from '@angular/material/input';
     MatFormFieldModule,
     CdkTextareaAutosize,
     TextFieldModule,
-    MatInputModule
+    MatInputModule,
+    MatCheckboxModule
   ],
   templateUrl: './edit-person-dialog.component.html',
   styleUrl: './edit-person-dialog.component.sass'
@@ -38,6 +46,10 @@ export class EditPersonDialogComponent {
   personId: string | undefined;
   create: boolean;
   conflict: string | undefined;
+  useFullNameForSorting = new FormControl(false, { nonNullable: true });
+  /** True once the curator manually edits Sort name (stops live guess sync). */
+  private sortNameManuallyEdited = false;
+  private syncingSort = false;
 
   constructor(
     private auth: AuthServiceWrapper,
@@ -54,12 +66,21 @@ export class EditPersonDialogComponent {
     this.isLoading = true;
     if (this.create) {
       this.originalPerson = { id: '', name: '' };
+      const initialName = this.personName ?? '';
+      const initialGuess = guessSortName(initialName);
       this.form = new FormGroup<PersonForm>({
-        name: new FormControl(this.personName ?? '', { nonNullable: true, validators: [Validators.required] }),
+        name: new FormControl(initialName, { nonNullable: true, validators: [Validators.required] }),
+        sortName: new FormControl(initialGuess, { nonNullable: false }),
         aliases: new FormControl([], { nonNullable: false }),
         twitterHandle: new FormControl('', { nonNullable: false }),
         blueskyHandle: new FormControl('', { nonNullable: false })
       });
+      this.useFullNameForSorting.setValue(
+        !!initialGuess && looksLikeOrganization(initialName),
+        { emitEvent: false }
+      );
+      this.sortNameManuallyEdited = false;
+      this.wireSortControls();
       this.isLoading = false;
       return;
     }
@@ -79,12 +100,22 @@ export class EditPersonDialogComponent {
           next: resp => {
             this.personId = resp.id;
             this.originalPerson = resp;
+            const name = resp.name ?? '';
+            const storedSort = resp.sortName?.trim() ?? '';
+            const guess = guessSortName(name);
+            const isOrgFullName = !!storedSort && storedSort === name.trim();
+            const displaySort = storedSort || guess;
+            this.sortNameManuallyEdited =
+              !!storedSort && !isOrgFullName && storedSort !== guess;
             this.form = new FormGroup<PersonForm>({
-              name: new FormControl(resp.name, { nonNullable: true, validators: [Validators.required] }),
+              name: new FormControl(name, { nonNullable: true, validators: [Validators.required] }),
+              sortName: new FormControl(displaySort, { nonNullable: false }),
               aliases: new FormControl(resp.aliases, { nonNullable: false }),
               twitterHandle: new FormControl(resp.twitterHandle ?? '', { nonNullable: false }),
               blueskyHandle: new FormControl(resp.blueskyHandle ?? '', { nonNullable: false })
             });
+            this.useFullNameForSorting.setValue(isOrgFullName, { emitEvent: false });
+            this.wireSortControls();
             this.isLoading = false;
           },
           error: e => {
@@ -96,6 +127,69 @@ export class EditPersonDialogComponent {
       this.isLoading = false;
       this.isInError = true;
     });
+  }
+
+  private wireSortControls() {
+    this.useFullNameForSorting.valueChanges.subscribe(checked => {
+      if (!this.form || this.syncingSort) {
+        return;
+      }
+      this.syncingSort = true;
+      if (checked) {
+        this.sortNameManuallyEdited = false;
+        this.form.controls.sortName.setValue(this.form.controls.name.value);
+      } else {
+        this.sortNameManuallyEdited = false;
+        this.form.controls.sortName.setValue(guessSortName(this.form.controls.name.value));
+      }
+      this.syncingSort = false;
+    });
+
+    this.form?.controls.name.valueChanges.subscribe(name => {
+      if (!this.form || this.syncingSort) {
+        return;
+      }
+      if (this.useFullNameForSorting.value) {
+        this.syncingSort = true;
+        this.form.controls.sortName.setValue(name);
+        this.syncingSort = false;
+        return;
+      }
+      if (!this.sortNameManuallyEdited) {
+        this.syncingSort = true;
+        const guess = guessSortName(name);
+        this.form.controls.sortName.setValue(guess);
+        // Auto-check org when the guess is the full org/show name.
+        const orgGuess = !!guess && looksLikeOrganization(name) && guess === name.trim();
+        if (this.useFullNameForSorting.value !== orgGuess) {
+          this.useFullNameForSorting.setValue(orgGuess, { emitEvent: false });
+        }
+        this.syncingSort = false;
+      }
+    });
+
+    this.form?.controls.sortName.valueChanges.subscribe(sortName => {
+      if (!this.form || this.syncingSort) {
+        return;
+      }
+      this.sortNameManuallyEdited = true;
+      const name = this.form.controls.name.value?.trim() ?? '';
+      const isOrg = !!(sortName?.trim()) && sortName.trim() === name;
+      if (this.useFullNameForSorting.value !== isOrg) {
+        this.syncingSort = true;
+        this.useFullNameForSorting.setValue(isOrg);
+        this.syncingSort = false;
+      }
+    });
+  }
+
+  get sortsAsHint(): string {
+    if (!this.form) {
+      return '';
+    }
+    const name = this.form.controls.name.value;
+    const sortName = this.form.controls.sortName.value;
+    return getEffectiveSortKey({ name, sortName }) || guessSortName(name) || '—';
   }
 
   close() {
@@ -149,9 +243,16 @@ export class EditPersonDialogComponent {
       return;
     }
 
+    const name = this.translateForEntity(this.form!.controls.name)!;
+    const persistedSort = sortNameForPersist(
+      name,
+      this.form!.controls.sortName.value,
+      this.useFullNameForSorting.value
+    );
     const update: Person = {
       id: this.personId ?? '',
-      name: this.translateForEntity(this.form!.controls.name)!,
+      name,
+      sortName: persistedSort ?? '',
       aliases: this.translateForEntityA(this.form!.controls.aliases),
       twitterHandle: this.translateForEntity(this.form!.controls.twitterHandle),
       blueskyHandle: this.translateForEntity(this.form!.controls.blueskyHandle)
@@ -192,6 +293,7 @@ export class EditPersonDialogComponent {
     if (this.create) {
       return {
         name: now.name,
+        sortName: now.sortName || null,
         aliases: now.aliases,
         twitterHandle: now.twitterHandle,
         blueskyHandle: now.blueskyHandle
@@ -199,6 +301,7 @@ export class EditPersonDialogComponent {
     }
 
     const changes: Partial<Person> = {};
+    if (!this.isSame(prev.sortName, now.sortName)) changes.sortName = now.sortName ?? '';
     if (!this.isSameA(prev.aliases, now.aliases)) changes.aliases = now.aliases;
     if (!this.isSame(prev.twitterHandle, now.twitterHandle)) changes.twitterHandle = now.twitterHandle ?? '';
     if (!this.isSame(prev.blueskyHandle, now.blueskyHandle)) changes.blueskyHandle = now.blueskyHandle ?? '';

--- a/cultpodcasts/src/app/edit-person-dialog/edit-person-dialog.component.ts
+++ b/cultpodcasts/src/app/edit-person-dialog/edit-person-dialog.component.ts
@@ -1,0 +1,224 @@
+import { Component, Inject } from '@angular/core';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MAT_DIALOG_DATA, MatDialog, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { PersonForm } from '../person-form.interface';
+import { Person } from '../person.interface';
+import { AuthServiceWrapper } from '../auth-service-wrapper.class';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
+import { environment } from './../../environments/environment';
+import { EditPersonSendComponent } from '../edit-person-send/edit-person-send.component';
+import { CdkTextareaAutosize, TextFieldModule } from '@angular/cdk/text-field';
+import { MatInputModule } from '@angular/material/input';
+
+@Component({
+  selector: 'app-edit-person-dialog',
+  imports: [
+    MatDialogModule,
+    MatProgressSpinnerModule,
+    MatButtonModule,
+    ReactiveFormsModule,
+    MatFormFieldModule,
+    CdkTextareaAutosize,
+    TextFieldModule,
+    MatInputModule
+  ],
+  templateUrl: './edit-person-dialog.component.html',
+  styleUrl: './edit-person-dialog.component.sass'
+})
+export class EditPersonDialogComponent {
+  personName: string | undefined;
+  isLoading: boolean = true;
+  isInError: boolean = false;
+  form: FormGroup<PersonForm> | undefined;
+  originalPerson: Person | undefined;
+  personId: string | undefined;
+  create: boolean;
+  conflict: string | undefined;
+
+  constructor(
+    private auth: AuthServiceWrapper,
+    private http: HttpClient,
+    private dialogRef: MatDialogRef<EditPersonDialogComponent, any>,
+    @Inject(MAT_DIALOG_DATA) public data: { personName: string | undefined, create: boolean | undefined },
+    private dialog: MatDialog,
+  ) {
+    this.personName = data.personName;
+    this.create = data.create || false;
+  }
+
+  ngOnInit() {
+    this.isLoading = true;
+    if (this.create) {
+      this.originalPerson = { id: '', name: '' };
+      this.form = new FormGroup<PersonForm>({
+        name: new FormControl(this.personName ?? '', { nonNullable: true, validators: [Validators.required] }),
+        aliases: new FormControl([], { nonNullable: false }),
+        twitterHandle: new FormControl('', { nonNullable: false }),
+        blueskyHandle: new FormControl('', { nonNullable: false })
+      });
+      this.isLoading = false;
+      return;
+    }
+
+    var token = firstValueFrom(this.auth.authService.getAccessTokenSilently({
+      authorizationParams: {
+        audience: `https://api.cultpodcasts.com/`,
+        scope: 'curate'
+      }
+    }));
+    token.then(_token => {
+      let headers: HttpHeaders = new HttpHeaders();
+      headers = headers.set("Authorization", "Bearer " + _token);
+      const personEndpoint = new URL(`/person/${encodeURIComponent(this.personName!)}`, environment.api).toString();
+      this.http.get<Person>(personEndpoint, { headers: headers })
+        .subscribe({
+          next: resp => {
+            this.personId = resp.id;
+            this.originalPerson = resp;
+            this.form = new FormGroup<PersonForm>({
+              name: new FormControl(resp.name, { nonNullable: true, validators: [Validators.required] }),
+              aliases: new FormControl(resp.aliases, { nonNullable: false }),
+              twitterHandle: new FormControl(resp.twitterHandle ?? '', { nonNullable: false }),
+              blueskyHandle: new FormControl(resp.blueskyHandle ?? '', { nonNullable: false })
+            });
+            this.isLoading = false;
+          },
+          error: e => {
+            this.isLoading = false;
+            this.isInError = true;
+          }
+        });
+    }).catch(x => {
+      this.isLoading = false;
+      this.isInError = true;
+    });
+  }
+
+  close() {
+    if (this.conflict) {
+      this.dialogRef.close({ conflict: this.conflict });
+    } else {
+      this.dialogRef.close({ closed: true });
+    }
+  }
+
+  searchTerm(): string {
+    return (this.form?.controls.name.value ?? this.personName ?? '').trim();
+  }
+
+  searchX() {
+    const q = this.searchTerm();
+    if (!q) {
+      return;
+    }
+    window.open(`https://x.com/search?q=${encodeURIComponent(q)}&f=user`, '_blank', 'noopener');
+  }
+
+  searchBluesky() {
+    const q = this.searchTerm();
+    if (!q) {
+      return;
+    }
+    window.open(`https://bsky.app/search?q=${encodeURIComponent(q)}`, '_blank', 'noopener');
+  }
+
+  translateForEntity(x: FormControl<string | undefined | null>): string | undefined {
+    if (x.value) return x.value;
+    return "";
+  }
+
+  translateForEntityA(x: FormControl<string[] | undefined | null>): string[] | undefined {
+    if (x.value) {
+      const valueS: any = x.value;
+      if (valueS.push) {
+        return x.value;
+      } else if (valueS.split) {
+        const valueSt: string = valueS;
+        return valueSt.split(",").map((s: string) => s.trim()).filter((s: string) => s.length > 0);
+      }
+    };
+    return [];
+  }
+
+  onSubmit() {
+    if (!this.form?.valid) {
+      return;
+    }
+
+    const update: Person = {
+      id: this.personId ?? '',
+      name: this.translateForEntity(this.form!.controls.name)!,
+      aliases: this.translateForEntityA(this.form!.controls.aliases),
+      twitterHandle: this.translateForEntity(this.form!.controls.twitterHandle),
+      blueskyHandle: this.translateForEntity(this.form!.controls.blueskyHandle)
+    };
+
+    const changes = this.getChanges(this.originalPerson!, update);
+    if (Object.keys(changes).length == 0) {
+      this.dialogRef.close({ noChange: true });
+    } else {
+      this.send(this.personId!, changes);
+    }
+  }
+
+  isSameA(a: string[] | null | undefined, b: string[] | null | undefined): boolean {
+    if (!a && !b) {
+      return true;
+    }
+    if (!a && b?.length == 0) {
+      return true;
+    }
+    if (a?.length == 0 && !b) {
+      return true;
+    }
+    return JSON.stringify(a) == JSON.stringify(b);
+  }
+
+  isSame(a: string | null | undefined, b: string | null | undefined): boolean {
+    if (!a && !b) {
+      return true;
+    }
+    if ((a === '' || a == null) && (b === '' || b == null)) {
+      return true;
+    }
+    return JSON.stringify(a) == JSON.stringify(b);
+  }
+
+  getChanges(prev: Person, now: Person): Partial<Person> & { name?: string } {
+    if (this.create) {
+      return {
+        name: now.name,
+        aliases: now.aliases,
+        twitterHandle: now.twitterHandle,
+        blueskyHandle: now.blueskyHandle
+      };
+    }
+
+    const changes: Partial<Person> = {};
+    if (!this.isSameA(prev.aliases, now.aliases)) changes.aliases = now.aliases;
+    if (!this.isSame(prev.twitterHandle, now.twitterHandle)) changes.twitterHandle = now.twitterHandle ?? '';
+    if (!this.isSame(prev.blueskyHandle, now.blueskyHandle)) changes.blueskyHandle = now.blueskyHandle ?? '';
+    return changes;
+  }
+
+  send(id: string, changes: Partial<Person>) {
+    const payload = changes as Person;
+    const dialogRef = this.dialog.open(EditPersonSendComponent, { disableClose: true, autoFocus: true, data: { create: this.create } });
+    dialogRef.componentInstance.submit(id, payload, this.create);
+    dialogRef.afterClosed().subscribe(async result => {
+      if (result?.updated) {
+        this.dialogRef.close({
+          updated: true,
+          personName: result.personName ?? changes.name,
+          person: result.person
+        });
+      } else if (result?.conflict) {
+        this.conflict = result.conflict;
+      }
+    });
+  }
+}

--- a/cultpodcasts/src/app/edit-person-dialog/edit-person-dialog.component.ts
+++ b/cultpodcasts/src/app/edit-person-dialog/edit-person-dialog.component.ts
@@ -15,10 +15,12 @@ import { EditPersonSendComponent } from '../edit-person-send/edit-person-send.co
 import { CdkTextareaAutosize, TextFieldModule } from '@angular/cdk/text-field';
 import { MatInputModule } from '@angular/material/input';
 import {
+  deriveSortKeyFromName,
   getEffectiveSortKey,
   guessSortName,
   looksLikeOrganization,
-  sortNameForPersist
+  sortNameForPersist,
+  stripLeadingThe
 } from '../person-sort';
 
 @Component({
@@ -103,7 +105,11 @@ export class EditPersonDialogComponent {
             const name = resp.name ?? '';
             const storedSort = resp.sortName?.trim() ?? '';
             const guess = guessSortName(name);
-            const isOrgFullName = !!storedSort && storedSort === name.trim();
+            const orgKey = stripLeadingThe(name.trim());
+            const isOrgFullName =
+              looksLikeOrganization(name) &&
+              !!storedSort &&
+              (storedSort === orgKey || storedSort === name.trim());
             const displaySort = storedSort || guess;
             this.sortNameManuallyEdited =
               !!storedSort && !isOrgFullName && storedSort !== guess;
@@ -135,12 +141,11 @@ export class EditPersonDialogComponent {
         return;
       }
       this.syncingSort = true;
+      this.sortNameManuallyEdited = false;
       if (checked) {
-        this.sortNameManuallyEdited = false;
-        this.form.controls.sortName.setValue(this.form.controls.name.value);
-      } else {
-        this.sortNameManuallyEdited = false;
         this.form.controls.sortName.setValue(guessSortName(this.form.controls.name.value));
+      } else {
+        this.form.controls.sortName.setValue(deriveSortKeyFromName(this.form.controls.name.value));
       }
       this.syncingSort = false;
     });
@@ -151,7 +156,7 @@ export class EditPersonDialogComponent {
       }
       if (this.useFullNameForSorting.value) {
         this.syncingSort = true;
-        this.form.controls.sortName.setValue(name);
+        this.form.controls.sortName.setValue(guessSortName(name));
         this.syncingSort = false;
         return;
       }
@@ -159,8 +164,7 @@ export class EditPersonDialogComponent {
         this.syncingSort = true;
         const guess = guessSortName(name);
         this.form.controls.sortName.setValue(guess);
-        // Auto-check org when the guess is the full org/show name.
-        const orgGuess = !!guess && looksLikeOrganization(name) && guess === name.trim();
+        const orgGuess = looksLikeOrganization(name);
         if (this.useFullNameForSorting.value !== orgGuess) {
           this.useFullNameForSorting.setValue(orgGuess, { emitEvent: false });
         }
@@ -174,7 +178,9 @@ export class EditPersonDialogComponent {
       }
       this.sortNameManuallyEdited = true;
       const name = this.form.controls.name.value?.trim() ?? '';
-      const isOrg = !!(sortName?.trim()) && sortName.trim() === name;
+      const trimmedSort = sortName?.trim() ?? '';
+      const orgKey = stripLeadingThe(name);
+      const isOrg = !!trimmedSort && (trimmedSort === orgKey || trimmedSort === name);
       if (this.useFullNameForSorting.value !== isOrg) {
         this.syncingSort = true;
         this.useFullNameForSorting.setValue(isOrg);

--- a/cultpodcasts/src/app/edit-person-send/edit-person-send.component.html
+++ b/cultpodcasts/src/app/edit-person-send/edit-person-send.component.html
@@ -1,0 +1,23 @@
+<h2 mat-dialog-title>{{create?"Adding":"Updating"}} Person</h2>
+
+<mat-dialog-content>
+
+    @if (isSending) {
+    <mat-spinner style="margin:0 auto;" mode="indeterminate"></mat-spinner>
+    }
+    @if (sendError) {
+    <div>
+        <p>An error occured updating person</p>
+        @if (conflict) {
+        <p id="error">A conflict occured with '{{conflict}}'.</p>
+        }
+    </div>
+    }
+
+</mat-dialog-content>
+
+@if (sendError) {
+<mat-dialog-actions>
+    <button mat-raised-button (click)="close()">Close</button>
+</mat-dialog-actions>
+}

--- a/cultpodcasts/src/app/edit-person-send/edit-person-send.component.sass
+++ b/cultpodcasts/src/app/edit-person-send/edit-person-send.component.sass
@@ -1,0 +1,2 @@
+#error
+    font-size: 1em

--- a/cultpodcasts/src/app/edit-person-send/edit-person-send.component.ts
+++ b/cultpodcasts/src/app/edit-person-send/edit-person-send.component.ts
@@ -1,0 +1,100 @@
+import { Component, Inject } from '@angular/core';
+import { Person } from '../person.interface';
+import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatButtonModule } from '@angular/material/button';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { AuthServiceWrapper } from '../auth-service-wrapper.class';
+import { environment } from './../../environments/environment';
+import { firstValueFrom } from 'rxjs';
+
+@Component({
+  selector: 'app-edit-person-send',
+  imports: [MatDialogModule, MatProgressSpinnerModule, MatButtonModule],
+  templateUrl: './edit-person-send.component.html',
+  styleUrl: './edit-person-send.component.sass'
+})
+export class EditPersonSendComponent {
+  isSending: boolean = true;
+  sendError: boolean = false;
+  conflict: string | undefined;
+  create: boolean;
+
+  constructor(
+    private http: HttpClient,
+    private dialogRef: MatDialogRef<EditPersonSendComponent>,
+    private auth: AuthServiceWrapper,
+    @Inject(MAT_DIALOG_DATA) public data: { create: boolean }
+  ) {
+    this.create = data.create;
+  }
+
+  public submit(personId: string, changes: Person, create: boolean) {
+    var token = firstValueFrom(this.auth.authService.getAccessTokenSilently({
+      authorizationParams: {
+        audience: `https://api.cultpodcasts.com/`,
+        scope: 'curate'
+      }
+    }));
+    token.then(_token => {
+      let headers: HttpHeaders = new HttpHeaders();
+      headers = headers.set("Authorization", "Bearer " + _token);
+
+      if (create) {
+        const personEndpoint = new URL(`/person`, environment.api).toString();
+        this.http.put<Person>(personEndpoint, changes, { headers: headers, observe: "response" })
+          .subscribe(
+            {
+              next: resp => {
+                if (resp.status == 202) {
+                  this.dialogRef.close({
+                    updated: true,
+                    person: resp.body,
+                    personName: resp.body?.name ?? changes.name
+                  });
+                }
+              },
+              error: e => {
+                if (e.status == 409) {
+                  this.isSending = false;
+                  this.sendError = true;
+                  this.conflict = e.error.conflict;
+                } else {
+                  this.isSending = false;
+                  this.sendError = true;
+                  console.error(e);
+                }
+              }
+            }
+          );
+      } else {
+        const personEndpoint = new URL(`/person/${personId}`, environment.api).toString();
+        this.http.post(personEndpoint, changes, { headers: headers, observe: "response" })
+          .subscribe(
+            {
+              next: resp => {
+                this.dialogRef.close({ updated: true, personName: changes.name });
+              },
+              error: e => {
+                this.isSending = false;
+                this.sendError = true;
+                console.error(e);
+              }
+            }
+          );
+      }
+    }).catch(x => {
+      this.isSending = false;
+      this.sendError = true;
+      console.error(x);
+    });
+  }
+
+  close() {
+    if (this.conflict) {
+      this.dialogRef.close({ conflict: this.conflict });
+    } else {
+      this.dialogRef.close({ updated: false });
+    }
+  }
+}

--- a/cultpodcasts/src/app/episode-form.interface.ts
+++ b/cultpodcasts/src/app/episode-form.interface.ts
@@ -23,6 +23,5 @@ export interface EpisodeForm {
     subjects: FormControl<string[]>,
     searchTerms: FormControl<string | null>,
     lang: FormControl<string | null>
-    twitterHandles: FormControl<string[]>,
-    blueskyHandles: FormControl<string[]>
+    guests: FormControl<string[]>,
 }

--- a/cultpodcasts/src/app/episode-post.interface.ts
+++ b/cultpodcasts/src/app/episode-post.interface.ts
@@ -16,6 +16,5 @@ export interface EpisodePost {
     subjects?: string[];
     searchTerms?: string | null;
     lang?: string;
-    twitterHandles?: string[];
-    blueskyHandles?: string[];
+    guests?: string[];
 }

--- a/cultpodcasts/src/app/person-form.interface.ts
+++ b/cultpodcasts/src/app/person-form.interface.ts
@@ -2,6 +2,7 @@ import { FormControl } from '@angular/forms';
 
 export interface PersonForm {
     name: FormControl<string>;
+    sortName: FormControl<string | null | undefined>;
     aliases: FormControl<string[] | null | undefined>;
     twitterHandle: FormControl<string | null | undefined>;
     blueskyHandle: FormControl<string | null | undefined>;

--- a/cultpodcasts/src/app/person-form.interface.ts
+++ b/cultpodcasts/src/app/person-form.interface.ts
@@ -1,0 +1,8 @@
+import { FormControl } from '@angular/forms';
+
+export interface PersonForm {
+    name: FormControl<string>;
+    aliases: FormControl<string[] | null | undefined>;
+    twitterHandle: FormControl<string | null | undefined>;
+    blueskyHandle: FormControl<string | null | undefined>;
+}

--- a/cultpodcasts/src/app/person-match.interface.ts
+++ b/cultpodcasts/src/app/person-match.interface.ts
@@ -1,0 +1,11 @@
+import { Person } from './person.interface';
+
+export interface PersonMatchResult {
+    term: string;
+    matches: number;
+}
+
+export interface PersonMatch {
+    person: Person;
+    matchResults: PersonMatchResult[];
+}

--- a/cultpodcasts/src/app/person-sort.ts
+++ b/cultpodcasts/src/app/person-sort.ts
@@ -79,6 +79,15 @@ export function deriveSortKeyFromName(name: string | null | undefined): string {
   return parts[parts.length - 1] ?? '';
 }
 
+/** Strip leading "The " for corp/entity sort keys (display Name unchanged). */
+export function stripLeadingThe(value: string | null | undefined): string {
+  const trimmed = value?.trim() ?? '';
+  if (trimmed.length >= 4 && /^the\s+/i.test(trimmed)) {
+    return trimmed.replace(/^the\s+/i, '').trimStart();
+  }
+  return trimmed;
+}
+
 /** True when the name looks like an org, show, or media brand. */
 export function looksLikeOrganization(name: string | null | undefined): boolean {
   const trimmed = name?.trim();
@@ -105,7 +114,7 @@ export function looksLikeOrganization(name: string | null | undefined): boolean 
 
 /**
  * Suggested sort name for the UI while typing.
- * Orgs/shows → full name; otherwise last whitespace token (single token = that token).
+ * Orgs/shows → StripLeadingThe(full name); otherwise last whitespace token.
  */
 export function guessSortName(name: string | null | undefined): string {
   const trimmed = name?.trim() ?? '';
@@ -113,7 +122,7 @@ export function guessSortName(name: string | null | undefined): string {
     return '';
   }
   if (looksLikeOrganization(trimmed)) {
-    return trimmed;
+    return stripLeadingThe(trimmed);
   }
   return deriveSortKeyFromName(trimmed);
 }
@@ -135,19 +144,35 @@ export function comparePeopleBySortKey(a: Person, b: Person): number {
 }
 
 /**
- * Value to persist: omit redundant last-token guesses (server derives them);
- * keep org full-name and manual overrides.
+ * Persist null ONLY when effective key equals last-token surname default.
+ * Org path: StripLeadingThe(Name). Keep other overrides.
  */
 export function sortNameForPersist(name: string, sortName: string | null | undefined, useFullName: boolean): string | null {
-  const trimmed = sortName?.trim() ?? '';
-  if (!trimmed) {
+  const trimmedName = name?.trim() ?? '';
+  const lastToken = deriveSortKeyFromName(trimmedName);
+  const isOrg = useFullName || looksLikeOrganization(trimmedName);
+  const orgKey = isOrg ? stripLeadingThe(trimmedName) : '';
+
+  let effective = sortName?.trim() ?? '';
+  if (effective) {
+    if (isOrg && orgKey) {
+      const stripped = stripLeadingThe(effective);
+      if (
+        effective.toLowerCase() === trimmedName.toLowerCase() ||
+        stripped.toLowerCase() === orgKey.toLowerCase() ||
+        /^the\s+/i.test(effective)
+      ) {
+        effective = orgKey;
+      }
+    }
+  } else if (isOrg && orgKey) {
+    effective = orgKey;
+  } else {
+    effective = lastToken;
+  }
+
+  if (!effective || effective === lastToken) {
     return null;
   }
-  if (useFullName) {
-    return trimmed;
-  }
-  if (trimmed === deriveSortKeyFromName(name)) {
-    return null;
-  }
-  return trimmed;
+  return effective;
 }

--- a/cultpodcasts/src/app/person-sort.ts
+++ b/cultpodcasts/src/app/person-sort.ts
@@ -1,0 +1,153 @@
+import { Person } from './person.interface';
+
+/** Keywords that suggest an organization, show, or media brand rather than a person. */
+const ORG_SORT_KEYWORDS = [
+  'podcast',
+  'news',
+  'morning',
+  'cnn',
+  'channel',
+  'fm',
+  'am',
+  'tv',
+  'radio',
+  'network',
+  'show',
+  'official',
+  'bbc',
+  'nbc',
+  'abc',
+  'cbs',
+  'msnbc',
+  'fox',
+  'sky',
+  'media',
+  'press',
+  'times',
+  'post',
+  'journal',
+  'gazette',
+  'tribune',
+  'herald',
+  'daily',
+  'weekly',
+  'magazine',
+  'inc',
+  'llc',
+  'ltd',
+  'corp',
+  'company',
+  'foundation',
+  'institute',
+  'ministry',
+  'church',
+  'temple',
+  'university',
+  'college',
+  'school',
+  'association',
+  'society',
+  'committee',
+  'commission',
+  'agency',
+  'bureau',
+  'department',
+  'office',
+  'group',
+  'collective',
+  'productions',
+  'entertainment',
+  'studios',
+  'records',
+];
+
+const ORG_KEYWORD_PATTERN = new RegExp(
+  `\\b(?:${ORG_SORT_KEYWORDS.map(escapeRegExp).join('|')})\\b`,
+  'i'
+);
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** Last whitespace-separated token of name (hyphenated tokens kept whole). */
+export function deriveSortKeyFromName(name: string | null | undefined): string {
+  if (!name?.trim()) {
+    return '';
+  }
+  const parts = name.trim().split(/\s+/);
+  return parts[parts.length - 1] ?? '';
+}
+
+/** True when the name looks like an org, show, or media brand. */
+export function looksLikeOrganization(name: string | null | undefined): boolean {
+  const trimmed = name?.trim();
+  if (!trimmed) {
+    return false;
+  }
+
+  if (ORG_KEYWORD_PATTERN.test(trimmed)) {
+    return true;
+  }
+
+  const parts = trimmed.split(/\s+/);
+  if (parts.length >= 5) {
+    return true;
+  }
+
+  // Multi-word ALL CAPS (e.g. "CNN NEWS") — treat as brand/org.
+  if (parts.length >= 2 && trimmed === trimmed.toUpperCase() && /[A-Z]/.test(trimmed)) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Suggested sort name for the UI while typing.
+ * Orgs/shows → full name; otherwise last whitespace token (single token = that token).
+ */
+export function guessSortName(name: string | null | undefined): string {
+  const trimmed = name?.trim() ?? '';
+  if (!trimmed) {
+    return '';
+  }
+  if (looksLikeOrganization(trimmed)) {
+    return trimmed;
+  }
+  return deriveSortKeyFromName(trimmed);
+}
+
+/** Override when sortName is set; otherwise last token of name (server EffectiveSortKey). */
+export function getEffectiveSortKey(person: Pick<Person, 'name' | 'sortName'> | { name: string; sortName?: string | null }): string {
+  if (person.sortName?.trim()) {
+    return person.sortName.trim();
+  }
+  return deriveSortKeyFromName(person.name);
+}
+
+export function comparePeopleBySortKey(a: Person, b: Person): number {
+  const bySort = getEffectiveSortKey(a).localeCompare(getEffectiveSortKey(b));
+  if (bySort !== 0) {
+    return bySort;
+  }
+  return a.name.localeCompare(b.name);
+}
+
+/**
+ * Value to persist: omit redundant last-token guesses (server derives them);
+ * keep org full-name and manual overrides.
+ */
+export function sortNameForPersist(name: string, sortName: string | null | undefined, useFullName: boolean): string | null {
+  const trimmed = sortName?.trim() ?? '';
+  if (!trimmed) {
+    return null;
+  }
+  if (useFullName) {
+    return trimmed;
+  }
+  if (trimmed === deriveSortKeyFromName(name)) {
+    return null;
+  }
+  return trimmed;
+}

--- a/cultpodcasts/src/app/person.interface.ts
+++ b/cultpodcasts/src/app/person.interface.ts
@@ -1,0 +1,7 @@
+export interface Person {
+    id: string;
+    name: string;
+    aliases?: string[] | null;
+    twitterHandle?: string | null;
+    blueskyHandle?: string | null;
+}

--- a/cultpodcasts/src/app/person.interface.ts
+++ b/cultpodcasts/src/app/person.interface.ts
@@ -1,6 +1,7 @@
 export interface Person {
     id: string;
     name: string;
+    sortName?: string | null;
     aliases?: string[] | null;
     twitterHandle?: string | null;
     blueskyHandle?: string | null;


### PR DESCRIPTION
## Summary
- Adds edit-person dialog/send components and person interfaces.
- Episode add/edit forms use `guests` (with guest people/suggestions) instead of raw twitter/bluesky handle fields in the form model.
- Companion to RedditPodcastPoster and Api People register PRs. Guests enrichment is intentionally out of scope for a follow-up.

## Companion PRs
- RedditPodcastPoster: https://github.com/cultpodcasts/RedditPodcastPoster/pull/879
- Api: https://github.com/cultpodcasts/Api/pull/112

## Excluded
- `cultpodcasts/.local/`

## Test plan
- [ ] Local site: open episode edit; guests chip/select UI works
- [ ] Create/edit person via edit-person dialog against local API worker
- [ ] Save episode with guests posts `guests` payload
- [ ] Build (`ng build` / `npm run start`) succeeds
