### PR TITLE
People/subjects UI: submit-url toast, review/outgoing inline edits

### DIFF
--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.910",
+  "version": "1.9.911",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/src/app/bookmarks-api/bookmarks-api.component.html
+++ b/cultpodcasts/src/app/bookmarks-api/bookmarks-api.component.html
@@ -11,6 +11,13 @@
         </p>
     </ng-container>
     }
+    @if (!isLoading && removedEpisodesNotice) {
+    <ng-container>
+        <p id="removed-episodes-notice">
+            {{ removedEpisodesMessage }}
+        </p>
+    </ng-container>
+    }
     <section id="resultsheading">
         <h2>Bookmarks</h2>
         @if (!isLoading && !error) {

--- a/cultpodcasts/src/app/bookmarks-api/bookmarks-api.component.sass
+++ b/cultpodcasts/src/app/bookmarks-api/bookmarks-api.component.sass
@@ -44,7 +44,7 @@ mat-card-header
     mat-card-header
         .mdc-icon-button
             right: 0
-#error
+#error,#removed-episodes-notice
     margin-left: 12px
 app-episode-podcast-links
     display: inherit

--- a/cultpodcasts/src/app/bookmarks-api/bookmarks-api.component.ts
+++ b/cultpodcasts/src/app/bookmarks-api/bookmarks-api.component.ts
@@ -3,7 +3,7 @@ import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { ProfileService } from '../profile.service';
 import { catchError, firstValueFrom, forkJoin, map, Observable, of, take } from 'rxjs';
 import { AuthServiceWrapper } from '../auth-service-wrapper.class';
-import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { HttpClient, HttpErrorResponse, HttpHeaders } from '@angular/common/http';
 import { environment } from './../../environments/environment';
 import { ApiEpisode } from '../api-episode.interface';
 import { DatePipe } from '@angular/common';
@@ -34,6 +34,15 @@ export enum sortMode {
 
 const pageSize = 10;
 
+const removedEpisodesMessage =
+  'Cultpodcasts.com has removed episodes it finds unsuitable.';
+
+interface BookmarkEpisodeLoadResult {
+  episode: ApiEpisode | null;
+  notFound: boolean;
+  failed: boolean;
+}
+
 @Component({
   selector: 'app-bookmarks-api',
   imports: [
@@ -58,6 +67,8 @@ export class BookmarksApiComponent {
   protected isLoading: boolean = true;
   protected isSubsequentLoading = signal<boolean>(false);
   protected error: boolean = false;
+  protected removedEpisodesNotice: boolean = false;
+  protected readonly removedEpisodesMessage = removedEpisodesMessage;
   protected sortMode = sortMode;
   protected authRoles: string[] = [];
   protected isSignedIn: boolean = false;
@@ -90,6 +101,7 @@ export class BookmarksApiComponent {
 
   async populatePage() {
     this.error = false;
+    this.removedEpisodesNotice = false;
     this.isLoading = true;
     this.episodes.set([]);
     this.page = 0;
@@ -129,7 +141,7 @@ export class BookmarksApiComponent {
       })).then(_token => {
         let headers: HttpHeaders = new HttpHeaders();
         headers = headers.set("Authorization", "Bearer " + _token);
-        const episodeResponses: Observable<ApiEpisode | null>[] = [];
+        const episodeResponses: Observable<BookmarkEpisodeLoadResult>[] = [];
         let orderedBookmarks = Array.from(this.bookmarks!);
         if (this.sortDirection == sortMode.addDatedDesc) {
           orderedBookmarks = orderedBookmarks.reverse();
@@ -142,10 +154,19 @@ export class BookmarksApiComponent {
         })
         forkJoin(episodeResponses).subscribe({
           next: episodes => {
-            const loaded = episodes.filter((x): x is ApiEpisode => x != null);
+            const loaded = episodes
+              .filter((x): x is BookmarkEpisodeLoadResult & { episode: ApiEpisode } => x.episode != null)
+              .map(x => x.episode);
+            const hasRemoved = episodes.some(x => x.notFound);
+            const hasFailure = episodes.some(x => x.failed);
+
+            if (hasRemoved) {
+              this.removedEpisodesNotice = true;
+            }
             this.episodes.update(v => v.concat(loaded));
-            // Only treat as a page error when this batch produced nothing.
-            if (loaded.length === 0 && items.length > 0) {
+            if (hasFailure) {
+              this.error = true;
+            } else if (loaded.length === 0 && items.length > 0 && !hasRemoved) {
               this.error = true;
             }
             this.isLoading = false;
@@ -192,10 +213,17 @@ export class BookmarksApiComponent {
   handleRequest() {
     return (observable: Observable<ApiEpisode>) => {
       return observable.pipe(
-        map((result) => result),
-        catchError((err) => {
+        map((result): BookmarkEpisodeLoadResult => ({
+          episode: result,
+          notFound: false,
+          failed: false
+        })),
+        catchError((err: HttpErrorResponse): Observable<BookmarkEpisodeLoadResult> => {
+          if (err.status === 404) {
+            return of({ episode: null, notFound: true, failed: false });
+          }
           console.error(err);
-          return of(null);
+          return of({ episode: null, notFound: false, failed: true });
         })
       );
     };
@@ -234,6 +262,7 @@ export class BookmarksApiComponent {
 
   async reset() {
     this.error = false;
+    this.removedEpisodesNotice = false;
     this.isLoading = true;
     this.episodes.set([]);
     this.page = 0;

--- a/cultpodcasts/src/app/episode-guests/episode-guests.component.html
+++ b/cultpodcasts/src/app/episode-guests/episode-guests.component.html
@@ -1,0 +1,20 @@
+@if ((guestPeople?.length ?? 0) > 0) {
+<div class="guest-group">
+    <mat-icon aria-hidden="true" class="group-icon">people</mat-icon>
+    @for (person of guestPeople; track person.id) {
+    <div class="guest">
+        <span>{{personLabel(person)}}</span>
+    </div>
+    }
+</div>
+}
+@if ((guestSuggestions?.length ?? 0) > 0) {
+<div class="guest-group guest-group-suggested">
+    <mat-icon aria-hidden="true" class="group-icon">person_search</mat-icon>
+    @for (suggestion of guestSuggestions; track suggestion.person.id) {
+    <div class="guest guest-suggested">
+        <span>{{suggestionLabel(suggestion)}}</span>
+    </div>
+    }
+</div>
+}

--- a/cultpodcasts/src/app/episode-guests/episode-guests.component.html
+++ b/cultpodcasts/src/app/episode-guests/episode-guests.component.html
@@ -4,6 +4,12 @@
     @for (person of guestPeople; track person.id) {
     <div class="guest">
         <span>{{personLabel(person)}}</span>
+        @if (editable) {
+        <button mat-icon-button type="button" class="remove-btn" [disabled]="disabled"
+            (click)="onRemoveGuest(person.name, $event)" [attr.aria-label]="'Remove guest ' + person.name">
+            <mat-icon>close</mat-icon>
+        </button>
+        }
     </div>
     }
 </div>
@@ -14,6 +20,12 @@
     @for (suggestion of guestSuggestions; track suggestion.person.id) {
     <div class="guest guest-suggested">
         <span>{{suggestionLabel(suggestion)}}</span>
+        @if (editable) {
+        <button mat-button type="button" class="add-btn" [disabled]="disabled"
+            (click)="onAddSuggestedGuest(suggestion.person.name, $event)">
+            Add
+        </button>
+        }
     </div>
     }
 </div>

--- a/cultpodcasts/src/app/episode-guests/episode-guests.component.sass
+++ b/cultpodcasts/src/app/episode-guests/episode-guests.component.sass
@@ -19,10 +19,26 @@
         color: var(--mat-theme-text-secondary)
 
     .guest
+        display: inline-flex
+        align-items: center
+        gap: 0
         span
             color: var(--mat-theme-text-secondary)
             text-decoration: dashed underline 1px
             text-underline-offset: 5px
+        .remove-btn
+            width: 28px
+            height: 28px
+            line-height: 28px
+            mat-icon
+                font-size: 16px
+                width: 16px
+                height: 16px
+        .add-btn
+            min-width: unset
+            padding: 0 8px
+            line-height: 28px
+            height: 28px
 
 .guest-group-suggested
     opacity: 0.85

--- a/cultpodcasts/src/app/episode-guests/episode-guests.component.sass
+++ b/cultpodcasts/src/app/episode-guests/episode-guests.component.sass
@@ -1,0 +1,31 @@
+:host
+    text-align: right
+    padding-right: 2px
+    margin-left: auto
+    display: block
+
+.guest-group
+    display: flex
+    flex-wrap: wrap
+    align-items: center
+    justify-content: flex-end
+    gap: 0 8px
+    padding-bottom: 6px
+
+    .group-icon
+        width: 18px
+        height: 18px
+        font-size: 18px
+        color: var(--mat-theme-text-secondary)
+
+    .guest
+        span
+            color: var(--mat-theme-text-secondary)
+            text-decoration: dashed underline 1px
+            text-underline-offset: 5px
+
+.guest-group-suggested
+    opacity: 0.85
+
+    .guest-suggested span
+        font-style: italic

--- a/cultpodcasts/src/app/episode-guests/episode-guests.component.ts
+++ b/cultpodcasts/src/app/episode-guests/episode-guests.component.ts
@@ -1,0 +1,32 @@
+import { Component, Input } from '@angular/core';
+import { MatIconModule } from '@angular/material/icon';
+import { Person } from '../person.interface';
+import { PersonMatch } from '../person-match.interface';
+
+@Component({
+  selector: 'app-episode-guests',
+  imports: [
+    MatIconModule
+  ],
+  templateUrl: './episode-guests.component.html',
+  styleUrl: './episode-guests.component.sass'
+})
+export class EpisodeGuestsComponent {
+  @Input()
+  guestPeople: Person[] | undefined;
+
+  @Input()
+  guestSuggestions: PersonMatch[] | undefined;
+
+  personLabel(person: Person): string {
+    const handles = [person.twitterHandle, person.blueskyHandle].filter(x => !!x).join(' ');
+    return handles ? `${person.name} (${handles})` : person.name;
+  }
+
+  suggestionLabel(suggestion: PersonMatch): string {
+    const term = suggestion.matchResults[0]?.term;
+    return term
+      ? `${this.personLabel(suggestion.person)} (${term})`
+      : this.personLabel(suggestion.person);
+  }
+}

--- a/cultpodcasts/src/app/episode-guests/episode-guests.component.ts
+++ b/cultpodcasts/src/app/episode-guests/episode-guests.component.ts
@@ -1,12 +1,14 @@
-import { Component, Input } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
 import { Person } from '../person.interface';
 import { PersonMatch } from '../person-match.interface';
 
 @Component({
   selector: 'app-episode-guests',
   imports: [
-    MatIconModule
+    MatIconModule,
+    MatButtonModule
   ],
   templateUrl: './episode-guests.component.html',
   styleUrl: './episode-guests.component.sass'
@@ -18,6 +20,18 @@ export class EpisodeGuestsComponent {
   @Input()
   guestSuggestions: PersonMatch[] | undefined;
 
+  @Input()
+  editable: boolean = false;
+
+  @Input()
+  disabled: boolean = false;
+
+  @Output()
+  removeGuest = new EventEmitter<string>();
+
+  @Output()
+  addSuggestedGuest = new EventEmitter<string>();
+
   personLabel(person: Person): string {
     const handles = [person.twitterHandle, person.blueskyHandle].filter(x => !!x).join(' ');
     return handles ? `${person.name} (${handles})` : person.name;
@@ -28,5 +42,17 @@ export class EpisodeGuestsComponent {
     return term
       ? `${this.personLabel(suggestion.person)} (${term})`
       : this.personLabel(suggestion.person);
+  }
+
+  onRemoveGuest(guestName: string, $event: Event) {
+    $event.preventDefault();
+    $event.stopPropagation();
+    this.removeGuest.emit(guestName);
+  }
+
+  onAddSuggestedGuest(guestName: string, $event: Event) {
+    $event.preventDefault();
+    $event.stopPropagation();
+    this.addSuggestedGuest.emit(guestName);
   }
 }

--- a/cultpodcasts/src/app/episode-status/episode-status.component.html
+++ b/cultpodcasts/src/app/episode-status/episode-status.component.html
@@ -3,11 +3,24 @@
     <mat-icon svgIcon="reddit" [class.not]="!_episode.posted"></mat-icon>
     <mat-icon svgIcon="twitter" [class.not]="!_episode.tweeted"></mat-icon>
     <mat-icon svgIcon="bluesky" [class.not]="!_episode.bluesky"></mat-icon>
+    @if (editable) {
+    <button mat-icon-button type="button" class="flag-toggle" [disabled]="disabled"
+        (click)="onToggleIgnored($event)" [attr.aria-pressed]="_episode.ignored"
+        [attr.aria-label]="_episode.ignored ? 'Clear ignored' : 'Mark ignored'">
+        <mat-icon svgIcon="visible" [class.not]="!_episode.ignored" title="ignored"></mat-icon>
+    </button>
+    <button mat-icon-button type="button" class="flag-toggle" [disabled]="disabled"
+        (click)="onToggleRemoved($event)" [attr.aria-pressed]="_episode.removed"
+        [attr.aria-label]="_episode.removed ? 'Clear removed' : 'Mark removed'">
+        <mat-icon svgIcon="removed" [class.not]="!_episode.removed" title="removed"></mat-icon>
+    </button>
+    } @else {
     @if (_episode.ignored) {
     <mat-icon svgIcon="visible" title="ignored"></mat-icon>
     }
     @if (_episode.removed) {
     <mat-icon svgIcon="removed" title="removed"></mat-icon>
+    }
     }
 </p>
 }

--- a/cultpodcasts/src/app/episode-status/episode-status.component.sass
+++ b/cultpodcasts/src/app/episode-status/episode-status.component.sass
@@ -5,3 +5,11 @@
         margin-right: 20px
     mat-icon.not
         filter: opacity(0.5)
+    .flag-toggle
+        width: 30px
+        height: 30px
+        line-height: 30px
+        margin-right: 20px
+        padding: 0
+        mat-icon
+            margin-right: 0

--- a/cultpodcasts/src/app/episode-status/episode-status.component.ts
+++ b/cultpodcasts/src/app/episode-status/episode-status.component.ts
@@ -1,19 +1,46 @@
-import { Component, Input } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { ApiEpisode } from '../api-episode.interface';
 import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
 
 @Component({
   selector: 'app-episode-status',
   imports: [
-    MatIconModule
+    MatIconModule,
+    MatButtonModule
   ],
   templateUrl: './episode-status.component.html',
   styleUrl: './episode-status.component.sass'
 })
 export class EpisodeStatusComponent {
   protected _episode: ApiEpisode | undefined;
+
+  @Input()
+  editable: boolean = false;
+
+  @Input()
+  disabled: boolean = false;
+
+  @Output()
+  toggleIgnored = new EventEmitter<void>();
+
+  @Output()
+  toggleRemoved = new EventEmitter<void>();
+
   @Input({ required: true })
   set episode(e: ApiEpisode) {
     this._episode = e;
+  }
+
+  onToggleIgnored($event: Event) {
+    $event.preventDefault();
+    $event.stopPropagation();
+    this.toggleIgnored.emit();
+  }
+
+  onToggleRemoved($event: Event) {
+    $event.preventDefault();
+    $event.stopPropagation();
+    this.toggleRemoved.emit();
   }
 }

--- a/cultpodcasts/src/app/episode-update.service.ts
+++ b/cultpodcasts/src/app/episode-update.service.ts
@@ -1,0 +1,100 @@
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+import { environment } from '../environments/environment';
+import { AuthServiceWrapper } from './auth-service-wrapper.class';
+import { ApiEpisode } from './api-episode.interface';
+import { EpisodePost } from './episode-post.interface';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class EpisodeUpdateService {
+  constructor(
+    private auth: AuthServiceWrapper,
+    private http: HttpClient
+  ) { }
+
+  async updateEpisode(podcastId: string, episodeId: string, changes: EpisodePost): Promise<void> {
+    const headers = await this.getAuthHeaders();
+    const episodeEndpoint = new URL(`/episode/${podcastId}/${episodeId}`, environment.api).toString();
+    await firstValueFrom(this.http.post(episodeEndpoint, changes, { headers: headers }));
+  }
+
+  async fetchEpisode(episodeId: string): Promise<ApiEpisode> {
+    const headers = await this.getAuthHeaders();
+    const episodeEndpoint = new URL(`/episode/${episodeId}`, environment.api).toString();
+    const episode = await firstValueFrom(this.http.get<ApiEpisode>(episodeEndpoint, { headers: headers }));
+    return this.normalizeEpisode(episode);
+  }
+
+  async applyAndRefresh(episode: ApiEpisode, changes: EpisodePost): Promise<ApiEpisode> {
+    const podcastId = episode.podcastId;
+    if (!podcastId) {
+      throw new Error('Episode podcastId is required for updates.');
+    }
+    await this.updateEpisode(podcastId, episode.id, changes);
+    return this.fetchEpisode(episode.id);
+  }
+
+  async removeSubject(episode: ApiEpisode, subject: string): Promise<ApiEpisode> {
+    const subjects = (episode.subjects ?? []).filter(x => x !== subject);
+    return this.applyAndRefresh(episode, { subjects });
+  }
+
+  async removeGuest(episode: ApiEpisode, guestName: string): Promise<ApiEpisode> {
+    const guests = this.getGuestNames(episode).filter(x => x !== guestName);
+    return this.applyAndRefresh(episode, { guests });
+  }
+
+  async addGuest(episode: ApiEpisode, guestName: string): Promise<ApiEpisode> {
+    const guests = this.getGuestNames(episode);
+    if (guests.includes(guestName)) {
+      return episode;
+    }
+    return this.applyAndRefresh(episode, { guests: [...guests, guestName] });
+  }
+
+  async toggleIgnored(episode: ApiEpisode): Promise<ApiEpisode> {
+    return this.applyAndRefresh(episode, { ignored: !episode.ignored });
+  }
+
+  async toggleRemoved(episode: ApiEpisode): Promise<ApiEpisode> {
+    return this.applyAndRefresh(episode, { removed: !episode.removed });
+  }
+
+  getGuestNames(episode: ApiEpisode): string[] {
+    if (episode.guests?.length) {
+      return [...episode.guests];
+    }
+    return episode.guestPeople?.map(x => x.name) ?? [];
+  }
+
+  replaceEpisode(episodes: ApiEpisode[] | undefined, updated: ApiEpisode): ApiEpisode[] | undefined {
+    if (!episodes) {
+      return episodes;
+    }
+    const index = episodes.findIndex(x => x.id === updated.id);
+    if (index < 0) {
+      return episodes;
+    }
+    return episodes.map((episode, i) => i === index ? updated : episode);
+  }
+
+  private async getAuthHeaders(): Promise<HttpHeaders> {
+    const token = await firstValueFrom(this.auth.authService.getAccessTokenSilently({
+      authorizationParams: {
+        audience: `https://api.cultpodcasts.com/`,
+        scope: 'curate'
+      }
+    }));
+    return new HttpHeaders().set('Authorization', 'Bearer ' + token);
+  }
+
+  private normalizeEpisode(episode: ApiEpisode): ApiEpisode {
+    return {
+      ...episode,
+      release: new Date(episode.release)
+    };
+  }
+}

--- a/cultpodcasts/src/app/episodes-api/episodes-api.component.html
+++ b/cultpodcasts/src/app/episodes-api/episodes-api.component.html
@@ -85,6 +85,12 @@
             <mat-card-footer class="subjects">
                 <app-subjects [subjects]="result.subjects!" [showHidden]="true"></app-subjects>
             </mat-card-footer>
+            @if ((result.guestPeople?.length ?? 0) > 0 || (result.guestSuggestions?.length ?? 0) > 0) {
+            <mat-card-footer class="guests">
+                <app-episode-guests [guestPeople]="result.guestPeople"
+                    [guestSuggestions]="result.guestSuggestions"></app-episode-guests>
+            </mat-card-footer>
+            }
         </mat-card-actions>
     </mat-card>
     }

--- a/cultpodcasts/src/app/episodes-api/episodes-api.component.html
+++ b/cultpodcasts/src/app/episodes-api/episodes-api.component.html
@@ -78,17 +78,20 @@
         <mat-card-content class="resultdescription">
             <app-episode-image [apiEpisode]="result"></app-episode-image>
             <p>{{result.displayDescription}}</p>
-            <app-episode-status [episode]="result"></app-episode-status>
+            <app-episode-status [episode]="result" [editable]="true" [disabled]="isUpdating(result.id)"
+                (toggleIgnored)="toggleIgnored(result)" (toggleRemoved)="toggleRemoved(result)"></app-episode-status>
         </mat-card-content>
         <mat-card-actions>
             <app-episode-podcast-links [episode]="result"></app-episode-podcast-links>
             <mat-card-footer class="subjects">
-                <app-subjects [subjects]="result.subjects!" [showHidden]="true"></app-subjects>
+                <app-subjects [subjects]="result.subjects!" [showHidden]="true" [editable]="true"
+                    [disabled]="isUpdating(result.id)" (removeSubject)="removeSubject(result, $event)"></app-subjects>
             </mat-card-footer>
             @if ((result.guestPeople?.length ?? 0) > 0 || (result.guestSuggestions?.length ?? 0) > 0) {
             <mat-card-footer class="guests">
-                <app-episode-guests [guestPeople]="result.guestPeople"
-                    [guestSuggestions]="result.guestSuggestions"></app-episode-guests>
+                <app-episode-guests [guestPeople]="result.guestPeople" [guestSuggestions]="result.guestSuggestions"
+                    [editable]="true" [disabled]="isUpdating(result.id)" (removeGuest)="removeGuest(result, $event)"
+                    (addSuggestedGuest)="addSuggestedGuest(result, $event)"></app-episode-guests>
             </mat-card-footer>
             }
         </mat-card-actions>

--- a/cultpodcasts/src/app/episodes-api/episodes-api.component.ts
+++ b/cultpodcasts/src/app/episodes-api/episodes-api.component.ts
@@ -22,6 +22,7 @@ import { DeleteEpisodeDialogComponent } from '../delete-episode-dialog/delete-ep
 import { EditPodcastDialogComponent } from '../edit-podcast-dialog/edit-podcast-dialog.component';
 import { EpisodeImageComponent } from "../episode-image/episode-image.component";
 import { SubjectsComponent } from "../subjects/subjects.component";
+import { EpisodeGuestsComponent } from "../episode-guests/episode-guests.component";
 import { EditEpisodeDialogResponse } from '../edit-episode-dialog-response.interface';
 import { EpisodePublishResponseSnackbarComponent } from '../episode-publish-response-snackbar/episode-publish-response-snackbar.component';
 import { PostEpisodeDialogResponse } from '../post-episode-dialog-response.interface';
@@ -43,7 +44,8 @@ const sortParamDateDesc: string = "date-desc";
     EpisodeStatusComponent,
     EpisodePodcastLinksComponent,
     EpisodeImageComponent,
-    SubjectsComponent
+    SubjectsComponent,
+    EpisodeGuestsComponent
   ],
   templateUrl: './episodes-api.component.html',
   styleUrl: './episodes-api.component.sass'

--- a/cultpodcasts/src/app/episodes-api/episodes-api.component.ts
+++ b/cultpodcasts/src/app/episodes-api/episodes-api.component.ts
@@ -27,6 +27,7 @@ import { EditEpisodeDialogResponse } from '../edit-episode-dialog-response.inter
 import { EpisodePublishResponseSnackbarComponent } from '../episode-publish-response-snackbar/episode-publish-response-snackbar.component';
 import { PostEpisodeDialogResponse } from '../post-episode-dialog-response.interface';
 import { PodcastIndexComponent } from '../podcast-index/podcast-index.component';
+import { EpisodeUpdateService } from '../episode-update.service';
 
 const sortParamDateAsc: string = "date-asc";
 const sortParamDateDesc: string = "date-desc";
@@ -59,6 +60,7 @@ export class EpisodesApiComponent {
   isLoading: boolean = true;
   sortDirection: string = sortParamDateDesc;
   authRoles: string[] = [];
+  updatingEpisodeId: string | null = null;
 
   constructor(
     private router: Router,
@@ -67,7 +69,8 @@ export class EpisodesApiComponent {
     private route: ActivatedRoute,
     private dialog: MatDialog,
     private snackBar: MatSnackBar,
-    private siteService: SiteService
+    private siteService: SiteService,
+    private episodeUpdate: EpisodeUpdateService
   ) {
     this.auth.roles.subscribe(roles => this.authRoles = roles);
   }
@@ -155,12 +158,62 @@ export class EpisodesApiComponent {
     dialogRef.afterClosed().subscribe(async result => {
       if (result) {
         if (result.updated) {
-          let snackBarRef = this.snackBar.open("Episode updated", "Ok", { duration: 10000 });
+          this.snackBar.open("Episode updated", "Ok", { duration: 10000 });
+          await this.refreshEpisode(episodeId);
         } else if (result.noChange) {
-          let snackBarRef = this.snackBar.open("No change", "Ok", { duration: 3000 });
+          this.snackBar.open("No change", "Ok", { duration: 3000 });
         }
       }
     });
+  }
+
+  isUpdating(episodeId: string): boolean {
+    return this.updatingEpisodeId === episodeId;
+  }
+
+  async refreshEpisode(episodeId: string) {
+    try {
+      const updated = await this.episodeUpdate.fetchEpisode(episodeId);
+      this.episodes = this.episodeUpdate.replaceEpisode(this.episodes, updated);
+    } catch (e) {
+      console.error(e);
+    }
+  }
+
+  private async runEpisodeUpdate(episode: ApiEpisode, action: () => Promise<ApiEpisode>) {
+    if (this.isUpdating(episode.id)) {
+      return;
+    }
+    this.updatingEpisodeId = episode.id;
+    try {
+      const updated = await action();
+      this.episodes = this.episodeUpdate.replaceEpisode(this.episodes, updated);
+    } catch (e) {
+      console.error(e);
+      this.snackBar.open("Failed to update episode", "Ok", { duration: 5000 });
+    } finally {
+      this.updatingEpisodeId = null;
+    }
+  }
+
+  removeSubject(episode: ApiEpisode, subject: string) {
+    this.runEpisodeUpdate(episode, () => this.episodeUpdate.removeSubject(episode, subject));
+  }
+
+  removeGuest(episode: ApiEpisode, guestName: string) {
+    this.runEpisodeUpdate(episode, () => this.episodeUpdate.removeGuest(episode, guestName));
+  }
+
+  addSuggestedGuest(episode: ApiEpisode, guestName: string) {
+    this.runEpisodeUpdate(episode, () => this.episodeUpdate.addGuest(episode, guestName));
+  }
+
+  toggleIgnored(episode: ApiEpisode) {
+    this.runEpisodeUpdate(episode, () => this.episodeUpdate.toggleIgnored(episode));
+  }
+
+  toggleRemoved(episode: ApiEpisode) {
+    this.runEpisodeUpdate(episode, () => this.episodeUpdate.toggleRemoved(episode));
   }
 
   post(podcastId: string, episodeId: string) {

--- a/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.html
+++ b/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.html
@@ -98,13 +98,22 @@
         <mat-card-content class="resultdescription">
             <app-episode-image [apiEpisode]="result"></app-episode-image>
             <p>{{result.displayDescription}}</p>
-            <app-episode-status [episode]="result"></app-episode-status>
+            <app-episode-status [episode]="result" [editable]="true" [disabled]="isUpdating(result.id)"
+                (toggleIgnored)="toggleIgnored(result)" (toggleRemoved)="toggleRemoved(result)"></app-episode-status>
         </mat-card-content>
         <mat-card-actions>
             <app-episode-podcast-links [episode]="result"></app-episode-podcast-links>
             <mat-card-footer class="subjects">
-                <app-subjects [subjects]="result.subjects!" [showHidden]="true"></app-subjects>
+                <app-subjects [subjects]="result.subjects!" [showHidden]="true" [editable]="true"
+                    [disabled]="isUpdating(result.id)" (removeSubject)="removeSubject(result, $event)"></app-subjects>
             </mat-card-footer>
+            @if ((result.guestPeople?.length ?? 0) > 0 || (result.guestSuggestions?.length ?? 0) > 0) {
+            <mat-card-footer class="guests">
+                <app-episode-guests [guestPeople]="result.guestPeople" [guestSuggestions]="result.guestSuggestions"
+                    [editable]="true" [disabled]="isUpdating(result.id)" (removeGuest)="removeGuest(result, $event)"
+                    (addSuggestedGuest)="addSuggestedGuest(result, $event)"></app-episode-guests>
+            </mat-card-footer>
+            }
         </mat-card-actions>
     </mat-card>
     }

--- a/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.ts
+++ b/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.ts
@@ -28,6 +28,8 @@ import { SubjectsComponent } from "../subjects/subjects.component";
 import { EditEpisodeDialogResponse } from '../edit-episode-dialog-response.interface';
 import { EpisodePublishResponseSnackbarComponent } from '../episode-publish-response-snackbar/episode-publish-response-snackbar.component';
 import { PostEpisodeDialogResponse } from '../post-episode-dialog-response.interface';
+import { EpisodeGuestsComponent } from '../episode-guests/episode-guests.component';
+import { EpisodeUpdateService } from '../episode-update.service';
 
 const sortParamDateAsc: string = "date-asc";
 const sortParamDateDesc: string = "date-desc";
@@ -49,7 +51,8 @@ const daysKey: string = "pref.outgoing-episodes.days";
     EpisodeStatusComponent,
     EpisodePodcastLinksComponent,
     EpisodeImageComponent,
-    SubjectsComponent
+    SubjectsComponent,
+    EpisodeGuestsComponent
   ],
   templateUrl: './outgoing-episodes-api.component.html',
   styleUrl: './outgoing-episodes-api.component.sass'
@@ -69,6 +72,7 @@ export class OutgoingEpisodesApiComponent {
   blueskyPosted: boolean | undefined = true;
   token: string = "";
   authRoles: string[] = [];
+  updatingEpisodeId: string | null = null;
 
   constructor(
     protected auth: AuthServiceWrapper,
@@ -76,7 +80,8 @@ export class OutgoingEpisodesApiComponent {
     private route: ActivatedRoute,
     private dialog: MatDialog,
     private snackBar: MatSnackBar,
-    private siteService: SiteService
+    private siteService: SiteService,
+    private episodeUpdate: EpisodeUpdateService
   ) {
     this.auth.roles.subscribe(roles => this.authRoles = roles);
   }
@@ -143,12 +148,62 @@ export class OutgoingEpisodesApiComponent {
     dialogRef.afterClosed().subscribe(async result => {
       if (result) {
         if (result.updated) {
-          let snackBarRef = this.snackBar.open("Episode updated", "Ok", { duration: 10000 });
+          this.snackBar.open("Episode updated", "Ok", { duration: 10000 });
+          await this.refreshEpisode(episodeId);
         } else if (result.noChange) {
-          let snackBarRef = this.snackBar.open("No change", "Ok", { duration: 3000 });
+          this.snackBar.open("No change", "Ok", { duration: 3000 });
         }
       }
     });
+  }
+
+  isUpdating(episodeId: string): boolean {
+    return this.updatingEpisodeId === episodeId;
+  }
+
+  async refreshEpisode(episodeId: string) {
+    try {
+      const updated = await this.episodeUpdate.fetchEpisode(episodeId);
+      this.episodes = this.episodeUpdate.replaceEpisode(this.episodes, updated);
+    } catch (e) {
+      console.error(e);
+    }
+  }
+
+  private async runEpisodeUpdate(episode: ApiEpisode, action: () => Promise<ApiEpisode>) {
+    if (this.isUpdating(episode.id)) {
+      return;
+    }
+    this.updatingEpisodeId = episode.id;
+    try {
+      const updated = await action();
+      this.episodes = this.episodeUpdate.replaceEpisode(this.episodes, updated);
+    } catch (e) {
+      console.error(e);
+      this.snackBar.open("Failed to update episode", "Ok", { duration: 5000 });
+    } finally {
+      this.updatingEpisodeId = null;
+    }
+  }
+
+  removeSubject(episode: ApiEpisode, subject: string) {
+    this.runEpisodeUpdate(episode, () => this.episodeUpdate.removeSubject(episode, subject));
+  }
+
+  removeGuest(episode: ApiEpisode, guestName: string) {
+    this.runEpisodeUpdate(episode, () => this.episodeUpdate.removeGuest(episode, guestName));
+  }
+
+  addSuggestedGuest(episode: ApiEpisode, guestName: string) {
+    this.runEpisodeUpdate(episode, () => this.episodeUpdate.addGuest(episode, guestName));
+  }
+
+  toggleIgnored(episode: ApiEpisode) {
+    this.runEpisodeUpdate(episode, () => this.episodeUpdate.toggleIgnored(episode));
+  }
+
+  toggleRemoved(episode: ApiEpisode) {
+    this.runEpisodeUpdate(episode, () => this.episodeUpdate.toggleRemoved(episode));
   }
 
   post(podcastId: string, episodeId: string) {

--- a/cultpodcasts/src/app/subjects/subjects.component.html
+++ b/cultpodcasts/src/app/subjects/subjects.component.html
@@ -2,6 +2,12 @@
 <div class="subject">
     @if (!subject.startsWith("_") || showHidden) {
     <a [routerLink]="['/subject', subject]" (click)="stopPropagate($event)">{{subject}}</a>
+    @if (editable) {
+    <button mat-icon-button type="button" class="remove-btn" [disabled]="disabled"
+        (click)="onRemove(subject, $event)" [attr.aria-label]="'Remove subject ' + subject">
+        <mat-icon>close</mat-icon>
+    </button>
+    }
     }
 </div>
 }

--- a/cultpodcasts/src/app/subjects/subjects.component.sass
+++ b/cultpodcasts/src/app/subjects/subjects.component.sass
@@ -6,9 +6,20 @@
     .subject
         padding-left: 8px
         padding-bottom: 6px
+        display: inline-flex
+        align-items: center
+        gap: 0
         a
             color: var(--mat-theme-text-secondary)
             text-decoration: dashed underline 1px
             text-underline-offset: 5px
         a:hover 
             text-decoration: none
+        .remove-btn
+            width: 28px
+            height: 28px
+            line-height: 28px
+            mat-icon
+                font-size: 16px
+                width: 16px
+                height: 16px

--- a/cultpodcasts/src/app/subjects/subjects.component.ts
+++ b/cultpodcasts/src/app/subjects/subjects.component.ts
@@ -1,10 +1,14 @@
-import { Component, Input } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { RouterLink } from '@angular/router';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
 
 @Component({
   selector: 'app-subjects',
   imports: [
-    RouterLink
+    RouterLink,
+    MatButtonModule,
+    MatIconModule
   ],
   templateUrl: './subjects.component.html',
   styleUrl: './subjects.component.sass'
@@ -19,9 +23,24 @@ export class SubjectsComponent {
   @Input()
   stopPropagation: boolean = false;
 
+  @Input()
+  editable: boolean = false;
+
+  @Input()
+  disabled: boolean = false;
+
+  @Output()
+  removeSubject = new EventEmitter<string>();
+
   stopPropagate($event: Event) {
     if (this.stopPropagation) {
       $event.stopPropagation();
     }
+  }
+
+  onRemove(subject: string, $event: Event) {
+    $event.preventDefault();
+    $event.stopPropagation();
+    this.removeSubject.emit(subject);
   }
 }

--- a/cultpodcasts/src/app/submit-episode-details.interface.ts
+++ b/cultpodcasts/src/app/submit-episode-details.interface.ts
@@ -1,10 +1,11 @@
-import { PersonMatch } from './person-match.interface';
+import { SubmitGuestSuggestion } from './submit-guest-suggestion.interface';
 
 export interface SubmitEpisodeDetails {
     spotify: boolean;
     apple: boolean;
     youtube: boolean;
     subjects: string[];
-    people?: PersonMatch[];
-    guestSuggestions?: PersonMatch[];
+    /** Display names of guests auto-added during submit (toast only). */
+    people?: string[];
+    guestSuggestions?: SubmitGuestSuggestion[];
 }

--- a/cultpodcasts/src/app/submit-episode-details.interface.ts
+++ b/cultpodcasts/src/app/submit-episode-details.interface.ts
@@ -1,7 +1,7 @@
-
 export interface SubmitEpisodeDetails {
     spotify: boolean;
     apple: boolean;
     youtube: boolean;
     subjects: string[];
+    people?: string[];
 }

--- a/cultpodcasts/src/app/submit-episode-details.interface.ts
+++ b/cultpodcasts/src/app/submit-episode-details.interface.ts
@@ -5,6 +5,6 @@ export interface SubmitEpisodeDetails {
     apple: boolean;
     youtube: boolean;
     subjects: string[];
-    people?: string[];
+    people?: PersonMatch[];
     guestSuggestions?: PersonMatch[];
 }

--- a/cultpodcasts/src/app/submit-episode-details.interface.ts
+++ b/cultpodcasts/src/app/submit-episode-details.interface.ts
@@ -1,7 +1,10 @@
+import { PersonMatch } from './person-match.interface';
+
 export interface SubmitEpisodeDetails {
     spotify: boolean;
     apple: boolean;
     youtube: boolean;
     subjects: string[];
     people?: string[];
+    guestSuggestions?: PersonMatch[];
 }

--- a/cultpodcasts/src/app/submit-guest-suggestion.interface.ts
+++ b/cultpodcasts/src/app/submit-guest-suggestion.interface.ts
@@ -1,0 +1,7 @@
+import { PersonMatchResult } from './person-match.interface';
+
+/** Submit-url guest suggestion — name only; People are unique on name. */
+export interface SubmitGuestSuggestion {
+    name: string;
+    matchResults: PersonMatchResult[];
+}

--- a/cultpodcasts/src/app/submit-url-origin-response-snackbar/submit-url-origin-response-snackbar.component.html
+++ b/cultpodcasts/src/app/submit-url-origin-response-snackbar/submit-url-origin-response-snackbar.component.html
@@ -39,13 +39,13 @@
             }
         </span>
         @if (data.response.episodeDetails.subjects.length > 0) {
-        <span title="Subjects: {{data.response.episodeDetails.subjects.join(', ')}}">
-            {{data.response.episodeDetails.subjects.length}}
-            @if(data.response.episodeDetails.subjects.length>1){
-            subjects
-            } @else {
-            subject
-            }
+        <span class="enrichment-count" title="Subjects: {{data.response.episodeDetails.subjects.join(', ')}}">
+            <mat-icon aria-hidden="true">category</mat-icon>{{data.response.episodeDetails.subjects.length}}
+        </span>
+        }
+        @if ((data.response.episodeDetails.people?.length ?? 0) > 0) {
+        <span class="enrichment-count" title="People: {{data.response.episodeDetails.people!.join(', ')}}">
+            <mat-icon aria-hidden="true">people</mat-icon>{{data.response.episodeDetails.people!.length}}
         </span>
         }
     </span>

--- a/cultpodcasts/src/app/submit-url-origin-response-snackbar/submit-url-origin-response-snackbar.component.html
+++ b/cultpodcasts/src/app/submit-url-origin-response-snackbar/submit-url-origin-response-snackbar.component.html
@@ -44,7 +44,7 @@
         </span>
         }
         @if ((data.response.episodeDetails.people?.length ?? 0) > 0) {
-        <span class="enrichment-count" title="People: {{data.response.episodeDetails.people!.join(', ')}}">
+        <span class="enrichment-count" title="People: {{data.response.episodeDetails.people!.map(p => p.person.name).join(', ')}}">
             <mat-icon aria-hidden="true">people</mat-icon>{{data.response.episodeDetails.people!.length}}
         </span>
         }

--- a/cultpodcasts/src/app/submit-url-origin-response-snackbar/submit-url-origin-response-snackbar.component.html
+++ b/cultpodcasts/src/app/submit-url-origin-response-snackbar/submit-url-origin-response-snackbar.component.html
@@ -44,13 +44,13 @@
         </span>
         }
         @if ((data.response.episodeDetails.people?.length ?? 0) > 0) {
-        <span class="enrichment-count" title="People: {{data.response.episodeDetails.people!.map(p => p.person.name).join(', ')}}">
+        <span class="enrichment-count" title="People: {{data.response.episodeDetails.people!.join(', ')}}">
             <mat-icon aria-hidden="true">people</mat-icon>{{data.response.episodeDetails.people!.length}}
         </span>
         }
         @if ((data.response.episodeDetails.guestSuggestions?.length ?? 0) > 0) {
         <span class="enrichment-count enrichment-count-suggested"
-            title="Suggested people: {{data.response.episodeDetails.guestSuggestions!.map(s => s.person.name).join(', ')}}">
+            title="Suggested people: {{data.response.episodeDetails.guestSuggestions!.map(s => s.name).join(', ')}}">
             <mat-icon aria-hidden="true">person_search</mat-icon>{{data.response.episodeDetails.guestSuggestions!.length}}
         </span>
         }

--- a/cultpodcasts/src/app/submit-url-origin-response-snackbar/submit-url-origin-response-snackbar.component.html
+++ b/cultpodcasts/src/app/submit-url-origin-response-snackbar/submit-url-origin-response-snackbar.component.html
@@ -48,6 +48,12 @@
             <mat-icon aria-hidden="true">people</mat-icon>{{data.response.episodeDetails.people!.length}}
         </span>
         }
+        @if ((data.response.episodeDetails.guestSuggestions?.length ?? 0) > 0) {
+        <span class="enrichment-count enrichment-count-suggested"
+            title="Suggested people: {{data.response.episodeDetails.guestSuggestions!.map(s => s.person.name).join(', ')}}">
+            <mat-icon aria-hidden="true">person_search</mat-icon>{{data.response.episodeDetails.guestSuggestions!.length}}
+        </span>
+        }
     </span>
     }
 </span>

--- a/cultpodcasts/src/app/submit-url-origin-response-snackbar/submit-url-origin-response-snackbar.component.sass
+++ b/cultpodcasts/src/app/submit-url-origin-response-snackbar/submit-url-origin-response-snackbar.component.sass
@@ -9,6 +9,18 @@
             top: -4px
             left: 0px
 
+.enrichment-count
+    display: inline-flex
+    align-items: center
+    margin-left: 8px
+    white-space: nowrap
+    mat-icon
+        width: 18px
+        height: 18px
+        font-size: 18px
+        margin-right: 2px
+        vertical-align: text-bottom
+
 :host
   display: flex
   

--- a/cultpodcasts/src/app/submit-url-origin-response-snackbar/submit-url-origin-response-snackbar.component.sass
+++ b/cultpodcasts/src/app/submit-url-origin-response-snackbar/submit-url-origin-response-snackbar.component.sass
@@ -21,6 +21,9 @@
         margin-right: 2px
         vertical-align: text-bottom
 
+.enrichment-count-suggested
+    opacity: 0.85
+
 :host
   display: flex
   


### PR DESCRIPTION
## Summary
- Submit-url toast shows guest people and suggestions with icons and hover names.
- Review (`/episodes`) and outgoing episode cards support inline AJAX curation:
  - Remove subjects (× on each chip)
  - Remove guests (× on each person)
  - Add suggested guests (Add button, same as Edit Episode dialog)
  - Toggle ignored / removed flags (clickable status icons)
- After each action the card re-fetches via GET `/episode/{id}` so the list reflects new state without a full page reload.

## API endpoints used
- **POST** `/episode/{podcastId}/{episodeId}` — partial episode update (`subjects`, `guests`, `ignored`, `removed`) with Auth0 `curate` scope (same as Edit Episode dialog)
- **GET** `/episode/{episodeId}` — refresh single episode after update

No API or Cloudflare worker changes required.

## UI behavior
- Inline controls appear on review and outgoing cards only (not public episode pages).
- Controls disable while an update is in flight; failures show a snackbar error.
- Edit Episode dialog success also refreshes the card in-place.

## Test plan
- [ ] On `/episodes`, remove a subject and confirm it disappears after refresh
- [ ] Remove a guest and confirm guest list updates
- [ ] Add a suggested guest and confirm it moves to confirmed guests
- [ ] Toggle ignored/removed and confirm status icons update
- [ ] Repeat on outgoing episodes view
- [ ] Confirm submit-url toast still shows people/suggestions correctly