### PR TITLE
Fix: harden bookmarks page for non-curators and incomplete episode data

### DIFF
--- a/cultpodcasts/src/app/bookmarks-api/bookmarks-api.component.html
+++ b/cultpodcasts/src/app/bookmarks-api/bookmarks-api.component.html
@@ -78,7 +78,7 @@
         <mat-card-actions>
             <app-episode-podcast-links [episode]="result"></app-episode-podcast-links>
             <mat-card-footer class="subjects">
-                <app-subjects [subjects]="result.subjects ?? []"></app-subjects>
+                <app-subjects [subjects]="result.subjects"></app-subjects>
             </mat-card-footer>
         </mat-card-actions>
     </mat-card>

--- a/cultpodcasts/src/app/bookmarks-api/bookmarks-api.component.html
+++ b/cultpodcasts/src/app/bookmarks-api/bookmarks-api.component.html
@@ -66,7 +66,9 @@
                 </a>
             </mat-card-subtitle>
             <mat-card-subtitle>{{result.release | date:'d MMM yyyy H:mm'}}
+                @if (result.duration) {
                 [{{result.duration.startsWith("0")?result.duration.split(".")[0].substring(1):result.duration.split(".")[0]}}]
+                }
             </mat-card-subtitle>
         </mat-card-header>
         <mat-card-content class="resultdescription">
@@ -76,7 +78,7 @@
         <mat-card-actions>
             <app-episode-podcast-links [episode]="result"></app-episode-podcast-links>
             <mat-card-footer class="subjects">
-                <app-subjects [subjects]="result.subjects!"></app-subjects>
+                <app-subjects [subjects]="result.subjects ?? []"></app-subjects>
             </mat-card-footer>
         </mat-card-actions>
     </mat-card>

--- a/cultpodcasts/src/app/bookmarks-api/bookmarks-api.component.ts
+++ b/cultpodcasts/src/app/bookmarks-api/bookmarks-api.component.ts
@@ -32,7 +32,7 @@ export enum sortMode {
   addDatedDesc
 }
 
