### PR TITLE
Fix: soften search description truncation with word-boundary ellipsis

### DIFF
--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.909",
+  "version": "1.9.910",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/src/app/podcast-api/podcast-api.component.html
+++ b/cultpodcasts/src/app/podcast-api/podcast-api.component.html
@@ -92,7 +92,7 @@
     </mat-card-header>
     <mat-card-content class="resultdescription">
       <app-episode-image [searchResult]="result" [linksOverlay]="true"></app-episode-image>
-      <p>{{result.episodeDescription}}</p>
+      <p>{{result.episodeDescription | searchDescription}}</p>
     </mat-card-content>
     <mat-card-actions>
       <app-episode-links [episode]="result"></app-episode-links>

--- a/cultpodcasts/src/app/podcast-api/podcast-api.component.ts
+++ b/cultpodcasts/src/app/podcast-api/podcast-api.component.ts
@@ -38,6 +38,7 @@ import { InfiniteScrollStrategy } from '../infinite-scroll-strategy';
 import { EditEpisodeDialogResponse } from '../edit-episode-dialog-response.interface';
 import { RenamePodcastDialogResponse } from "../rename-podcast-dialog-response.interface";
 import { SearchIndexerState } from '../search-indexer-state.interface';
+import { SearchDescriptionPipe } from '../search-description.pipe';
 
 const sortParam: string = "sort";
 const pageParam: string = "page";
@@ -61,7 +62,8 @@ const sortParamDateDesc: string = "date-desc";
     EpisodeImageComponent,
     EpisodeLinksComponent,
     BookmarkComponent,
-    SubjectsComponent
+    SubjectsComponent,
+    SearchDescriptionPipe
   ],
   templateUrl: './podcast-api.component.html',
   styleUrl: './podcast-api.component.sass'

--- a/cultpodcasts/src/app/podcast-episode/podcast-episode.component.html
+++ b/cultpodcasts/src/app/podcast-episode/podcast-episode.component.html
@@ -31,7 +31,7 @@
     </mat-card-header>
     <mat-card-content class="resultdescription">
       <app-episode-image [searchResult]="episode" [linksOverlay]="true"></app-episode-image>
-      <p>{{episode.episodeDescription}}</p>
+      <p>{{episode.episodeDescription | searchDescription}}</p>
     </mat-card-content>
     <mat-card-actions>
       <app-episode-links [episode]="episode"></app-episode-links>

--- a/cultpodcasts/src/app/podcast-episode/podcast-episode.component.ts
+++ b/cultpodcasts/src/app/podcast-episode/podcast-episode.component.ts
@@ -20,6 +20,7 @@ import { SubjectsComponent } from "../subjects/subjects.component";
 import { EditEpisodeDialogResponse } from '../edit-episode-dialog-response.interface';
 import { PostEpisodeDialogResponse } from '../post-episode-dialog-response.interface';
 import { EpisodePublishResponseSnackbarComponent } from '../episode-publish-response-snackbar/episode-publish-response-snackbar.component';
+import { SearchDescriptionPipe } from '../search-description.pipe';
 
 @Component({
   selector: 'app-podcast-episode',
@@ -33,7 +34,8 @@ import { EpisodePublishResponseSnackbarComponent } from '../episode-publish-resp
     EpisodeImageComponent,
     EpisodeLinksComponent,
     BookmarkComponent,
-    SubjectsComponent
+    SubjectsComponent,
+    SearchDescriptionPipe
   ],
   templateUrl: './podcast-episode.component.html',
   styleUrl: './podcast-episode.component.sass'

--- a/cultpodcasts/src/app/search-api/search-api.component.html
+++ b/cultpodcasts/src/app/search-api/search-api.component.html
@@ -87,7 +87,7 @@
     </mat-card-header>
     <mat-card-content class="resultdescription">
       <app-episode-image [searchResult]="result" [linksOverlay]="true"></app-episode-image>
-      <p>{{result.episodeDescription}}</p>
+      <p>{{result.episodeDescription | searchDescription}}</p>
     </mat-card-content>
     <mat-card-actions>
       <app-episode-links [episode]="result"></app-episode-links>

--- a/cultpodcasts/src/app/search-api/search-api.component.ts
+++ b/cultpodcasts/src/app/search-api/search-api.component.ts
@@ -23,6 +23,7 @@ import { AuthServiceWrapper } from '../auth-service-wrapper.class';
 import { SubjectsComponent } from "../subjects/subjects.component";
 import { ScrollDispatcher } from '@angular/cdk/scrolling';
 import { InfiniteScrollStrategy } from '../infinite-scroll-strategy';
+import { SearchDescriptionPipe } from '../search-description.pipe';
 
 const sortParam: string = "sort";
 const pageParam: string = "page";
@@ -48,7 +49,8 @@ const sortParamDateDesc: string = "date-desc";
     EpisodeImageComponent,
     EpisodeLinksComponent,
     BookmarkComponent,
-    SubjectsComponent
+    SubjectsComponent,
+    SearchDescriptionPipe
   ],
   templateUrl: './search-api.component.html',
   styleUrl: './search-api.component.sass'

--- a/cultpodcasts/src/app/search-description.pipe.ts
+++ b/cultpodcasts/src/app/search-description.pipe.ts
@@ -1,0 +1,12 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { formatSearchDescription } from './search-description';
+
+@Pipe({
+  name: 'searchDescription',
+  standalone: true
+})
+export class SearchDescriptionPipe implements PipeTransform {
+  transform(value: string | null | undefined): string {
+    return formatSearchDescription(value);
+  }
+}

