### PR TITLE
Fix: Manual Tweet snackbar button height and markup cleanup

### DIFF
--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.908",
+  "version": "1.9.909",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.9.908",
+      "version": "1.9.909",
       "dependencies": {
         "@angular/animations": "^21.0.6",
         "@angular/cdk": "^21.0.5",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.908",
+  "version": "1.9.909",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/src/app/episode-publish-response-snackbar/episode-publish-response-snackbar.component.html
+++ b/cultpodcasts/src/app/episode-publish-response-snackbar/episode-publish-response-snackbar.component.html
@@ -3,25 +3,17 @@
 
     <div matSnackBarActions>
         @if (showManualTweet){
-        <button class="action" mat-button matsnackbaraction
+        <button matButton matSnackBarAction
             class="mat-mdc-snack-bar-action mdc-snackbar__action mdc-button mat-mdc-button mat-unthemed mat-mdc-button-base"
-            mat-ripple-loader-class-name="mat-mdc-button-ripple" (click)="manualTweet()">
-            <span class="mat-mdc-button-persistent-ripple mdc-button__ripple"></span>
-            <span class="mdc-button__label"> Manual Tweet </span>
-            <span class="mat-mdc-focus-indicator"></span>
-            <span class="mat-mdc-button-touch-target"></span>
-            <span class="mat-ripple mat-mdc-button-ripple"></span>
+            (click)="manualTweet()">
+            Manual Tweet
         </button>
         }
 
-        <button class="action" mat-button matsnackbaraction
+        <button matButton matSnackBarAction
             class="mat-mdc-snack-bar-action mdc-snackbar__action mdc-button mat-mdc-button mat-unthemed mat-mdc-button-base"
-            mat-ripple-loader-class-name="mat-mdc-button-ripple" (click)="action()">
-            <span class="mat-mdc-button-persistent-ripple mdc-button__ripple"></span>
-            <span class="mdc-button__label"> Ok </span>
-            <span class="mat-mdc-focus-indicator"></span>
-            <span class="mat-mdc-button-touch-target"></span>
-            <span class="mat-ripple mat-mdc-button-ripple"></span>
+            (click)="action()">
+            Ok
         </button>
     </div>
 </div>

--- a/cultpodcasts/src/app/episode-publish-response-snackbar/episode-publish-response-snackbar.component.sass
+++ b/cultpodcasts/src/app/episode-publish-response-snackbar/episode-publish-response-snackbar.component.sass
@@ -8,8 +8,6 @@
       align-items: center
       box-sizing: border-box
       margin-left: auto
-  button
-    height: var(--mat-text-button-container-height)
 
 .mdc-snackbar__label
   padding: 0


### PR DESCRIPTION
## Summary
- Removed a mistyped CSS custom property (--mat-text-button-container-height) from the snackbar sass that was overriding the button height; buttons now use Material's default 40px height.
- Simplified the Manual Tweet / Ok button HTML by removing duplicated Material internal ripple/focus-indicator markup, relying on the matButton directive to render it.
- Bumped app version to 1.9.909 (package.json / package-lock.json).

## Test plan
- [ ] Trigger an episode publish action that shows the snackbar with both Manual Tweet and Ok buttons; confirm both buttons render at the standard Material button height (no longer stretched/mis-sized).
- [ ] Confirm Manual Tweet button click still opens the manual tweet flow.
- [ ] Confirm Ok button click still dismisses the snackbar as before.
- [ ] Visually check snackbar in both light and dark themes.

Made with [Cursor](https://cursor.com)