### PR TITLE
Fix: add Romanian to subject language facet labels

### DIFF
--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.907",
+  "version": "1.9.908",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.9.907",
+      "version": "1.9.908",
       "dependencies": {
         "@angular/animations": "^21.0.6",
         "@angular/cdk": "^21.0.5",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.907",
+  "version": "1.9.908",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/src/app/languages.ts
+++ b/cultpodcasts/src/app/languages.ts
@@ -1,8 +1,7 @@
 // Static language-name table baked in at build time (no runtime Intl.DisplayNames).
-// Codes mirror the backend curator allow-list (LanguagesPublisher.LanguageNames in
-// RedditPodcastPoster, 51 languages), which covers every non-English code observed
-// in live search facets. Names were generated once from Intl.DisplayNames at
-// development time and checked in as static data.
+// Codes mirror the published R2 curator languages object (GET /languages), which
+// is produced by LanguagesPublisher in RedditPodcastPoster. Names were generated
+// once from Intl.DisplayNames at development time and checked in as static data.
 
 export interface LanguageNames {
   english: string;
@@ -22,6 +21,7 @@ export const LANGUAGES: Readonly<Record<string, LanguageNames>> = {
   "zh": { english: "Chinese", local: "中文" },
   "ko": { english: "Korean", local: "한국어" },
   "hi": { english: "Hindi", local: "हिन्दी" },
+  "ro": { english: "Romanian", local: "Română" },
   "ru": { english: "Russian", local: "Русский" },
   "he": { english: "Hebrew", local: "עברית" },
   "ar": { english: "Arabic", local: "العربية" },

--- a/cultpodcasts/src/app/subject-language-filter.spec.ts
+++ b/cultpodcasts/src/app/subject-language-filter.spec.ts
@@ -81,6 +81,7 @@ describe("subject-language-filter", () => {
       expect(languageLabel("es")).toBe("Spanish (Español)");
       expect(languageLabel("de")).toBe("German (Deutsch)");
       expect(languageLabel("fr")).toBe("French (Français)");
+      expect(languageLabel("ro")).toBe("Romanian (Română)");
     });
 
     it("shows the name once when English and local names match", () => {


### PR DESCRIPTION
## Summary
- Add missing `ro` → Romanian (Română) to the baked-in `languages.ts` lookup used by subject-page language facets.
- Cover `languageLabel("ro")` in unit tests and bump webapp to `1.9.908`.
- Audited remote R2 `languages` (52 codes) against the frontend table: **only `ro` was missing**; no other publisher gaps.

## Notes
- Live R2 `/languages` includes `"ro":"Romanian"` (matches Edit Episode dialog).
- Current `LanguagesPublisher.LanguageNames` source array on RPP `main` does **not** list `"Romanian"` even though remote R2 has it — separate source/R2 drift to reconcile later; no RPP change in this PR.

## Test plan
- [x] `ng test --include=**/subject-language-filter.spec.ts` — 14/14 SUCCESS
- [ ] After CF Pages deploy: subject page with a Romanian episode shows "Romanian (Română) (1)" instead of "ro (1)"

Made with [Cursor](https://cursor.com)