--- a/cultpodcasts/src/app/search-description.spec.ts
+++ b/cultpodcasts/src/app/search-description.spec.ts
@@ -1,0 +1,31 @@
+import { formatSearchDescription, SEARCH_DESCRIPTION_SIZE } from './search-description';
+
+describe('formatSearchDescription', () => {
+  it('returns empty for nullish values', () => {
+    expect(formatSearchDescription(null)).toBe('');
+    expect(formatSearchDescription(undefined)).toBe('');
+  });
+
+  it('leaves short descriptions unchanged', () => {
+    expect(formatSearchDescription('A short description.')).toBe('A short description.');
+  });
+
+  it('normalizes three ASCII periods to a Unicode ellipsis', () => {
+    expect(formatSearchDescription('Already truncated at a word...')).toBe(
+      'Already truncated at a word\u2026'
+    );
+  });
+
+  it('leaves descriptions that already end with a Unicode ellipsis unchanged', () => {
+    const text = 'Already truncated at a word\u2026';
+    expect(formatSearchDescription(text)).toBe(text);
+  });
+
+  it('trims a mid-word hard truncate at the search size and adds a Unicode ellipsis', () => {
+    const prefix = 'x'.repeat(SEARCH_DESCRIPTION_SIZE - 9);
+    const hardTruncated = `${prefix} Salt Lak`;
+    expect(hardTruncated.length).toBe(SEARCH_DESCRIPTION_SIZE);
+
+    expect(formatSearchDescription(hardTruncated)).toBe(`${prefix} Salt\u2026`);
+  });
+});

--- a/cultpodcasts/src/app/search-description.ts
+++ b/cultpodcasts/src/app/search-description.ts
@@ -1,0 +1,36 @@
+/** Matches RedditPodcastPoster.Search.Constants.DescriptionSize */
+export const SEARCH_DESCRIPTION_SIZE = 230;
+
+/** Unicode ellipsis (U+2026) — not three ASCII periods. */
+const ELLIPSIS = '\u2026';
+
+/**
+ * Softens server-truncated search descriptions for card display:
+ * when the text hits the search-index length cap mid-word (no ellipsis),
+ * trim back to the last word boundary and append an ellipsis.
+ */
+export function formatSearchDescription(description: string | null | undefined): string {
+  if (!description) {
+    return '';
+  }
+
+  let text = description.trimEnd();
+  if (text.endsWith('...')) {
+    text = `${text.slice(0, -3)}${ELLIPSIS}`;
+  }
+  if (text.endsWith(ELLIPSIS)) {
+    return text;
+  }
+
+  // Hard-truncated search documents are exactly DescriptionSize with no ellipsis.
+  if (text.length < SEARCH_DESCRIPTION_SIZE) {
+    return text;
+  }
+
+  const withoutPartialWord = text.replace(/\s+\S*$/, '').trimEnd();
+  if (withoutPartialWord.length === 0 || withoutPartialWord.length < text.length / 2) {
+    return `${text}${ELLIPSIS}`;
+  }
+
+  return `${withoutPartialWord}${ELLIPSIS}`;
+}

--- a/cultpodcasts/src/app/subject-api/subject-api.component.html
+++ b/cultpodcasts/src/app/subject-api/subject-api.component.html
@@ -111,7 +111,7 @@
     </mat-card-header>
     <mat-card-content class="resultdescription">
       <app-episode-image [searchResult]="result" [linksOverlay]="true"></app-episode-image>
-      <p>{{result.episodeDescription}}</p>
+      <p>{{result.episodeDescription | searchDescription}}</p>
     </mat-card-content>
     <mat-card-actions>
       <app-episode-links [episode]="result"></app-episode-links>

--- a/cultpodcasts/src/app/subject-api/subject-api.component.ts
+++ b/cultpodcasts/src/app/subject-api/subject-api.component.ts
@@ -38,6 +38,7 @@ import {
   shouldShowLanguageSelector
 } from '../subject-language-filter';
 import { SearchResultFacet } from '../search-result-facet.interface';
+import { SearchDescriptionPipe } from '../search-description.pipe';
 
 const sortParam: string = "sort";
 const pageParam: string = "page";
@@ -61,7 +62,8 @@ const sortParamDateDesc: string = "date-desc";
     EpisodeImageComponent,
     EpisodeLinksComponent,
     BookmarkComponent,
-    SubjectsComponent
+    SubjectsComponent,
+    SearchDescriptionPipe
   ],
   templateUrl: './subject-api.component.html',
   styleUrl: './subject-api.component.sass'


### PR DESCRIPTION
## Summary
- Add a `searchDescription` pipe that softens hard-cut 230-char search descriptions by trimming to the last word boundary and appending a Unicode ellipsis (…).
- Normalize trailing ASCII `...` to … so search cards render a consistent ellipsis.
- Wire the pipe into search, podcast, subject, and podcast-episode result templates, with unit specs for the formatter.

## Test plan
- [ ] Run `cultpodcasts` unit specs covering `formatSearchDescription` (nullish, short text, `...` → …, existing …, mid-word hard truncate).
- [ ] Search results: descriptions that hit the 230-char index cap end on a word boundary with … (not a mid-word cut).
- [ ] Podcast and subject list pages show the same description treatment.
- [ ] Podcast episode page description matches search-card formatting.
- [ ] Descriptions shorter than 230 chars are unchanged; those already ending in … are left as-is.

Made with [Cursor](https://cursor.com)