-const take: number = 10;
+const pageSize = 10;
 
 @Component({
   selector: 'app-bookmarks-api',
@@ -107,8 +107,8 @@ export class BookmarksApiComponent {
   }
 
   async batch(first: boolean = false) {
-    const start = this.page * take;
-    const end = start + take;
+    const start = this.page * pageSize;
+    const end = start + pageSize;
     if (start >= this.bookmarks!.size) {
       if (this.bookmarks!.size == 0) {
         this.zeroBookmarks();
@@ -150,7 +150,7 @@ export class BookmarksApiComponent {
             }
             this.isLoading = false;
             this.isSubsequentLoading.set(false);
-            if (first && this.bookmarks!.size > take) {
+            if (first && this.bookmarks!.size > pageSize) {
               this.scrollDisplatcher.scrolled().subscribe(async () => {
                 if (
                   this.bookmarks &&

--- a/cultpodcasts/src/app/bookmarks-api/bookmarks-api.component.ts
+++ b/cultpodcasts/src/app/bookmarks-api/bookmarks-api.component.ts
@@ -1,7 +1,7 @@
 import { Component, signal } from '@angular/core';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { ProfileService } from '../profile.service';
-import { catchError, firstValueFrom, forkJoin, map, Observable, of } from 'rxjs';
+import { catchError, firstValueFrom, forkJoin, map, Observable, of, take } from 'rxjs';
 import { AuthServiceWrapper } from '../auth-service-wrapper.class';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { environment } from './../../environments/environment';
@@ -89,12 +89,20 @@ export class BookmarksApiComponent {
   }
 
   async populatePage() {
-    this.profileService.bookmarks$.subscribe(async bookmarks => {
+    this.error = false;
+    this.isLoading = true;
+    this.episodes.set([]);
+    this.page = 0;
+
+    if (this.bookmarks) {
+      await this.batch(true);
+      return;
+    }
+
+    this.profileService.bookmarks$.pipe(take(1)).subscribe(async bookmarks => {
       console.log("bookmarks", bookmarks);
-      if (!this.bookmarks) {
-        this.bookmarks = bookmarks;
-        this.batch(true);
-      }
+      this.bookmarks = bookmarks;
+      await this.batch(true);
     });
   }
 
@@ -112,13 +120,13 @@ export class BookmarksApiComponent {
     }
     if (this.bookmarks!.size > 0) {
       this.noBookmarks = false;
-      var token = firstValueFrom(this.auth.authService.getAccessTokenSilently({
+      // Bookmarks are available to any signed-in user; do not require curator scope.
+      firstValueFrom(this.auth.authService.getAccessTokenSilently({
         authorizationParams: {
           audience: `https://api.cultpodcasts.com/`,
-          scope: 'curate'
+          scope: ''
         }
-      }));
-      token.then(_token => {
+      })).then(_token => {
         let headers: HttpHeaders = new HttpHeaders();
         headers = headers.set("Authorization", "Bearer " + _token);
         const episodeResponses: Observable<ApiEpisode | null>[] = [];
@@ -129,12 +137,17 @@ export class BookmarksApiComponent {
         const items = orderedBookmarks.slice(start, end);
         items.forEach(episodeId => {
           const episodeEndpoint = new URL(`/public/episode/${episodeId}`, environment.api).toString();
-          const get = this.http.get<ApiEpisode>(episodeEndpoint, { headers: headers }).pipe(this.handleRequest(this).bind(this))
+          const get = this.http.get<ApiEpisode>(episodeEndpoint, { headers: headers }).pipe(this.handleRequest())
           episodeResponses.push(get);
         })
         forkJoin(episodeResponses).subscribe({
           next: episodes => {
-            this.episodes.update(v => v.concat(episodes.filter(x => x != null)));
+            const loaded = episodes.filter((x): x is ApiEpisode => x != null);
+            this.episodes.update(v => v.concat(loaded));
+            // Only treat as a page error when this batch produced nothing.
+            if (loaded.length === 0 && items.length > 0) {
+              this.error = true;
+            }
             this.isLoading = false;
             this.isSubsequentLoading.set(false);
             if (first && this.bookmarks!.size > take) {
@@ -158,6 +171,11 @@ export class BookmarksApiComponent {
             console.error(e);
           }
         })
+      }).catch(e => {
+        this.error = true;
+        this.isLoading = false;
+        this.isSubsequentLoading.set(false);
+        console.error(e);
       });
     } else {
       this.zeroBookmarks();
@@ -171,15 +189,12 @@ export class BookmarksApiComponent {
     this.noBookmarks = true;
   }
 
-  handleRequest(that: any) {
-    return function (observable: Observable<any>) {
+  handleRequest() {
+    return (observable: Observable<ApiEpisode>) => {
       return observable.pipe(
-        map((result) => {
-          return result;
-        }),
+        map((result) => result),
         catchError((err) => {
           console.error(err);
-          that.error = true;
           return of(null);
         })
       );
@@ -218,6 +233,7 @@ export class BookmarksApiComponent {
   }
 
   async reset() {
+    this.error = false;
     this.isLoading = true;
     this.episodes.set([]);
     this.page = 0;

--- a/cultpodcasts/src/app/episode-podcast-links/episode-podcast-links.component.html
+++ b/cultpodcasts/src/app/episode-podcast-links/episode-podcast-links.component.html
@@ -1,5 +1,5 @@
 @if (_episode?.urls?.youtube) {
-<a href="{{_episode.urls.youtube}}" mat-icon-button>
+<a href="{{_episode?.urls?.youtube}}" mat-icon-button>
     <mat-icon svgIcon="youtube"></mat-icon>
 </a>
 } @else if (_episode?.youTubePodcast) {
@@ -9,7 +9,7 @@
 }
 
 @if (_episode?.urls?.spotify) {
-<a href="{{_episode.urls.spotify}}" mat-icon-button>
+<a href="{{_episode?.urls?.spotify}}" mat-icon-button>
     <mat-icon svgIcon="spotify"></mat-icon>
 </a>
 } @else if (_episode?.spotifyPodcast) {
@@ -19,7 +19,7 @@
 }
 
 @if (_episode?.urls?.apple) {
-<a href="{{_episode.urls.apple}}" mat-icon-button>
+<a href="{{_episode?.urls?.apple}}" mat-icon-button>
     <mat-icon><app-apple-podcasts-svg></app-apple-podcasts-svg></mat-icon>
 </a>
 } @else if (_episode?.applePodcast) {
@@ -29,7 +29,7 @@
 }
 
 @if (this.isSounds() || this.isIplayer()) {
-<a href="{{_episode!.urls.bbc}}" mat-icon-button>
+<a href="{{_episode?.urls?.bbc}}" mat-icon-button>
 
     @if (this.isIplayer()) {
     <mat-icon svgIcon="bbc-iplayer"></mat-icon>
@@ -40,7 +40,7 @@
 }
 
 @if (_episode?.urls?.internetArchive) {
-<a href="{{_episode.urls.internetArchive}}" mat-icon-button>
+<a href="{{_episode?.urls?.internetArchive}}" mat-icon-button>
     <mat-icon svgIcon="internet-archive"></mat-icon>
 </a>
 }

--- a/cultpodcasts/src/app/episode-podcast-links/episode-podcast-links.component.html
+++ b/cultpodcasts/src/app/episode-podcast-links/episode-podcast-links.component.html
@@ -1,37 +1,35 @@
-@if (_episode) {
-
-@if (_episode.urls.youtube) {
+@if (_episode?.urls?.youtube) {
 <a href="{{_episode.urls.youtube}}" mat-icon-button>
     <mat-icon svgIcon="youtube"></mat-icon>
 </a>
-} @else if (_episode.youTubePodcast) {
+} @else if (_episode?.youTubePodcast) {
 <button mat-icon-button disabled="true">
     <mat-icon svgIcon="youtube" class="not"></mat-icon>
 </button>
 }
 
-@if (_episode.urls.spotify) {
+@if (_episode?.urls?.spotify) {
 <a href="{{_episode.urls.spotify}}" mat-icon-button>
     <mat-icon svgIcon="spotify"></mat-icon>
 </a>
-} @else if (_episode.spotifyPodcast) {
+} @else if (_episode?.spotifyPodcast) {
 <button mat-icon-button disabled="true">
     <mat-icon svgIcon="spotify" class="not"></mat-icon>
 </button>
 }
 
-@if (_episode.urls.apple) {
+@if (_episode?.urls?.apple) {
 <a href="{{_episode.urls.apple}}" mat-icon-button>
     <mat-icon><app-apple-podcasts-svg></app-apple-podcasts-svg></mat-icon>
 </a>
-} @else if (_episode.applePodcast) {
+} @else if (_episode?.applePodcast) {
 <button mat-icon-button disabled="true">
     <mat-icon><app-apple-podcasts-svg class="not"></app-apple-podcasts-svg></mat-icon>
 </button>
 }
 
 @if (this.isSounds() || this.isIplayer()) {
-<a href="{{_episode.urls.bbc}}" mat-icon-button>
+<a href="{{_episode!.urls.bbc}}" mat-icon-button>
 
     @if (this.isIplayer()) {
     <mat-icon svgIcon="bbc-iplayer"></mat-icon>
@@ -41,9 +39,8 @@
 </a>
 }
 
-@if (_episode.urls.internetArchive) {
+@if (_episode?.urls?.internetArchive) {
 <a href="{{_episode.urls.internetArchive}}" mat-icon-button>
     <mat-icon svgIcon="internet-archive"></mat-icon>
 </a>
-}
 }

--- a/cultpodcasts/src/app/episode-podcast-links/episode-podcast-links.component.ts
+++ b/cultpodcasts/src/app/episode-podcast-links/episode-podcast-links.component.ts
@@ -26,7 +26,7 @@ export class EpisodePodcastLinksComponent {
   protected _episode: ApiEpisode | undefined;
 
   private isBBC(): boolean {
-    return this._episode?.urls.bbc != null &&
+    return this._episode?.urls?.bbc != null &&
       BBCServiceResolver.isBBC(this._episode.urls.bbc);
   }
 

--- a/cultpodcasts/src/app/profile.service.ts
+++ b/cultpodcasts/src/app/profile.service.ts
@@ -46,7 +46,8 @@ export class ProfileService {
         headers = headers.set("Authorization", "Bearer " + token);
         const episodeEndpoint = new URL(`/bookmarks`, environment.api).toString();
         var resp = await firstValueFrom(this.http.get<string[]>(episodeEndpoint, { headers: headers }));
-        return { isUser: true, success: true, episodeIds: resp };
+        const episodeIds = Array.isArray(resp) ? resp : [];
+        return { isUser: true, success: true, episodeIds };
       } catch (error) {
         console.error(error);
         return { isUser: true, success: false, episodeIds: [] };


### PR DESCRIPTION
## Summary
- Allow bookmarks to load with a normal signed-in token instead of requiring curator scope.
- Guard duration, subjects, podcast link URLs, and bookmark API responses so missing fields no longer break the page.
- Improve reload and batch error handling so partial episode failures and auth errors surface correctly without false whole-page failures.

## Test plan
- [ ] Sign in as a non-curator user and open Bookmarks; episodes load without auth errors
- [ ] Sign in as a curator and confirm Bookmarks still loads
- [ ] Reload Bookmarks and confirm list refreshes without stacking duplicate pages
- [ ] Verify episodes with missing duration, subjects, or podcast URLs render without template errors
- [ ] Confirm empty bookmarks shows the empty state; failed token/fetch shows the error state

Made with [Cursor](https://cursor.com)