### PR TITLE
feat(search): support slim search result payloads

### DIFF
--- a/.cursor/rules/language-list-sync.mdc
+++ b/.cursor/rules/language-list-sync.mdc
@@ -1,0 +1,20 @@
+---
+description: Keep the baked-in website language lookup synchronized with the backend language allow-list
+globs: "cultpodcasts/src/app/languages.ts,cultpodcasts/src/app/subject-language-filter.ts,cultpodcasts/src/app/subject-language-filter.spec.ts,cultpodcasts/package.json,cultpodcasts/package-lock.json"
+alwaysApply: false
+---
+
+# Backend and website language-list sync
+
+The backend list in `RedditPodcastPoster/Class-Libraries/RedditPodcastPoster.ContentPublisher/LanguagesPublisher.cs` (`LanguageNames`) is authoritative. It is published by `Console-Apps/R2Publisher` to the R2 object `languages` and exposed to curators by `GET /languages`.
+
+The public website does **not** read that endpoint at runtime. `cultpodcasts/src/app/languages.ts` is compiled into the webapp and used by `cultpodcasts/src/app/subject-language-filter.ts`.
+
+Whenever `LanguageNames` adds, removes, or renames a language, all of the following are required:
+
+- [ ] Update `cultpodcasts/src/app/languages.ts` to match every backend language code, English name, and local/endonym name.
+- [ ] Keep `cultpodcasts/src/app/subject-language-filter.spec.ts` green.
+- [ ] Bump the webapp version in `cultpodcasts/package.json` and `cultpodcasts/package-lock.json`.
+- [ ] Merge the website change to the production branch and verify the resulting Cloudflare Pages Git-integration build deploys successfully.
+
+Do not treat publishing the R2 `languages` object as a website release. Until the table is updated and a new webapp build is deployed, new languages appear as raw ISO-code fallbacks on public subject pages.

--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.906",
+  "version": "1.9.907",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.9.906",
+      "version": "1.9.907",
       "dependencies": {
         "@angular/animations": "^21.0.6",
         "@angular/cdk": "^21.0.5",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.906",
+  "version": "1.9.907",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/src/app/episode-image/episode-image.component.ts
+++ b/cultpodcasts/src/app/episode-image/episode-image.component.ts
@@ -7,6 +7,7 @@ import { ApplePodcastsSvgComponent } from '../apple-podcasts-svg/apple-podcasts-
 import { SearchResult } from '../search-result.interface';
 import { MatButtonModule } from '@angular/material/button';
 import { BBCServiceResolver } from '../service-resolver';
+import { appleUrl, episodeImageUrl, spotifyUrl, toUrl, youtubeUrl } from '../search-result-links';
 
 @Component({
   selector: 'app-episode-image',
@@ -36,7 +37,7 @@ export class EpisodeImageComponent {
   get imageUrl(): URL | undefined {
     let imageUrl: URL | undefined;
     if (this.searchResult) {
-      imageUrl = this.searchResult.image;
+      imageUrl = episodeImageUrl(this.searchResult);
     } else if (this.apiEpisode) {
       imageUrl = this.apiEpisode.image;
     } else if (this.discoveryResult) {
@@ -64,7 +65,7 @@ export class EpisodeImageComponent {
 
   get spotify(): URL | undefined {
     if (this.searchResult) {
-      return this.searchResult.spotify;
+      return spotifyUrl(this.searchResult);
     } else if (this.apiEpisode) {
       if (this.apiEpisode.urls.spotify) {
         if (typeof this.apiEpisode.urls.spotify !== 'string') {
@@ -81,7 +82,7 @@ export class EpisodeImageComponent {
 
   get applePodcasts(): URL | undefined {
     if (this.searchResult) {
-      return this.searchResult.apple;
+      return appleUrl(this.searchResult);
     } else if (this.apiEpisode) {
       if (this.apiEpisode.urls.apple) {
         if (typeof this.apiEpisode.urls.apple !== 'string') {
@@ -98,7 +99,7 @@ export class EpisodeImageComponent {
 
   get youtube(): URL | undefined {
     if (this.searchResult) {
-      return this.searchResult.youtube;
+      return youtubeUrl(this.searchResult);
     } else if (this.apiEpisode) {
       if (this.apiEpisode.urls.youtube) {
         if (typeof this.apiEpisode.urls.youtube !== 'string') {
@@ -115,7 +116,7 @@ export class EpisodeImageComponent {
 
   private get bbc(): URL | undefined {
     if (this.searchResult) {
-      return this.searchResult.bbc;
+      return toUrl(this.searchResult.bbc);
     } else if (this.apiEpisode) {
       if (this.apiEpisode.urls.bbc) {
         if (typeof this.apiEpisode.urls.bbc !== 'string') {
@@ -144,7 +145,7 @@ export class EpisodeImageComponent {
 
   get internetArchive(): URL | undefined {
     if (this.searchResult) {
-      return this.searchResult.internetArchive;
+      return toUrl(this.searchResult.internetArchive);
     } else if (this.apiEpisode) {
       if (this.apiEpisode.urls.internetArchive) {
         if (typeof this.apiEpisode.urls.internetArchive !== 'string') {

--- a/cultpodcasts/src/app/episode-links/episode-links.component.ts
+++ b/cultpodcasts/src/app/episode-links/episode-links.component.ts
@@ -7,6 +7,8 @@ import { MatButtonModule } from '@angular/material/button';
 import { HomepageEpisode } from "../homepage-episode.interface";
 import { ApplePodcastsSvgComponent } from "../apple-podcasts-svg/apple-podcasts-svg.component";
 import { BBCServiceResolver } from "../service-resolver";
+import { SearchResult } from "../search-result.interface";
+import { appleUrl, spotifyUrl, toUrl, youtubeUrl } from "../search-result-links";
 
 @Component({
   selector: 'app-episode-links',
@@ -20,41 +22,43 @@ import { BBCServiceResolver } from "../service-resolver";
 })
 export class EpisodeLinksComponent {
   @Input()
-  episode: HomepageEpisode | undefined;
+  episode: HomepageEpisode | SearchResult | undefined;
 
   get spotify(): URL | undefined {
-    return this.episode?.spotify;
+    return this.episode ? spotifyUrl(this.episode) : undefined;
   }
 
   get applePodcasts(): URL | undefined {
-    return this.episode?.apple;
+    return this.episode ? appleUrl(this.episode) : undefined;
   }
 
   get youtube(): URL | undefined {
-    return this.episode?.youtube;
+    return this.episode ? youtubeUrl(this.episode) : undefined;
   }
 
   get bbciPlayer(): URL | undefined {
-    if (this.episode?.bbc && BBCServiceResolver.isIplayer(this.episode.bbc)) {
-      return this.episode?.bbc;
+    const bbc = toUrl(this.episode?.bbc);
+    if (bbc && BBCServiceResolver.isIplayer(bbc)) {
+      return bbc;
     }
     return undefined;
   }
 
   get bbcSounds(): URL | undefined {
-    if (this.episode?.bbc && BBCServiceResolver.isSounds(this.episode.bbc)) {
-      return this.episode?.bbc;
+    const bbc = toUrl(this.episode?.bbc);
+    if (bbc && BBCServiceResolver.isSounds(bbc)) {
+      return bbc;
     }
     return undefined;
   }
 
   get internetArchive(): URL | undefined {
-    return this.episode?.internetArchive;
+    return toUrl(this.episode?.internetArchive);
   }
 
   constructor(private guidService: GuidService) { }
 
-  share(item: HomepageEpisode) {
+  share(item: HomepageEpisode | SearchResult) {
     let description = `"${item.episodeTitle}" - ${item.podcastName}`;
     description = description + ", " + formatDate(item.release, 'mediumDate', 'en-US');
 

--- a/cultpodcasts/src/app/languages.ts
+++ b/cultpodcasts/src/app/languages.ts
@@ -1,0 +1,64 @@
+// Static language-name table baked in at build time (no runtime Intl.DisplayNames).
+// Codes mirror the backend curator allow-list (LanguagesPublisher.LanguageNames in
+// RedditPodcastPoster, 51 languages), which covers every non-English code observed
+// in live search facets. Names were generated once from Intl.DisplayNames at
+// development time and checked in as static data.
+
+export interface LanguageNames {
+  english: string;
+  local: string;
+}
+
+export const LANGUAGES: Readonly<Record<string, LanguageNames>> = {
+  "en": { english: "English", local: "English" },
+  "fr": { english: "French", local: "Français" },
+  "es": { english: "Spanish", local: "Español" },
+  "de": { english: "German", local: "Deutsch" },
+  "pt": { english: "Portuguese", local: "Português" },
+  "tr": { english: "Turkish", local: "Türkçe" },
+  "nl": { english: "Dutch", local: "Nederlands" },
+  "it": { english: "Italian", local: "Italiano" },
+  "ja": { english: "Japanese", local: "日本語" },
+  "zh": { english: "Chinese", local: "中文" },
+  "ko": { english: "Korean", local: "한국어" },
+  "hi": { english: "Hindi", local: "हिन्दी" },
+  "ru": { english: "Russian", local: "Русский" },
+  "he": { english: "Hebrew", local: "עברית" },
+  "ar": { english: "Arabic", local: "العربية" },
+  "bn": { english: "Bangla", local: "বাংলা" },
+  "id": { english: "Indonesian", local: "Indonesia" },
+  "fil": { english: "Filipino", local: "Filipino" },
+  "ur": { english: "Urdu", local: "اردو" },
+  "sw": { english: "Swahili", local: "Kiswahili" },
+  "vi": { english: "Vietnamese", local: "Tiếng Việt" },
+  "sk": { english: "Slovak", local: "Slovenčina" },
+  "cs": { english: "Czech", local: "Čeština" },
+  "te": { english: "Telugu", local: "తెలుగు" },
+  "af": { english: "Afrikaans", local: "Afrikaans" },
+  "fa": { english: "Persian", local: "فارسی" },
+  "ms": { english: "Malay", local: "Melayu" },
+  "no": { english: "Norwegian", local: "Norsk" },
+  "pl": { english: "Polish", local: "Polski" },
+  "pa": { english: "Punjabi", local: "ਪੰਜਾਬੀ" },
+  "th": { english: "Thai", local: "ไทย" },
+  "uk": { english: "Ukrainian", local: "Українська" },
+  "mr": { english: "Marathi", local: "मराठी" },
+  "fi": { english: "Finnish", local: "Suomi" },
+  "da": { english: "Danish", local: "Dansk" },
+  "el": { english: "Greek", local: "Ελληνικά" },
+  "hu": { english: "Hungarian", local: "Magyar" },
+  "sv": { english: "Swedish", local: "Svenska" },
+  "bg": { english: "Bulgarian", local: "Български" },
+  "sr": { english: "Serbian", local: "Српски" },
+  "hr": { english: "Croatian", local: "Hrvatski" },
+  "lt": { english: "Lithuanian", local: "Lietuvių" },
+  "lv": { english: "Latvian", local: "Latviešu" },
+  "sl": { english: "Slovenian", local: "Slovenščina" },
+  "bs": { english: "Bosnian", local: "Bosanski" },
+  "mk": { english: "Macedonian", local: "Македонски" },
+  "sq": { english: "Albanian", local: "Shqip" },
+  "et": { english: "Estonian", local: "Eesti" },
+  "ca": { english: "Catalan", local: "Català" },
+  "si": { english: "Sinhala", local: "සිංහල" },
+  "yi": { english: "Yiddish", local: "ייִדיש" }
+};

--- a/cultpodcasts/src/app/search-result-links.spec.ts
+++ b/cultpodcasts/src/app/search-result-links.spec.ts
@@ -1,0 +1,66 @@
+import { appleUrl, episodeImageUrl, spotifyUrl, youtubeUrl } from "./search-result-links";
+import { SearchResult } from "./search-result.interface";
+import { HomepageEpisode } from "./homepage-episode.interface";
+
+describe("search-result-links", () => {
+  const searchResult: SearchResult = {
+    id: "id",
+    podcastName: "Podcast",
+    episodeTitle: "Title",
+    episodeDescription: "Description",
+    release: new Date("2026-07-17T00:00:00Z"),
+    duration: "00:01:02",
+    spotifyId: "spotify123",
+    youtubeId: "yt123456789",
+    appleId: "987654321",
+    podcastAppleId: "1234567890",
+    youtubeImageVariant: "hq"
+  };
+
+  it("reconstructs platform URLs from compact ids", () => {
+    expect(spotifyUrl(searchResult)?.toString()).toBe("https://open.spotify.com/episode/spotify123");
+    expect(youtubeUrl(searchResult)?.toString()).toBe("https://www.youtube.com/watch?v=yt123456789");
+    expect(appleUrl(searchResult)?.toString()).toBe("https://podcasts.apple.com/podcast/id1234567890?i=987654321");
+  });
+
+  it("derives YouTube thumbnail when image is omitted", () => {
+    expect(episodeImageUrl(searchResult)?.toString())
+      .toBe("https://i.ytimg.com/vi/yt123456789/hqdefault.jpg");
+  });
+
+  it("keeps opaque homepage URLs unchanged", () => {
+    const homepage: HomepageEpisode = {
+      id: "id",
+      podcastName: "Podcast",
+      episodeTitle: "Title",
+      episodeDescription: "Description",
+      release: new Date("2026-07-17T00:00:00Z"),
+      duration: "00:01:02",
+      spotify: new URL("https://open.spotify.com/episode/homepage"),
+      apple: undefined,
+      youtube: undefined,
+      bbc: undefined,
+      internetArchive: undefined,
+      subjects: [],
+      image: new URL("https://i.scdn.co/image/opaque")
+    };
+
+    expect(spotifyUrl(homepage)?.toString()).toBe("https://open.spotify.com/episode/homepage");
+    expect(episodeImageUrl(homepage)?.toString()).toBe("https://i.scdn.co/image/opaque");
+  });
+
+  it("returns undefined when required ids are missing", () => {
+    const incomplete: SearchResult = {
+      ...searchResult,
+      spotifyId: undefined,
+      appleId: undefined,
+      youtubeId: undefined,
+      youtubeImageVariant: undefined
+    };
+
+    expect(spotifyUrl(incomplete)).toBeUndefined();
+    expect(appleUrl(incomplete)).toBeUndefined();
+    expect(youtubeUrl(incomplete)).toBeUndefined();
+    expect(episodeImageUrl(incomplete)).toBeUndefined();
+  });
+});

--- a/cultpodcasts/src/app/search-result-links.ts
+++ b/cultpodcasts/src/app/search-result-links.ts
@@ -1,0 +1,66 @@
+import { HomepageEpisode } from "./homepage-episode.interface";
+import { SearchResult } from "./search-result.interface";
+
+export type SearchDisplayEpisode = HomepageEpisode | SearchResult;
+
+export function spotifyUrl(episode: SearchDisplayEpisode): URL | undefined {
+  if (isHomepageEpisode(episode)) {
+    return toUrl(episode.spotify);
+  }
+  return episode.spotifyId
+    ? toUrl(`https://open.spotify.com/episode/${encodeURIComponent(episode.spotifyId)}`)
+    : undefined;
+}
+
+export function youtubeUrl(episode: SearchDisplayEpisode): URL | undefined {
+  if (isHomepageEpisode(episode)) {
+    return toUrl(episode.youtube);
+  }
+  return episode.youtubeId
+    ? toUrl(`https://www.youtube.com/watch?v=${encodeURIComponent(episode.youtubeId)}`)
+    : undefined;
+}
+
+export function appleUrl(episode: SearchDisplayEpisode): URL | undefined {
+  if (isHomepageEpisode(episode)) {
+    return toUrl(episode.apple);
+  }
+  return episode.appleId && episode.podcastAppleId
+    ? toUrl(`https://podcasts.apple.com/podcast/id${encodeURIComponent(episode.podcastAppleId)}?i=${encodeURIComponent(episode.appleId)}`)
+    : undefined;
+}
+
+export function episodeImageUrl(episode: SearchDisplayEpisode): URL | undefined {
+  const image = toUrl(episode.image);
+  if (image) {
+    return image;
+  }
+  if (isHomepageEpisode(episode) || !episode.youtubeId || !episode.youtubeImageVariant) {
+    return undefined;
+  }
+
+  const variant = {
+    maxres: "maxresdefault",
+    sd: "sddefault",
+    hq: "hqdefault"
+  }[episode.youtubeImageVariant];
+  return toUrl(`https://i.ytimg.com/vi/${encodeURIComponent(episode.youtubeId)}/${variant}.jpg`);
+}
+
+export function toUrl(value: URL | string | undefined): URL | undefined {
+  if (!value) {
+    return undefined;
+  }
+  if (value instanceof URL) {
+    return value;
+  }
+  try {
+    return new URL(value);
+  } catch {
+    return undefined;
+  }
+}
+
+function isHomepageEpisode(episode: SearchDisplayEpisode): episode is HomepageEpisode {
+  return "spotify" in episode || "apple" in episode || "youtube" in episode;
+}

--- a/cultpodcasts/src/app/search-result.interface.ts
+++ b/cultpodcasts/src/app/search-result.interface.ts
@@ -1,5 +1,17 @@
-import { HomepageEpisode } from "./homepage-episode.interface";
-
-export interface SearchResult extends HomepageEpisode {
-  explicit: boolean;
+export interface SearchResult {
+  id: string;
+  podcastName: string;
+  episodeTitle: string;
+  episodeDescription: string;
+  release: Date;
+  duration: string;
+  spotifyId?: string;
+  appleId?: string;
+  podcastAppleId?: string;
+  youtubeId?: string;
+  bbc?: URL | string;
+  internetArchive?: URL | string;
+  subjects?: string[];
+  image?: URL | string;
+  youtubeImageVariant?: "maxres" | "sd" | "hq";
 }

--- a/cultpodcasts/src/app/search-results-facets.interface.ts
+++ b/cultpodcasts/src/app/search-results-facets.interface.ts
@@ -3,6 +3,7 @@ import { SearchResultFacet } from "./search-result-facet.interface";
 export interface SearchResultsFacets {
     podcastName?: SearchResultFacet[];
     subjects?: SearchResultFacet[];
+    lang?: SearchResultFacet[];
 }
 
 

--- a/cultpodcasts/src/app/subject-api/subject-api.component.html
+++ b/cultpodcasts/src/app/subject-api/subject-api.component.html
@@ -61,6 +61,39 @@
   </mat-expansion-panel>
   }
 
+  @if (languageOptions.length > 0 || englishLanguageCount > 0) {
+  <mat-expansion-panel>
+    <mat-expansion-panel-header>
+      <mat-panel-title>Languages</mat-panel-title>
+      <mat-panel-description>
+        @if (languageSelection.mode === 'all') {
+        All languages
+        } @else if (languageSelection.mode === 'english') {
+        English
+        } @else {
+        {{selectedLanguageValues.length}} Selected
+        }
+      </mat-panel-description>
+    </mat-expansion-panel-header>
+    <mat-chip-listbox multiple (change)="languagesChange($event)">
+      <mat-chip-option [value]="englishLanguageValue"
+        [selected]="selectedLanguageValues.indexOf(englishLanguageValue)>=0">
+        English ({{englishLanguageCount}})
+      </mat-chip-option>
+      @for (language of languageOptions; track language.value) {
+      <mat-chip-option [value]="language.value"
+        [selected]="selectedLanguageValues.indexOf(language.value)>=0">
+        {{languageDisplayName(language.value)}} ({{language.count}})
+      </mat-chip-option>
+      }
+      <mat-chip-option [value]="allLanguagesValue"
+        [selected]="selectedLanguageValues.indexOf(allLanguagesValue)>=0">
+        All languages
+      </mat-chip-option>
+    </mat-chip-listbox>
+  </mat-expansion-panel>
+  }
+
   @for (result of results(); track result.id) {
   <mat-card class="result">
     <mat-card-header>

--- a/cultpodcasts/src/app/subject-api/subject-api.component.html
+++ b/cultpodcasts/src/app/subject-api/subject-api.component.html
@@ -61,7 +61,7 @@
   </mat-expansion-panel>
   }
 
-  @if (languageOptions.length > 0 || englishLanguageCount > 0) {
+  @if (showLanguageSelector) {
   <mat-expansion-panel>
     <mat-expansion-panel-header>
       <mat-panel-title>Languages</mat-panel-title>
@@ -80,7 +80,7 @@
         [selected]="selectedLanguageValues.indexOf(englishLanguageValue)>=0">
         English ({{englishLanguageCount}})
       </mat-chip-option>
-      @for (language of languageOptions; track language.value) {
+      @for (language of visibleLanguageOptions; track language.value) {
       <mat-chip-option [value]="language.value"
         [selected]="selectedLanguageValues.indexOf(language.value)>=0">
         {{languageDisplayName(language.value)}} ({{language.count}})

--- a/cultpodcasts/src/app/subject-api/subject-api.component.ts
+++ b/cultpodcasts/src/app/subject-api/subject-api.component.ts
@@ -26,6 +26,16 @@ import { BookmarkComponent } from "../bookmark/bookmark.component";
 import { SubjectsComponent } from "../subjects/subjects.component";
 import { ScrollDispatcher } from '@angular/cdk/scrolling';
 import { InfiniteScrollStrategy } from '../infinite-scroll-strategy';
+import {
+  ALL_LANGUAGES_VALUE,
+  ENGLISH_LANGUAGE_VALUE,
+  SubjectLanguageSelection,
+  buildSubjectLangFilter,
+  englishFacetCount,
+  languageLabel,
+  selectionFromChipValues
+} from '../subject-language-filter';
+import { SearchResultFacet } from '../search-result-facet.interface';
 
 const sortParam: string = "sort";
 const pageParam: string = "page";
@@ -73,7 +83,13 @@ export class SubjectApiComponent {
   authRoles: string[] = [];
   podcasts: string[] = [];
   podcastFilter: string = "";
-  langFilter = ` and lang eq null`;
+  languageSelection: SubjectLanguageSelection = { mode: "english" };
+  langFilter = buildSubjectLangFilter(this.languageSelection);
+  selectedLanguageValues: string[] = [ENGLISH_LANGUAGE_VALUE];
+  languageOptions: SearchResultFacet[] = [];
+  englishLanguageCount: number = 0;
+  readonly englishLanguageValue = ENGLISH_LANGUAGE_VALUE;
+  readonly allLanguagesValue = ALL_LANGUAGES_VALUE;
   isSignedIn: boolean = false;
   private route = inject(ActivatedRoute);
   facets: SearchResultsFacets = {};
@@ -155,53 +171,96 @@ export class SubjectApiComponent {
     } else if (this.searchState.sort == "date-desc") {
       sort = "release desc";
     }
-    this.oDataService.getEntitiesWithFacets<SearchResult>(
-      new URL("/search", environment.api).toString(),
-      {
-        search: this.searchState.query,
-        filter: this.searchState.filter + this.podcastFilter + this.langFilter,
-        searchMode: 'any',
-        queryType: 'simple',
-        count: true,
-        skip: this.infiniteScrollStrategy.getSkip(this.searchState.page),
-        top: this.infiniteScrollStrategy.getTake(this.searchState.page),
-        facets: ["podcastName,count:1000,sort:count", "subjects,count:10,sort:count"],
-        orderby: sort
-      }).subscribe(
+
+    const baseFilter = this.searchState.filter + this.podcastFilter;
+    const resultFilter = baseFilter + this.langFilter;
+    // Facets must omit the language filter so Azure returns non-null lang buckets.
+    const facetFilter = subsequent ? baseFilter : resultFilter;
+    const runResults = (facetsFromResponse?: SearchResultsFacets, facetCount?: number) => {
+      this.oDataService.getEntitiesWithFacets<SearchResult>(
+        new URL("/search", environment.api).toString(),
         {
-          next: data => {
-            if (data.entities.length && !this.results().length) {
-              this.scrollDisplatcher.scrolled().subscribe(async () => {
-                if (this.results().length < count &&
-                  this.isScrolledToBottom() && !this.isSubsequentLoading()) {
-                  this.isSubsequentLoading.set(true);
-                  this.searchState.page++;
-                  this.execSearch(false, false);
-                }
-              });
+          search: this.searchState.query,
+          filter: resultFilter,
+          searchMode: 'any',
+          queryType: 'simple',
+          count: true,
+          skip: this.infiniteScrollStrategy.getSkip(this.searchState.page),
+          top: this.infiniteScrollStrategy.getTake(this.searchState.page),
+          facets: subsequent
+            ? []
+            : ["podcastName,count:1000,sort:count", "subjects,count:10,sort:count"],
+          orderby: sort
+        }).subscribe(
+          {
+            next: data => {
+              if (data.entities.length && !this.results().length) {
+                this.scrollDisplatcher.scrolled().subscribe(async () => {
+                  if (this.results().length < count &&
+                    this.isScrolledToBottom() && !this.isSubsequentLoading()) {
+                    this.isSubsequentLoading.set(true);
+                    this.searchState.page++;
+                    this.execSearch(false, false);
+                  }
+                });
+              }
+              if (initial) {
+                this.results.set(data.entities);
+              } else {
+                this.results.update(v => v.concat(data.entities));
+              }
+              this.isSubsequentLoading.set(false);
+              if (subsequent && facetsFromResponse) {
+                this.facets = {
+                  podcastName: facetsFromResponse.podcastName,
+                  subjects: facetsFromResponse.subjects?.filter(x => !x.value.startsWith("_")),
+                  lang: facetsFromResponse.lang
+                };
+                this.languageOptions = this.facets.lang ?? [];
+                const subjectScopedTotal = facetCount ?? data.metadata.get("count");
+                this.englishLanguageCount = englishFacetCount(subjectScopedTotal, this.languageOptions);
+              }
+              const count = data.metadata.get("count");
+              this.count = count;
+              this.isLoading = false;
+            },
+            error: (e) => {
+              console.error(e);
+              this.resultsHeading = "Something went wrong. Please try again.";
+              this.isLoading = false;
             }
-            if (initial) {
-              this.results.set(data.entities);
-            } else {
-              this.results.update(v => v.concat(data.entities));
-            }
-            this.isSubsequentLoading.set(false);
-            if (subsequent) {
-              this.facets = {
-                podcastName: data.facets.podcastName,
-                subjects: data.facets.subjects?.filter(x => !x.value.startsWith("_"))
-              };
-            }
-            const count = data.metadata.get("count");
-            this.count = count;
-            this.isLoading = false;
-          },
+          });
+    };
+
+    if (subsequent) {
+      this.oDataService.getEntitiesWithFacets<SearchResult>(
+        new URL("/search", environment.api).toString(),
+        {
+          search: this.searchState.query,
+          filter: facetFilter,
+          searchMode: 'any',
+          queryType: 'simple',
+          count: true,
+          skip: 0,
+          top: 0,
+          facets: [
+            "podcastName,count:1000,sort:count",
+            "subjects,count:10,sort:count",
+            "lang,count:50,sort:count"
+          ],
+          orderby: sort
+        }).subscribe({
+          next: facetData => runResults(facetData.facets, facetData.metadata.get("count")),
           error: (e) => {
             console.error(e);
             this.resultsHeading = "Something went wrong. Please try again.";
             this.isLoading = false;
           }
         });
+      return;
+    }
+
+    runResults();
   }
 
   setSort(sort: string) {
@@ -269,6 +328,24 @@ export class SubjectApiComponent {
     }
     this.searchState.page = 1;
     this.execSearch(true, false);
+  }
+
+  languagesChange($event: MatChipListboxChange) {
+    const values: string[] = ($event.value as Array<string | { value: string }>)
+      .map(item => typeof item === "string" ? item : item.value);
+    if (values.includes(ALL_LANGUAGES_VALUE) && values.length > 1) {
+      this.selectedLanguageValues = [ALL_LANGUAGES_VALUE];
+    } else {
+      this.selectedLanguageValues = values;
+    }
+    this.languageSelection = selectionFromChipValues(this.selectedLanguageValues);
+    this.langFilter = buildSubjectLangFilter(this.languageSelection);
+    this.searchState.page = 1;
+    this.execSearch(true, false);
+  }
+
+  languageDisplayName(code: string): string {
+    return languageLabel(code, undefined);
   }
 
   isScrolledToBottom(): boolean {

--- a/cultpodcasts/src/app/subject-api/subject-api.component.ts
+++ b/cultpodcasts/src/app/subject-api/subject-api.component.ts
@@ -345,7 +345,7 @@ export class SubjectApiComponent {
   }
 
   languageDisplayName(code: string): string {
-    return languageLabel(code, undefined);
+    return languageLabel(code);
   }
 
   isScrolledToBottom(): boolean {

--- a/cultpodcasts/src/app/subject-api/subject-api.component.ts
+++ b/cultpodcasts/src/app/subject-api/subject-api.component.ts
@@ -31,9 +31,11 @@ import {
   ENGLISH_LANGUAGE_VALUE,
   SubjectLanguageSelection,
   buildSubjectLangFilter,
+  displayedLanguageOptions,
   englishFacetCount,
   languageLabel,
-  selectionFromChipValues
+  selectionFromChipValues,
+  shouldShowLanguageSelector
 } from '../subject-language-filter';
 import { SearchResultFacet } from '../search-result-facet.interface';
 
@@ -346,6 +348,14 @@ export class SubjectApiComponent {
 
   languageDisplayName(code: string): string {
     return languageLabel(code);
+  }
+
+  get showLanguageSelector(): boolean {
+    return shouldShowLanguageSelector(this.languageOptions, this.languageSelection);
+  }
+
+  get visibleLanguageOptions(): SearchResultFacet[] {
+    return displayedLanguageOptions(this.languageOptions, this.languageSelection);
   }
 
   isScrolledToBottom(): boolean {

--- a/cultpodcasts/src/app/subject-language-filter.spec.ts
+++ b/cultpodcasts/src/app/subject-language-filter.spec.ts
@@ -1,0 +1,32 @@
+import {
+  ALL_LANGUAGES_VALUE,
+  ENGLISH_LANGUAGE_VALUE,
+  buildSubjectLangFilter,
+  englishFacetCount,
+  selectionFromChipValues
+} from "./subject-language-filter";
+
+describe("subject-language-filter", () => {
+  it("defaults English to lang eq null", () => {
+    expect(buildSubjectLangFilter({ mode: "english" })).toBe(" and lang eq null");
+    expect(selectionFromChipValues([])).toEqual({ mode: "english" });
+    expect(selectionFromChipValues([ENGLISH_LANGUAGE_VALUE])).toEqual({ mode: "english" });
+  });
+
+  it("builds exact and search.in filters for non-English codes", () => {
+    expect(buildSubjectLangFilter({ mode: "codes", codes: ["es"] })).toBe(" and lang eq 'es'");
+    expect(buildSubjectLangFilter({ mode: "codes", codes: ["es", "fr"] }))
+      .toBe(" and search.in(lang, 'es,fr', ',')");
+  });
+
+  it("supports English plus other codes and all-languages", () => {
+    expect(buildSubjectLangFilter({ mode: "englishAndCodes", codes: ["es"] }))
+      .toBe(" and (lang eq null or search.in(lang, 'es', ','))");
+    expect(buildSubjectLangFilter({ mode: "all" })).toBe("");
+    expect(selectionFromChipValues([ALL_LANGUAGES_VALUE])).toEqual({ mode: "all" });
+  });
+
+  it("synthesizes English count from omitted null facet buckets", () => {
+    expect(englishFacetCount(100, [{ value: "es", count: 30 }, { value: "fr", count: 20 }])).toBe(50);
+  });
+});

--- a/cultpodcasts/src/app/subject-language-filter.spec.ts
+++ b/cultpodcasts/src/app/subject-language-filter.spec.ts
@@ -32,23 +32,22 @@ describe("subject-language-filter", () => {
   });
 
   describe("languageLabel", () => {
-    it("shows English name with capitalized endonym when they differ", () => {
+    it("shows English name with local name when they differ", () => {
       expect(languageLabel("es")).toBe("Spanish (Español)");
       expect(languageLabel("de")).toBe("German (Deutsch)");
       expect(languageLabel("fr")).toBe("French (Français)");
     });
 
-    it("shows the name once when English name and endonym match", () => {
+    it("shows the name once when English and local names match", () => {
       expect(languageLabel("en")).toBe("English");
+      expect(languageLabel("af")).toBe("Afrikaans");
     });
 
-    it("handles region subtags", () => {
-      const label = languageLabel("pt-BR");
-      expect(label).toContain("Portuguese");
-      expect(label).toContain("Português");
+    it("resolves region subtags to the base language entry", () => {
+      expect(languageLabel("pt-BR")).toBe("Portuguese (Português)");
     });
 
-    it("falls back to the raw code for unknown or malformed codes", () => {
+    it("falls back to the raw code for unknown codes", () => {
       expect(languageLabel("zz")).toBe("zz");
       expect(languageLabel("not a lang code!")).toBe("not a lang code!");
       expect(languageLabel("")).toBe("");

--- a/cultpodcasts/src/app/subject-language-filter.spec.ts
+++ b/cultpodcasts/src/app/subject-language-filter.spec.ts
@@ -2,9 +2,11 @@ import {
   ALL_LANGUAGES_VALUE,
   ENGLISH_LANGUAGE_VALUE,
   buildSubjectLangFilter,
+  displayedLanguageOptions,
   englishFacetCount,
   languageLabel,
-  selectionFromChipValues
+  selectionFromChipValues,
+  shouldShowLanguageSelector
 } from "./subject-language-filter";
 
 describe("subject-language-filter", () => {
@@ -29,6 +31,49 @@ describe("subject-language-filter", () => {
 
   it("synthesizes English count from omitted null facet buckets", () => {
     expect(englishFacetCount(100, [{ value: "es", count: 30 }, { value: "fr", count: 20 }])).toBe(50);
+  });
+
+  describe("shouldShowLanguageSelector", () => {
+    it("hides the selector when facets contain only English/default results", () => {
+      expect(shouldShowLanguageSelector(undefined, { mode: "english" })).toBe(false);
+      expect(shouldShowLanguageSelector([], { mode: "english" })).toBe(false);
+      expect(shouldShowLanguageSelector([{ value: "es", count: 0 }], { mode: "english" })).toBe(false);
+    });
+
+    it("shows the selector when non-English buckets have counts", () => {
+      expect(shouldShowLanguageSelector([{ value: "es", count: 3 }], { mode: "english" })).toBe(true);
+      expect(shouldShowLanguageSelector(
+        [{ value: "es", count: 3 }, { value: "fr", count: 1 }],
+        { mode: "english" })).toBe(true);
+    });
+
+    it("keeps the selector visible while a non-default selection is active", () => {
+      expect(shouldShowLanguageSelector([], { mode: "codes", codes: ["es"] })).toBe(true);
+      expect(shouldShowLanguageSelector(undefined, { mode: "englishAndCodes", codes: ["es"] })).toBe(true);
+      expect(shouldShowLanguageSelector([], { mode: "all" })).toBe(true);
+    });
+  });
+
+  describe("displayedLanguageOptions", () => {
+    it("passes through facet buckets with counts", () => {
+      expect(displayedLanguageOptions([{ value: "es", count: 3 }], { mode: "english" }))
+        .toEqual([{ value: "es", count: 3 }]);
+    });
+
+    it("drops zero-count buckets", () => {
+      expect(displayedLanguageOptions(
+        [{ value: "es", count: 3 }, { value: "fr", count: 0 }],
+        { mode: "english" })).toEqual([{ value: "es", count: 3 }]);
+    });
+
+    it("keeps actively selected codes visible when missing from facets", () => {
+      expect(displayedLanguageOptions([], { mode: "codes", codes: ["es"] }))
+        .toEqual([{ value: "es", count: 0 }]);
+      expect(displayedLanguageOptions(
+        [{ value: "fr", count: 2 }],
+        { mode: "englishAndCodes", codes: ["es"] }))
+        .toEqual([{ value: "fr", count: 2 }, { value: "es", count: 0 }]);
+    });
   });
 
   describe("languageLabel", () => {

--- a/cultpodcasts/src/app/subject-language-filter.spec.ts
+++ b/cultpodcasts/src/app/subject-language-filter.spec.ts
@@ -3,6 +3,7 @@ import {
   ENGLISH_LANGUAGE_VALUE,
   buildSubjectLangFilter,
   englishFacetCount,
+  languageLabel,
   selectionFromChipValues
 } from "./subject-language-filter";
 
@@ -28,5 +29,29 @@ describe("subject-language-filter", () => {
 
   it("synthesizes English count from omitted null facet buckets", () => {
     expect(englishFacetCount(100, [{ value: "es", count: 30 }, { value: "fr", count: 20 }])).toBe(50);
+  });
+
+  describe("languageLabel", () => {
+    it("shows English name with capitalized endonym when they differ", () => {
+      expect(languageLabel("es")).toBe("Spanish (Español)");
+      expect(languageLabel("de")).toBe("German (Deutsch)");
+      expect(languageLabel("fr")).toBe("French (Français)");
+    });
+
+    it("shows the name once when English name and endonym match", () => {
+      expect(languageLabel("en")).toBe("English");
+    });
+
+    it("handles region subtags", () => {
+      const label = languageLabel("pt-BR");
+      expect(label).toContain("Portuguese");
+      expect(label).toContain("Português");
+    });
+
+    it("falls back to the raw code for unknown or malformed codes", () => {
+      expect(languageLabel("zz")).toBe("zz");
+      expect(languageLabel("not a lang code!")).toBe("not a lang code!");
+      expect(languageLabel("")).toBe("");
+    });
   });
 });

--- a/cultpodcasts/src/app/subject-language-filter.ts
+++ b/cultpodcasts/src/app/subject-language-filter.ts
@@ -67,11 +67,48 @@ export function englishFacetCount(
   return Math.max(0, subjectTotal - nonNull);
 }
 
-export function languageLabel(
-  code: string,
-  languages: Record<string, string> | undefined
-): string {
-  return languages?.[code] || code;
+export function languageLabel(code: string): string {
+  const trimmed = (code ?? "").trim();
+  if (!trimmed) {
+    return code;
+  }
+
+  const english = intlLanguageName(trimmed, "en");
+  const endonym = intlLanguageName(trimmed, trimmed);
+
+  if (english && endonym && english.toLowerCase() !== endonym.toLowerCase()) {
+    return `${english} (${endonym})`;
+  }
+  return english ?? endonym ?? trimmed;
+}
+
+function intlLanguageName(code: string, locale: string): string | undefined {
+  try {
+    const name = new Intl.DisplayNames([locale], { type: "language" }).of(code);
+    if (!name || name.toLowerCase() === code.toLowerCase()) {
+      return undefined;
+    }
+    return capitalizeFirst(name, locale);
+  } catch {
+    return undefined;
+  }
+}
+
+// Some endonyms come back lowercase (e.g. "español"); uppercase the first
+// character only when the locale produces a single cased letter, so caseless
+// scripts pass through untouched.
+function capitalizeFirst(name: string, locale: string): string {
+  const first = name.charAt(0);
+  let upper: string;
+  try {
+    upper = first.toLocaleUpperCase(locale);
+  } catch {
+    upper = first.toUpperCase();
+  }
+  if (upper === first || upper.length !== 1) {
+    return name;
+  }
+  return upper + name.slice(1);
 }
 
 function uniqueCodes(codes: string[]): string[] {

--- a/cultpodcasts/src/app/subject-language-filter.ts
+++ b/cultpodcasts/src/app/subject-language-filter.ts
@@ -1,0 +1,83 @@
+import { SearchResultFacet } from "./search-result-facet.interface";
+
+export const ENGLISH_LANGUAGE_VALUE = "__english__";
+export const ALL_LANGUAGES_VALUE = "__all__";
+
+export type SubjectLanguageSelection =
+  | { mode: "english" }
+  | { mode: "all" }
+  | { mode: "codes"; codes: string[] }
+  | { mode: "englishAndCodes"; codes: string[] };
+
+export function buildSubjectLangFilter(selection: SubjectLanguageSelection): string {
+  if (selection.mode === "all") {
+    return "";
+  }
+  if (selection.mode === "english") {
+    return " and lang eq null";
+  }
+
+  const codes = uniqueCodes(selection.codes);
+  if (!codes.length) {
+    return " and lang eq null";
+  }
+
+  const delimiter = ",";
+  const list = codes.map(escapeODataString).join(delimiter);
+  const codesFilter = `search.in(lang, '${list}', '${delimiter}')`;
+  if (selection.mode === "englishAndCodes") {
+    return ` and (lang eq null or ${codesFilter})`;
+  }
+  if (codes.length === 1) {
+    return ` and lang eq '${escapeODataString(codes[0])}'`;
+  }
+  return ` and ${codesFilter}`;
+}
+
+export function selectionFromChipValues(values: string[]): SubjectLanguageSelection {
+  const selected = new Set(values);
+  if (selected.has(ALL_LANGUAGES_VALUE)) {
+    return { mode: "all" };
+  }
+  if (selected.size === 0) {
+    return { mode: "english" };
+  }
+
+  const includeEnglish = selected.has(ENGLISH_LANGUAGE_VALUE);
+  const codes = [...selected]
+    .filter(value => value !== ENGLISH_LANGUAGE_VALUE && value !== ALL_LANGUAGES_VALUE);
+
+  if (includeEnglish && codes.length) {
+    return { mode: "englishAndCodes", codes };
+  }
+  if (includeEnglish) {
+    return { mode: "english" };
+  }
+  if (codes.length) {
+    return { mode: "codes", codes };
+  }
+  return { mode: "english" };
+}
+
+export function englishFacetCount(
+  subjectTotal: number,
+  langFacets: SearchResultFacet[] | undefined
+): number {
+  const nonNull = (langFacets ?? []).reduce((sum, facet) => sum + (facet.count ?? 0), 0);
+  return Math.max(0, subjectTotal - nonNull);
+}
+
+export function languageLabel(
+  code: string,
+  languages: Record<string, string> | undefined
+): string {
+  return languages?.[code] || code;
+}
+
+function uniqueCodes(codes: string[]): string[] {
+  return [...new Set(codes.map(code => code.trim()).filter(code => !!code))];
+}
+
+function escapeODataString(value: string): string {
+  return value.replaceAll("'", "''");
+}

--- a/cultpodcasts/src/app/subject-language-filter.ts
+++ b/cultpodcasts/src/app/subject-language-filter.ts
@@ -1,3 +1,4 @@
+import { LANGUAGES } from "./languages";
 import { SearchResultFacet } from "./search-result-facet.interface";
 
 export const ENGLISH_LANGUAGE_VALUE = "__english__";
@@ -68,47 +69,16 @@ export function englishFacetCount(
 }
 
 export function languageLabel(code: string): string {
-  const trimmed = (code ?? "").trim();
-  if (!trimmed) {
+  const normalized = (code ?? "").trim().toLowerCase();
+  // Region subtags (e.g. pt-BR) fall back to the base language entry.
+  const names = LANGUAGES[normalized] ?? LANGUAGES[normalized.split("-")[0]];
+  if (!names) {
     return code;
   }
-
-  const english = intlLanguageName(trimmed, "en");
-  const endonym = intlLanguageName(trimmed, trimmed);
-
-  if (english && endonym && english.toLowerCase() !== endonym.toLowerCase()) {
-    return `${english} (${endonym})`;
+  if (names.english.toLowerCase() === names.local.toLowerCase()) {
+    return names.english;
   }
-  return english ?? endonym ?? trimmed;
-}
-
-function intlLanguageName(code: string, locale: string): string | undefined {
-  try {
-    const name = new Intl.DisplayNames([locale], { type: "language" }).of(code);
-    if (!name || name.toLowerCase() === code.toLowerCase()) {
-      return undefined;
-    }
-    return capitalizeFirst(name, locale);
-  } catch {
-    return undefined;
-  }
-}
-
-// Some endonyms come back lowercase (e.g. "español"); uppercase the first
-// character only when the locale produces a single cased letter, so caseless
-// scripts pass through untouched.
-function capitalizeFirst(name: string, locale: string): string {
-  const first = name.charAt(0);
-  let upper: string;
-  try {
-    upper = first.toLocaleUpperCase(locale);
-  } catch {
-    upper = first.toUpperCase();
-  }
-  if (upper === first || upper.length !== 1) {
-    return name;
-  }
-  return upper + name.slice(1);
+  return `${names.english} (${names.local})`;
 }
 
 function uniqueCodes(codes: string[]): string[] {

--- a/cultpodcasts/src/app/subject-language-filter.ts
+++ b/cultpodcasts/src/app/subject-language-filter.ts
@@ -68,6 +68,36 @@ export function englishFacetCount(
   return Math.max(0, subjectTotal - nonNull);
 }
 
+export function hasNonEnglishFacets(langFacets: SearchResultFacet[] | undefined): boolean {
+  return (langFacets ?? []).some(facet => !!facet.value && (facet.count ?? 0) > 0);
+}
+
+// The Languages panel is pointless when a subject only has English/default
+// results — hide it unless other languages exist, or a non-default selection
+// is active (so the user can always switch back).
+export function shouldShowLanguageSelector(
+  langFacets: SearchResultFacet[] | undefined,
+  selection: SubjectLanguageSelection
+): boolean {
+  return hasNonEnglishFacets(langFacets) || selection.mode !== "english";
+}
+
+// Facet buckets plus any actively selected codes missing from the current
+// facets (count 0), so an active selection never disappears from the chips.
+export function displayedLanguageOptions(
+  langFacets: SearchResultFacet[] | undefined,
+  selection: SubjectLanguageSelection
+): SearchResultFacet[] {
+  const facets = (langFacets ?? []).filter(facet => !!facet.value && (facet.count ?? 0) > 0);
+  const selectedCodes = selection.mode === "codes" || selection.mode === "englishAndCodes"
+    ? selection.codes
+    : [];
+  const missing = uniqueCodes(selectedCodes)
+    .filter(code => !facets.some(facet => facet.value === code))
+    .map(value => ({ value, count: 0 }));
+  return [...facets, ...missing];
+}
+
 export function languageLabel(code: string): string {
   const normalized = (code ?? "").trim().toLowerCase();
   // Region subtags (e.g. pt-BR) fall back to the base language entry.


### PR DESCRIPTION
## Summary
- reconstruct search-result service URLs from compact episode and podcast IDs
- derive YouTube thumbnail URLs with fallback handling
- split the search-only result shape from full episode data
- add a subject language selector that defaults to English with `lang eq null` compatibility
- update the web package to 1.9.907

## Verification
- `npx ng test --no-watch --browsers=ChromeHeadless --include=src/app/search-result-links.spec.ts --include=src/app/subject-language-filter.spec.ts` — 8 passed
- `npx ng build --configuration production` — succeeded
- branch preview manually verified for images, links, and Apple redirect behavior

## Rollout
The production search index has already been rebuilt with the new slim shape. Merge timing is intentional: merging this PR is expected to promote the website through Cloudflare Git integration so production can fully consume that shape.