### PR TITLE
fix: subject/guest align, names-only people, ignore/remove loading

### DIFF
--- a/cultpodcasts/AGENTS.md
+++ b/cultpodcasts/AGENTS.md
@@ -35,4 +35,8 @@ Auth0 requires hostname **`local.cultpodcasts.com`** (hosts → `127.0.0.1`). De
 | `npm run start` | `https://local.cultpodcasts.com:8788` (builds with `local` env) |
 | `npm run dev` | `https://local.cultpodcasts.com:4200` |
 
-Build: `ng build`. Mobile/TWA notes: `MOBILE_BUILDS.md`.
+Build: `ng build` (defaults to **production** via `fileReplacements` → `environment.production.ts`). Local Pages: `npm run start` (configuration `local`).
+
+**Production Pages deploy:** `npm run deploy` → `ng build --configuration production` + `process` + `wrangler pages deploy`. From a feature branch you must pass `--branch main` or the upload goes to Preview only. Do **not** deploy a `local`/`npm start` dist — `environment.ts` points at `127.0.0.1`. Mobile uses `env=production ./build.sh` (copies `environment.production.ts`).
+
+Mobile/TWA notes: `MOBILE_BUILDS.md`.

--- a/cultpodcasts/angular.json
+++ b/cultpodcasts/angular.json
@@ -73,7 +73,13 @@
                   "maximumError": "4kb"
                 }
               ],
-              "outputHashing": "all"
+              "outputHashing": "all",
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.production.ts"
+                }
+              ]
             },
             "staging": {
               "budgets": [

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.920",
+  "version": "1.9.921",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.926",
+  "version": "1.9.927",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.918",
+  "version": "1.9.919",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.922",
+  "version": "1.9.923",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.925",
+  "version": "1.9.926",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.911",
+  "version": "1.9.912",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.924",
+  "version": "1.9.925",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.928",
+  "version": "1.9.929",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.919",
+  "version": "1.9.920",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.923",
+  "version": "1.9.924",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.915",
+  "version": "1.9.916",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.916",
+  "version": "1.9.917",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.921",
+  "version": "1.9.922",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.912",
+  "version": "1.9.913",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.927",
+  "version": "1.9.928",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.917",
+  "version": "1.9.918",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,15 +1,17 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.914",
+  "version": "1.9.915",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",
-    "build": "ng build --configuration",
+    "build": "ng build --configuration production",
+    "build:staging": "ng build --configuration staging",
+    "build:local": "ng build --configuration local",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
     "serve:ssr:cultpodcasts": "node dist/server/server.mjs",
     "process": "node ./tools/copy-files.mjs && node ./tools/alter-polyfills.mjs",
-    "deploy": "npm run build && wrangler pages deploy dist/cloudflare",
+    "deploy": "npm run build && npm run process && wrangler pages deploy dist/cloudflare",
     "dev": "ng serve --configuration development"
   },
   "private": true,

--- a/cultpodcasts/src/app/add-episode-dialog/add-episode-dialog.component.html
+++ b/cultpodcasts/src/app/add-episode-dialog/add-episode-dialog.component.html
@@ -25,10 +25,12 @@
             </mat-tab>
             <mat-tab label="Flags">
                 <div class="flags">
+                    @if (featureSwtichService.IsEnabled(FeatureSwitch.redditPost)) {
                     <label>
                         <span>Posted:</span>
                         <mat-checkbox [formControl]="form!.controls.posted" />
                     </label>
+                    }
                     <label>
                         <span>Tweeted:</span>
                         <mat-checkbox [formControl]="form!.controls.tweeted" />

--- a/cultpodcasts/src/app/add-episode-dialog/add-episode-dialog.component.ts
+++ b/cultpodcasts/src/app/add-episode-dialog/add-episode-dialog.component.ts
@@ -29,6 +29,8 @@ import { filterKeepingSelectedInOrder } from '../subject-filter.util';
 import { buildEpisodeLanguageOptions } from '../language-options.util';
 import { EditPersonDialogComponent } from '../edit-person-dialog/edit-person-dialog.component';
 import { comparePeopleBySortKey } from '../person-sort';
+import { FeatureSwitch } from '../feature-switch.enum';
+import { FeatureSwtichService } from '../feature-switch-service';
 
 @Component({
   selector: 'app-add-episode-dialog',
@@ -52,6 +54,7 @@ import { comparePeopleBySortKey } from '../person-sort';
   styleUrl: './add-episode-dialog.component.sass'
 })
 export class AddEpisodeDialogComponent {
+  protected FeatureSwitch = FeatureSwitch;
   readonly hoistedSubjectNames: string[] = subjectNamesConfig.hostedSubjectNames;
   readonly enableDesktopSubjectTypingFilter: boolean = typeof window !== 'undefined'
     && window.matchMedia('(hover: hover) and (pointer: fine)').matches;
@@ -86,6 +89,7 @@ export class AddEpisodeDialogComponent {
     @Inject(MAT_DIALOG_DATA) public data: { podcastId: string, episodeId: string, isNewPodcast: boolean },
     private fb: FormBuilder,
     private dialog: MatDialog,
+    protected featureSwtichService: FeatureSwtichService,
   ) {
     this.podcastId = data.podcastId;
     this.episodeId = data.episodeId;

--- a/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.html
+++ b/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.html
@@ -25,10 +25,12 @@
             </mat-tab>
             <mat-tab label="Flags">
                 <div class="flags">
+                    @if (featureSwtichService.IsEnabled(FeatureSwitch.redditPost)) {
                     <label>
                         <span>Posted:</span>
                         <mat-checkbox [formControl]="form!.controls.posted" />
                     </label>
+                    }
                     <label>
                         <span>Tweeted:</span>
                         <mat-checkbox [formControl]="form!.controls.tweeted" />

--- a/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.ts
+++ b/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.ts
@@ -30,6 +30,8 @@ import { filterKeepingSelectedInOrder } from '../subject-filter.util';
 import { buildEpisodeLanguageOptions } from '../language-options.util';
 import { EditPersonDialogComponent } from '../edit-person-dialog/edit-person-dialog.component';
 import { comparePeopleBySortKey } from '../person-sort';
+import { FeatureSwitch } from '../feature-switch.enum';
+import { FeatureSwtichService } from '../feature-switch-service';
 
 @Component({
   selector: 'app-edit-episode-dialog',
@@ -53,6 +55,7 @@ import { comparePeopleBySortKey } from '../person-sort';
   styleUrl: './edit-episode-dialog.component.sass'
 })
 export class EditEpisodeDialogComponent {
+  protected FeatureSwitch = FeatureSwitch;
   readonly hoistedSubjectNames: string[] = subjectNamesConfig.hostedSubjectNames;
   readonly enableDesktopSubjectTypingFilter: boolean = typeof window !== 'undefined'
     && window.matchMedia('(hover: hover) and (pointer: fine)').matches;
@@ -86,6 +89,7 @@ export class EditEpisodeDialogComponent {
     private dialogRef: MatDialogRef<EditEpisodeDialogComponent, any>,
     @Inject(MAT_DIALOG_DATA) public data: { podcastIdentifier: string, episodeId: string },
     private dialog: MatDialog,
+    protected featureSwtichService: FeatureSwtichService,
   ) {
     this.episodeId = data.episodeId;
     this.podcastIdentifier = data.podcastIdentifier;

--- a/cultpodcasts/src/app/episode-guests/episode-guests.component.html
+++ b/cultpodcasts/src/app/episode-guests/episode-guests.component.html
@@ -18,7 +18,6 @@
 }
 @if ((guestSuggestions?.length ?? 0) > 0) {
 <div class="guest-group guest-group-suggested">
-    <mat-icon aria-hidden="true" class="group-icon">person_search</mat-icon>
     @for (suggestion of guestSuggestions; track suggestion.person.id) {
     <div class="guest guest-suggested" [class.loading]="isGuestLoading(suggestion.person.name)">
         <span>{{suggestionLabel(suggestion)}}</span>

--- a/cultpodcasts/src/app/episode-guests/episode-guests.component.html
+++ b/cultpodcasts/src/app/episode-guests/episode-guests.component.html
@@ -20,15 +20,19 @@
 <div class="guest-group guest-group-suggested">
     <mat-icon aria-hidden="true" class="group-icon">person_search</mat-icon>
     @for (suggestion of guestSuggestions; track suggestion.person.id) {
-    <div class="guest guest-suggested">
+    <div class="guest guest-suggested" [class.loading]="isGuestLoading(suggestion.person.name)">
         <span>{{suggestionLabel(suggestion)}}</span>
         @if (editable) {
-        <button mat-button type="button" class="add-btn"
+        <button mat-icon-button type="button" class="add-btn"
             [disabled]="disabled || isGuestLoading(suggestion.person.name)"
             [attr.aria-busy]="isGuestLoading(suggestion.person.name)"
+            [attr.aria-label]="'Add guest ' + suggestion.person.name"
             (click)="onAddSuggestedGuest(suggestion.person.name, $event)">
-            Add
+            <mat-icon>add</mat-icon>
         </button>
+        }
+        @if (isGuestLoading(suggestion.person.name)) {
+        <mat-spinner diameter="16"></mat-spinner>
         }
     </div>
     }

--- a/cultpodcasts/src/app/episode-guests/episode-guests.component.html
+++ b/cultpodcasts/src/app/episode-guests/episode-guests.component.html
@@ -1,13 +1,16 @@
 @if ((guestPeople?.length ?? 0) > 0) {
 <div class="guest-group">
     @for (person of guestPeople; track person.id) {
-    <div class="guest">
+    <div class="guest" [class.loading]="isGuestLoading(person.name)">
         <span>{{personLabel(person)}}</span>
         @if (editable) {
-        <button mat-icon-button type="button" class="remove-btn" [disabled]="disabled"
+        <button mat-icon-button type="button" class="remove-btn" [disabled]="disabled || isGuestLoading(person.name)"
             (click)="onRemoveGuest(person.name, $event)" [attr.aria-label]="'Remove guest ' + person.name">
             <mat-icon>close</mat-icon>
         </button>
+        }
+        @if (isGuestLoading(person.name)) {
+        <mat-spinner diameter="16"></mat-spinner>
         }
     </div>
     }
@@ -20,7 +23,9 @@
     <div class="guest guest-suggested">
         <span>{{suggestionLabel(suggestion)}}</span>
         @if (editable) {
-        <button mat-button type="button" class="add-btn" [disabled]="disabled"
+        <button mat-button type="button" class="add-btn"
+            [disabled]="disabled || isGuestLoading(suggestion.person.name)"
+            [attr.aria-busy]="isGuestLoading(suggestion.person.name)"
             (click)="onAddSuggestedGuest(suggestion.person.name, $event)">
             Add
         </button>

--- a/cultpodcasts/src/app/episode-guests/episode-guests.component.html
+++ b/cultpodcasts/src/app/episode-guests/episode-guests.component.html
@@ -1,6 +1,5 @@
 @if ((guestPeople?.length ?? 0) > 0) {
 <div class="guest-group">
-    <mat-icon aria-hidden="true" class="group-icon">people</mat-icon>
     @for (person of guestPeople; track person.id) {
     <div class="guest">
         <span>{{personLabel(person)}}</span>

--- a/cultpodcasts/src/app/episode-guests/episode-guests.component.sass
+++ b/cultpodcasts/src/app/episode-guests/episode-guests.component.sass
@@ -1,15 +1,16 @@
 :host
     text-align: right
     padding-right: 2px
-    margin-left: auto
-    display: block
+    display: flex
+    flex-direction: column
+    align-items: stretch
+    width: 100%
+    box-sizing: border-box
 
 .guest-group
     display: flex
-    flex-wrap: wrap
-    align-items: center
-    justify-content: flex-end
-    gap: 0 8px
+    flex-direction: column
+    align-items: stretch
     padding-bottom: 6px
 
     .group-icon
@@ -17,27 +18,42 @@
         height: 18px
         font-size: 18px
         color: var(--mat-theme-text-secondary)
+        align-self: flex-end
+        margin-bottom: 2px
 
     .guest
-        display: inline-flex
+        display: flex
+        flex-direction: row
+        justify-content: flex-end
         align-items: baseline
+        align-self: stretch
+        width: 100%
+        box-sizing: border-box
+        padding-left: 8px
+        padding-bottom: 6px
         gap: 0
         span
             color: var(--mat-theme-text-secondary)
             text-decoration: dashed underline 1px
             text-underline-offset: 5px
+            line-height: 1.25
         .remove-btn
-            --mdc-icon-button-state-layer-size: 22px
+            --mdc-icon-button-state-layer-size: 20px
             --mdc-icon-button-icon-size: 14px
-            width: 22px
-            height: 22px
+            width: 20px
+            height: 20px
+            min-width: 20px
+            min-height: 20px
             padding: 0
-            margin: 0 0 0 1px
+            margin: 0 0 0 2px
             line-height: 1
             vertical-align: baseline
+            flex: 0 0 auto
+            align-self: baseline
             display: inline-flex
             align-items: center
             justify-content: center
+            transform: none !important
             mat-icon
                 font-size: 14px
                 width: 14px

--- a/cultpodcasts/src/app/episode-guests/episode-guests.component.sass
+++ b/cultpodcasts/src/app/episode-guests/episode-guests.component.sass
@@ -65,6 +65,10 @@
             padding: 0 8px
             line-height: 28px
             height: 28px
+        mat-spinner
+            margin: 0 0 0 4px
+            flex: 0 0 auto
+            align-self: center
 
 .guest-group-suggested
     opacity: 0.85

--- a/cultpodcasts/src/app/episode-guests/episode-guests.component.sass
+++ b/cultpodcasts/src/app/episode-guests/episode-guests.component.sass
@@ -14,14 +14,6 @@
     margin-top: 8px
     padding-bottom: 6px
 
-    .group-icon
-        width: 18px
-        height: 18px
-        font-size: 18px
-        color: var(--mat-theme-text-secondary)
-        align-self: flex-end
-        margin-bottom: 2px
-
     .guest
         display: flex
         flex-direction: row

--- a/cultpodcasts/src/app/episode-guests/episode-guests.component.sass
+++ b/cultpodcasts/src/app/episode-guests/episode-guests.component.sass
@@ -38,7 +38,8 @@
             text-decoration: dashed underline 1px
             text-underline-offset: 5px
             line-height: 1.25
-        .remove-btn
+        .remove-btn,
+        .add-btn
             --mdc-icon-button-state-layer-size: 20px
             --mdc-icon-button-icon-size: 14px
             width: 20px
@@ -60,11 +61,6 @@
                 width: 14px
                 height: 14px
                 line-height: 14px
-        .add-btn
-            min-width: unset
-            padding: 0 8px
-            line-height: 28px
-            height: 28px
         mat-spinner
             margin: 0 0 0 4px
             flex: 0 0 auto
@@ -72,6 +68,7 @@
 
 .guest-group-suggested
     opacity: 0.85
+    margin-top: 16px
 
     .guest-suggested span
         font-style: italic

--- a/cultpodcasts/src/app/episode-guests/episode-guests.component.sass
+++ b/cultpodcasts/src/app/episode-guests/episode-guests.component.sass
@@ -11,6 +11,7 @@
     display: flex
     flex-direction: column
     align-items: stretch
+    margin-top: 8px
     padding-bottom: 6px
 
     .group-icon

--- a/cultpodcasts/src/app/episode-guests/episode-guests.component.sass
+++ b/cultpodcasts/src/app/episode-guests/episode-guests.component.sass
@@ -20,20 +20,29 @@
 
     .guest
         display: inline-flex
-        align-items: center
+        align-items: baseline
         gap: 0
         span
             color: var(--mat-theme-text-secondary)
             text-decoration: dashed underline 1px
             text-underline-offset: 5px
         .remove-btn
-            width: 28px
-            height: 28px
-            line-height: 28px
+            --mdc-icon-button-state-layer-size: 22px
+            --mdc-icon-button-icon-size: 14px
+            width: 22px
+            height: 22px
+            padding: 0
+            margin: 0 0 0 1px
+            line-height: 1
+            vertical-align: baseline
+            display: inline-flex
+            align-items: center
+            justify-content: center
             mat-icon
-                font-size: 16px
-                width: 16px
-                height: 16px
+                font-size: 14px
+                width: 14px
+                height: 14px
+                line-height: 14px
         .add-btn
             min-width: unset
             padding: 0 8px

--- a/cultpodcasts/src/app/episode-guests/episode-guests.component.ts
+++ b/cultpodcasts/src/app/episode-guests/episode-guests.component.ts
@@ -1,6 +1,7 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { Person } from '../person.interface';
 import { PersonMatch } from '../person-match.interface';
 
@@ -8,7 +9,8 @@ import { PersonMatch } from '../person-match.interface';
   selector: 'app-episode-guests',
   imports: [
     MatIconModule,
-    MatButtonModule
+    MatButtonModule,
+    MatProgressSpinnerModule
   ],
   templateUrl: './episode-guests.component.html',
   styleUrl: './episode-guests.component.sass'
@@ -26,6 +28,10 @@ export class EpisodeGuestsComponent {
   @Input()
   disabled: boolean = false;
 
+  /** Guest name currently being added (optimistic / in-flight). */
+  @Input()
+  loadingGuestName: string | null = null;
+
   @Output()
   removeGuest = new EventEmitter<string>();
 
@@ -38,6 +44,10 @@ export class EpisodeGuestsComponent {
 
   suggestionLabel(suggestion: PersonMatch): string {
     return suggestion.person.name;
+  }
+
+  isGuestLoading(guestName: string): boolean {
+    return !!this.loadingGuestName && this.loadingGuestName === guestName;
   }
 
   onRemoveGuest(guestName: string, $event: Event) {

--- a/cultpodcasts/src/app/episode-guests/episode-guests.component.ts
+++ b/cultpodcasts/src/app/episode-guests/episode-guests.component.ts
@@ -33,15 +33,11 @@ export class EpisodeGuestsComponent {
   addSuggestedGuest = new EventEmitter<string>();
 
   personLabel(person: Person): string {
-    const handles = [person.twitterHandle, person.blueskyHandle].filter(x => !!x).join(' ');
-    return handles ? `${person.name} (${handles})` : person.name;
+    return person.name;
   }
 
   suggestionLabel(suggestion: PersonMatch): string {
-    const term = suggestion.matchResults[0]?.term;
-    return term
-      ? `${this.personLabel(suggestion.person)} (${term})`
-      : this.personLabel(suggestion.person);
+    return suggestion.person.name;
   }
 
   onRemoveGuest(guestName: string, $event: Event) {

--- a/cultpodcasts/src/app/episode-status/episode-status.component.html
+++ b/cultpodcasts/src/app/episode-status/episode-status.component.html
@@ -1,36 +1,42 @@
 @if (_episode) {
-<p id="status">
+<div id="status">
     @if (editable) {
-    <button mat-icon-button type="button" class="flag-toggle" [class.loading]="loadingIgnored"
-        [disabled]="disabled || loadingIgnored || loadingRemoved" (click)="onToggleIgnored($event)"
-        [attr.aria-pressed]="_episode.ignored"
-        [attr.aria-label]="_episode.ignored ? 'Clear ignored' : 'Mark ignored'"
-        [attr.aria-busy]="loadingIgnored">
-        <mat-icon svgIcon="visible" [class.not]="!_episode.ignored" title="ignored"></mat-icon>
-        @if (loadingIgnored) {
-        <mat-spinner diameter="20"></mat-spinner>
+    <p class="flags">
+        <button mat-icon-button type="button" class="flag-toggle" [class.loading]="loadingIgnored"
+            [disabled]="disabled || loadingIgnored || loadingRemoved" (click)="onToggleIgnored($event)"
+            [attr.aria-pressed]="_episode.ignored"
+            [attr.aria-label]="_episode.ignored ? 'Clear ignored' : 'Mark ignored'"
+            [attr.aria-busy]="loadingIgnored">
+            <mat-icon svgIcon="visible" [class.not]="!_episode.ignored" title="ignored"></mat-icon>
+            @if (loadingIgnored) {
+            <mat-spinner diameter="20"></mat-spinner>
+            }
+        </button>
+        <button mat-icon-button type="button" class="flag-toggle" [class.loading]="loadingRemoved"
+            [disabled]="disabled || loadingIgnored || loadingRemoved" (click)="onToggleRemoved($event)"
+            [attr.aria-pressed]="_episode.removed"
+            [attr.aria-label]="_episode.removed ? 'Clear removed' : 'Mark removed'"
+            [attr.aria-busy]="loadingRemoved">
+            <mat-icon svgIcon="removed" [class.not]="!_episode.removed" title="removed"></mat-icon>
+            @if (loadingRemoved) {
+            <mat-spinner diameter="20"></mat-spinner>
+            }
+        </button>
+    </p>
+    } @else if (_episode.ignored || _episode.removed) {
+    <p class="flags">
+        @if (_episode.ignored) {
+        <mat-icon svgIcon="visible" title="ignored"></mat-icon>
         }
-    </button>
-    <button mat-icon-button type="button" class="flag-toggle" [class.loading]="loadingRemoved"
-        [disabled]="disabled || loadingIgnored || loadingRemoved" (click)="onToggleRemoved($event)"
-        [attr.aria-pressed]="_episode.removed"
-        [attr.aria-label]="_episode.removed ? 'Clear removed' : 'Mark removed'"
-        [attr.aria-busy]="loadingRemoved">
-        <mat-icon svgIcon="removed" [class.not]="!_episode.removed" title="removed"></mat-icon>
-        @if (loadingRemoved) {
-        <mat-spinner diameter="20"></mat-spinner>
+        @if (_episode.removed) {
+        <mat-icon svgIcon="removed" title="removed"></mat-icon>
         }
-    </button>
-    } @else {
-    @if (_episode.ignored) {
-    <mat-icon svgIcon="visible" title="ignored"></mat-icon>
+    </p>
     }
-    @if (_episode.removed) {
-    <mat-icon svgIcon="removed" title="removed"></mat-icon>
-    }
-    }
-    <mat-icon svgIcon="reddit" [class.not]="!_episode.posted"></mat-icon>
-    <mat-icon svgIcon="twitter" [class.not]="!_episode.tweeted"></mat-icon>
-    <mat-icon svgIcon="bluesky" [class.not]="!_episode.bluesky"></mat-icon>
-</p>
+    <p class="social">
+        <mat-icon svgIcon="reddit" [class.not]="!_episode.posted"></mat-icon>
+        <mat-icon svgIcon="twitter" [class.not]="!_episode.tweeted"></mat-icon>
+        <mat-icon svgIcon="bluesky" [class.not]="!_episode.bluesky"></mat-icon>
+    </p>
+</div>
 }

--- a/cultpodcasts/src/app/episode-status/episode-status.component.html
+++ b/cultpodcasts/src/app/episode-status/episode-status.component.html
@@ -1,26 +1,42 @@
 @if (_episode) {
-<p id="status">
-    <mat-icon svgIcon="reddit" [class.not]="!_episode.posted"></mat-icon>
-    <mat-icon svgIcon="twitter" [class.not]="!_episode.tweeted"></mat-icon>
-    <mat-icon svgIcon="bluesky" [class.not]="!_episode.bluesky"></mat-icon>
+<div id="status">
+    <p class="social">
+        <mat-icon svgIcon="reddit" [class.not]="!_episode.posted"></mat-icon>
+        <mat-icon svgIcon="twitter" [class.not]="!_episode.tweeted"></mat-icon>
+        <mat-icon svgIcon="bluesky" [class.not]="!_episode.bluesky"></mat-icon>
+    </p>
     @if (editable) {
-    <button mat-icon-button type="button" class="flag-toggle" [disabled]="disabled"
-        (click)="onToggleIgnored($event)" [attr.aria-pressed]="_episode.ignored"
-        [attr.aria-label]="_episode.ignored ? 'Clear ignored' : 'Mark ignored'">
-        <mat-icon svgIcon="visible" [class.not]="!_episode.ignored" title="ignored"></mat-icon>
-    </button>
-    <button mat-icon-button type="button" class="flag-toggle" [disabled]="disabled"
-        (click)="onToggleRemoved($event)" [attr.aria-pressed]="_episode.removed"
-        [attr.aria-label]="_episode.removed ? 'Clear removed' : 'Mark removed'">
-        <mat-icon svgIcon="removed" [class.not]="!_episode.removed" title="removed"></mat-icon>
-    </button>
-    } @else {
-    @if (_episode.ignored) {
-    <mat-icon svgIcon="visible" title="ignored"></mat-icon>
+    <p class="flags">
+        <button mat-icon-button type="button" class="flag-toggle" [class.loading]="loadingIgnored"
+            [disabled]="disabled || loadingIgnored || loadingRemoved" (click)="onToggleIgnored($event)"
+            [attr.aria-pressed]="_episode.ignored"
+            [attr.aria-label]="_episode.ignored ? 'Clear ignored' : 'Mark ignored'"
+            [attr.aria-busy]="loadingIgnored">
+            <mat-icon svgIcon="visible" [class.not]="!_episode.ignored" title="ignored"></mat-icon>
+            @if (loadingIgnored) {
+            <mat-spinner diameter="20"></mat-spinner>
+            }
+        </button>
+        <button mat-icon-button type="button" class="flag-toggle" [class.loading]="loadingRemoved"
+            [disabled]="disabled || loadingIgnored || loadingRemoved" (click)="onToggleRemoved($event)"
+            [attr.aria-pressed]="_episode.removed"
+            [attr.aria-label]="_episode.removed ? 'Clear removed' : 'Mark removed'"
+            [attr.aria-busy]="loadingRemoved">
+            <mat-icon svgIcon="removed" [class.not]="!_episode.removed" title="removed"></mat-icon>
+            @if (loadingRemoved) {
+            <mat-spinner diameter="20"></mat-spinner>
+            }
+        </button>
+    </p>
+    } @else if (_episode.ignored || _episode.removed) {
+    <p class="flags">
+        @if (_episode.ignored) {
+        <mat-icon svgIcon="visible" title="ignored"></mat-icon>
+        }
+        @if (_episode.removed) {
+        <mat-icon svgIcon="removed" title="removed"></mat-icon>
+        }
+    </p>
     }
-    @if (_episode.removed) {
-    <mat-icon svgIcon="removed" title="removed"></mat-icon>
-    }
-    }
-</p>
+</div>
 }

--- a/cultpodcasts/src/app/episode-status/episode-status.component.html
+++ b/cultpodcasts/src/app/episode-status/episode-status.component.html
@@ -1,7 +1,7 @@
 @if (_episode) {
 <div id="status">
     @if (editable) {
-    <p class="flags">
+    <div class="flags">
         <button mat-icon-button type="button" class="flag-toggle" [class.loading]="loadingIgnored"
             [disabled]="anyActionBusy" (click)="onToggleIgnored($event)"
             [attr.aria-pressed]="_episode.ignored"
@@ -22,18 +22,18 @@
             <mat-spinner diameter="20"></mat-spinner>
             }
         </button>
-    </p>
+    </div>
     } @else if (_episode.ignored || _episode.removed) {
-    <p class="flags">
+    <div class="flags">
         @if (_episode.ignored) {
         <mat-icon svgIcon="visible" title="ignored"></mat-icon>
         }
         @if (_episode.removed) {
         <mat-icon svgIcon="removed" title="removed"></mat-icon>
         }
-    </p>
+    </div>
     }
-    <p class="social">
+    <div class="social">
         @if (showReddit) {
         <mat-icon svgIcon="reddit" [class.not]="!_episode.posted" title="reddit"></mat-icon>
         }
@@ -62,6 +62,6 @@
         <mat-icon svgIcon="twitter" [class.not]="!_episode.tweeted" title="twitter"></mat-icon>
         <mat-icon svgIcon="bluesky" [class.not]="!_episode.bluesky" title="bluesky"></mat-icon>
         }
-    </p>
+    </div>
 </div>
 }

--- a/cultpodcasts/src/app/episode-status/episode-status.component.html
+++ b/cultpodcasts/src/app/episode-status/episode-status.component.html
@@ -1,42 +1,36 @@
 @if (_episode) {
-<div id="status">
-    <p class="social">
-        <mat-icon svgIcon="reddit" [class.not]="!_episode.posted"></mat-icon>
-        <mat-icon svgIcon="twitter" [class.not]="!_episode.tweeted"></mat-icon>
-        <mat-icon svgIcon="bluesky" [class.not]="!_episode.bluesky"></mat-icon>
-    </p>
+<p id="status">
     @if (editable) {
-    <p class="flags">
-        <button mat-icon-button type="button" class="flag-toggle" [class.loading]="loadingIgnored"
-            [disabled]="disabled || loadingIgnored || loadingRemoved" (click)="onToggleIgnored($event)"
-            [attr.aria-pressed]="_episode.ignored"
-            [attr.aria-label]="_episode.ignored ? 'Clear ignored' : 'Mark ignored'"
-            [attr.aria-busy]="loadingIgnored">
-            <mat-icon svgIcon="visible" [class.not]="!_episode.ignored" title="ignored"></mat-icon>
-            @if (loadingIgnored) {
-            <mat-spinner diameter="20"></mat-spinner>
-            }
-        </button>
-        <button mat-icon-button type="button" class="flag-toggle" [class.loading]="loadingRemoved"
-            [disabled]="disabled || loadingIgnored || loadingRemoved" (click)="onToggleRemoved($event)"
-            [attr.aria-pressed]="_episode.removed"
-            [attr.aria-label]="_episode.removed ? 'Clear removed' : 'Mark removed'"
-            [attr.aria-busy]="loadingRemoved">
-            <mat-icon svgIcon="removed" [class.not]="!_episode.removed" title="removed"></mat-icon>
-            @if (loadingRemoved) {
-            <mat-spinner diameter="20"></mat-spinner>
-            }
-        </button>
-    </p>
-    } @else if (_episode.ignored || _episode.removed) {
-    <p class="flags">
-        @if (_episode.ignored) {
-        <mat-icon svgIcon="visible" title="ignored"></mat-icon>
+    <button mat-icon-button type="button" class="flag-toggle" [class.loading]="loadingIgnored"
+        [disabled]="disabled || loadingIgnored || loadingRemoved" (click)="onToggleIgnored($event)"
+        [attr.aria-pressed]="_episode.ignored"
+        [attr.aria-label]="_episode.ignored ? 'Clear ignored' : 'Mark ignored'"
+        [attr.aria-busy]="loadingIgnored">
+        <mat-icon svgIcon="visible" [class.not]="!_episode.ignored" title="ignored"></mat-icon>
+        @if (loadingIgnored) {
+        <mat-spinner diameter="20"></mat-spinner>
         }
-        @if (_episode.removed) {
-        <mat-icon svgIcon="removed" title="removed"></mat-icon>
+    </button>
+    <button mat-icon-button type="button" class="flag-toggle" [class.loading]="loadingRemoved"
+        [disabled]="disabled || loadingIgnored || loadingRemoved" (click)="onToggleRemoved($event)"
+        [attr.aria-pressed]="_episode.removed"
+        [attr.aria-label]="_episode.removed ? 'Clear removed' : 'Mark removed'"
+        [attr.aria-busy]="loadingRemoved">
+        <mat-icon svgIcon="removed" [class.not]="!_episode.removed" title="removed"></mat-icon>
+        @if (loadingRemoved) {
+        <mat-spinner diameter="20"></mat-spinner>
         }
-    </p>
+    </button>
+    } @else {
+    @if (_episode.ignored) {
+    <mat-icon svgIcon="visible" title="ignored"></mat-icon>
     }
-</div>
+    @if (_episode.removed) {
+    <mat-icon svgIcon="removed" title="removed"></mat-icon>
+    }
+    }
+    <mat-icon svgIcon="reddit" [class.not]="!_episode.posted"></mat-icon>
+    <mat-icon svgIcon="twitter" [class.not]="!_episode.tweeted"></mat-icon>
+    <mat-icon svgIcon="bluesky" [class.not]="!_episode.bluesky"></mat-icon>
+</p>
 }

--- a/cultpodcasts/src/app/episode-status/episode-status.component.html
+++ b/cultpodcasts/src/app/episode-status/episode-status.component.html
@@ -3,7 +3,7 @@
     @if (editable) {
     <p class="flags">
         <button mat-icon-button type="button" class="flag-toggle" [class.loading]="loadingIgnored"
-            [disabled]="disabled || loadingIgnored || loadingRemoved" (click)="onToggleIgnored($event)"
+            [disabled]="anyActionBusy" (click)="onToggleIgnored($event)"
             [attr.aria-pressed]="_episode.ignored"
             [attr.aria-label]="_episode.ignored ? 'Clear ignored' : 'Mark ignored'"
             [attr.aria-busy]="loadingIgnored">
@@ -13,7 +13,7 @@
             }
         </button>
         <button mat-icon-button type="button" class="flag-toggle" [class.loading]="loadingRemoved"
-            [disabled]="disabled || loadingIgnored || loadingRemoved" (click)="onToggleRemoved($event)"
+            [disabled]="anyActionBusy" (click)="onToggleRemoved($event)"
             [attr.aria-pressed]="_episode.removed"
             [attr.aria-label]="_episode.removed ? 'Clear removed' : 'Mark removed'"
             [attr.aria-busy]="loadingRemoved">
@@ -34,9 +34,34 @@
     </p>
     }
     <p class="social">
-        <mat-icon svgIcon="reddit" [class.not]="!_episode.posted"></mat-icon>
-        <mat-icon svgIcon="twitter" [class.not]="!_episode.tweeted"></mat-icon>
-        <mat-icon svgIcon="bluesky" [class.not]="!_episode.bluesky"></mat-icon>
+        @if (showReddit) {
+        <mat-icon svgIcon="reddit" [class.not]="!_episode.posted" title="reddit"></mat-icon>
+        }
+        @if (editable) {
+        <button mat-icon-button type="button" class="flag-toggle" [class.loading]="loadingTweeted"
+            [disabled]="anyActionBusy" (click)="onToggleTweeted($event)"
+            [attr.aria-pressed]="_episode.tweeted"
+            [attr.aria-label]="_episode.tweeted ? 'Clear tweeted' : 'Mark tweeted'"
+            [attr.aria-busy]="loadingTweeted">
+            <mat-icon svgIcon="twitter" [class.not]="!_episode.tweeted" title="twitter"></mat-icon>
+            @if (loadingTweeted) {
+            <mat-spinner diameter="20"></mat-spinner>
+            }
+        </button>
+        <button mat-icon-button type="button" class="flag-toggle" [class.loading]="loadingBluesky"
+            [disabled]="anyActionBusy" (click)="onToggleBluesky($event)"
+            [attr.aria-pressed]="_episode.bluesky == true"
+            [attr.aria-label]="_episode.bluesky ? 'Unpost Bluesky' : 'Post Bluesky'"
+            [attr.aria-busy]="loadingBluesky">
+            <mat-icon svgIcon="bluesky" [class.not]="!_episode.bluesky" title="bluesky"></mat-icon>
+            @if (loadingBluesky) {
+            <mat-spinner diameter="20"></mat-spinner>
+            }
+        </button>
+        } @else {
+        <mat-icon svgIcon="twitter" [class.not]="!_episode.tweeted" title="twitter"></mat-icon>
+        <mat-icon svgIcon="bluesky" [class.not]="!_episode.bluesky" title="bluesky"></mat-icon>
+        }
     </p>
 </div>
 }

--- a/cultpodcasts/src/app/episode-status/episode-status.component.sass
+++ b/cultpodcasts/src/app/episode-status/episode-status.component.sass
@@ -1,4 +1,12 @@
 #status
+    .social,
+    .flags
+        display: flex
+        flex-wrap: wrap
+        align-items: center
+        margin: 0
+    .flags
+        margin-top: 8px
     mat-icon
         height: 30px
         width: 30px
@@ -6,6 +14,7 @@
     mat-icon.not
         filter: opacity(0.5)
     .flag-toggle
+        position: relative
         width: 30px
         height: 30px
         line-height: 30px
@@ -13,3 +22,12 @@
         padding: 0
         mat-icon
             margin-right: 0
+        mat-spinner
+            position: absolute
+            top: 5px
+            left: 5px
+            margin: 0
+    .flag-toggle.loading
+        opacity: 1
+        mat-icon
+            opacity: 0.55

--- a/cultpodcasts/src/app/episode-status/episode-status.component.sass
+++ b/cultpodcasts/src/app/episode-status/episode-status.component.sass
@@ -2,7 +2,6 @@
     // Cell metrics are LITERAL dd9dd09 (#415, yesterday). Only additions vs that
     // commit: split .flags/.social so ignore/removed sit on their own row ABOVE
     // the brand icons, plus spinner overlay for optimistic loading.
-    margin-top: 12px
     .flags,
     .social
         display: flex

--- a/cultpodcasts/src/app/episode-status/episode-status.component.sass
+++ b/cultpodcasts/src/app/episode-status/episode-status.component.sass
@@ -2,6 +2,7 @@
     // Cell metrics are LITERAL dd9dd09 (#415, yesterday). Only additions vs that
     // commit: split .flags/.social so ignore/removed sit on their own row ABOVE
     // the brand icons, plus spinner overlay for optimistic loading.
+    margin-top: 12px
     .flags,
     .social
         display: flex

--- a/cultpodcasts/src/app/episode-status/episode-status.component.sass
+++ b/cultpodcasts/src/app/episode-status/episode-status.component.sass
@@ -1,4 +1,12 @@
 #status
+    .social,
+    .flags
+        display: flex
+        flex-wrap: wrap
+        align-items: center
+        margin: 0
+    .social
+        margin-top: 8px
     mat-icon
         height: 30px
         width: 30px

--- a/cultpodcasts/src/app/episode-status/episode-status.component.sass
+++ b/cultpodcasts/src/app/episode-status/episode-status.component.sass
@@ -1,27 +1,54 @@
 #status
+    // Layout: flags row above socials. Icon cell metrics from dd9dd09
+    // (People/subjects UI #415 / main pre-today episode-status.component.sass).
     .social,
     .flags
         display: flex
         flex-wrap: wrap
         align-items: center
         margin: 0
+        padding: 0
+        font-size: 0
+        line-height: 0
     .social
         margin-top: 8px
     mat-icon
         height: 30px
         width: 30px
         margin-right: 20px
+        font-size: 30px
+        line-height: 30px
+        svg
+            width: 30px
+            height: 30px
     mat-icon.not
         filter: opacity(0.5)
     .flag-toggle
+        // Exact dd9dd09 sizes + MDC overrides so button icons match bare brand icons
         position: relative
+        --mdc-icon-button-state-layer-size: 30px
+        --mdc-icon-button-icon-size: 30px
         width: 30px
         height: 30px
+        min-width: 30px
+        min-height: 30px
         line-height: 30px
         margin-right: 20px
         padding: 0
+        display: inline-flex
+        align-items: center
+        justify-content: center
+        vertical-align: top
+        transform: none !important
         mat-icon
+            width: 30px
+            height: 30px
+            font-size: 30px
+            line-height: 30px
             margin-right: 0
+            svg
+                width: 30px
+                height: 30px
         mat-spinner
             position: absolute
             top: 5px

--- a/cultpodcasts/src/app/episode-status/episode-status.component.sass
+++ b/cultpodcasts/src/app/episode-status/episode-status.component.sass
@@ -1,54 +1,30 @@
 #status
-    // Layout: flags row above socials. Icon cell metrics from dd9dd09
-    // (People/subjects UI #415 / main pre-today episode-status.component.sass).
-    .social,
-    .flags
+    // Cell metrics are LITERAL dd9dd09 (#415, yesterday). Only additions vs that
+    // commit: split .flags/.social so ignore/removed sit on their own row ABOVE
+    // the brand icons, plus spinner overlay for optimistic loading.
+    .flags,
+    .social
         display: flex
         flex-wrap: wrap
         align-items: center
         margin: 0
-        padding: 0
-        font-size: 0
-        line-height: 0
     .social
         margin-top: 8px
     mat-icon
         height: 30px
         width: 30px
         margin-right: 20px
-        font-size: 30px
-        line-height: 30px
-        svg
-            width: 30px
-            height: 30px
     mat-icon.not
         filter: opacity(0.5)
     .flag-toggle
-        // Exact dd9dd09 sizes + MDC overrides so button icons match bare brand icons
         position: relative
-        --mdc-icon-button-state-layer-size: 30px
-        --mdc-icon-button-icon-size: 30px
         width: 30px
         height: 30px
-        min-width: 30px
-        min-height: 30px
         line-height: 30px
         margin-right: 20px
         padding: 0
-        display: inline-flex
-        align-items: center
-        justify-content: center
-        vertical-align: top
-        transform: none !important
         mat-icon
-            width: 30px
-            height: 30px
-            font-size: 30px
-            line-height: 30px
             margin-right: 0
-            svg
-                width: 30px
-                height: 30px
         mat-spinner
             position: absolute
             top: 5px

--- a/cultpodcasts/src/app/episode-status/episode-status.component.sass
+++ b/cultpodcasts/src/app/episode-status/episode-status.component.sass
@@ -1,12 +1,4 @@
 #status
-    .social,
-    .flags
-        display: flex
-        flex-wrap: wrap
-        align-items: center
-        margin: 0
-    .flags
-        margin-top: 8px
     mat-icon
         height: 30px
         width: 30px

--- a/cultpodcasts/src/app/episode-status/episode-status.component.ts
+++ b/cultpodcasts/src/app/episode-status/episode-status.component.ts
@@ -2,12 +2,14 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { ApiEpisode } from '../api-episode.interface';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 
 @Component({
   selector: 'app-episode-status',
   imports: [
     MatIconModule,
-    MatButtonModule
+    MatButtonModule,
+    MatProgressSpinnerModule
   ],
   templateUrl: './episode-status.component.html',
   styleUrl: './episode-status.component.sass'
@@ -20,6 +22,12 @@ export class EpisodeStatusComponent {
 
   @Input()
   disabled: boolean = false;
+
+  @Input()
+  loadingIgnored: boolean = false;
+
+  @Input()
+  loadingRemoved: boolean = false;
 
   @Output()
   toggleIgnored = new EventEmitter<void>();

--- a/cultpodcasts/src/app/episode-status/episode-status.component.ts
+++ b/cultpodcasts/src/app/episode-status/episode-status.component.ts
@@ -3,6 +3,8 @@ import { ApiEpisode } from '../api-episode.interface';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { FeatureSwitch } from '../feature-switch.enum';
+import { FeatureSwtichService } from '../feature-switch-service';
 
 @Component({
   selector: 'app-episode-status',
@@ -16,6 +18,7 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 })
 export class EpisodeStatusComponent {
   protected _episode: ApiEpisode | undefined;
+  protected readonly showReddit: boolean;
 
   @Input()
   editable: boolean = false;
@@ -29,15 +32,39 @@ export class EpisodeStatusComponent {
   @Input()
   loadingRemoved: boolean = false;
 
+  @Input()
+  loadingTweeted: boolean = false;
+
+  @Input()
+  loadingBluesky: boolean = false;
+
   @Output()
   toggleIgnored = new EventEmitter<void>();
 
   @Output()
   toggleRemoved = new EventEmitter<void>();
 
+  @Output()
+  toggleTweeted = new EventEmitter<void>();
+
+  @Output()
+  toggleBluesky = new EventEmitter<void>();
+
+  constructor(featureSwitchService: FeatureSwtichService) {
+    this.showReddit = featureSwitchService.IsEnabled(FeatureSwitch.redditPost);
+  }
+
   @Input({ required: true })
   set episode(e: ApiEpisode) {
     this._episode = e;
+  }
+
+  get anyActionBusy(): boolean {
+    return this.disabled
+      || this.loadingIgnored
+      || this.loadingRemoved
+      || this.loadingTweeted
+      || this.loadingBluesky;
   }
 
   onToggleIgnored($event: Event) {
@@ -50,5 +77,17 @@ export class EpisodeStatusComponent {
     $event.preventDefault();
     $event.stopPropagation();
     this.toggleRemoved.emit();
+  }
+
+  onToggleTweeted($event: Event) {
+    $event.preventDefault();
+    $event.stopPropagation();
+    this.toggleTweeted.emit();
+  }
+
+  onToggleBluesky($event: Event) {
+    $event.preventDefault();
+    $event.stopPropagation();
+    this.toggleBluesky.emit();
   }
 }

--- a/cultpodcasts/src/app/episode-update.service.ts
+++ b/cultpodcasts/src/app/episode-update.service.ts
@@ -56,11 +56,21 @@ export class EpisodeUpdateService {
   }
 
   async toggleIgnored(episode: ApiEpisode, ignored?: boolean): Promise<ApiEpisode> {
-    return this.applyAndRefresh(episode, { ignored: ignored ?? !episode.ignored });
+    const next = ignored ?? !episode.ignored;
+    const changes: EpisodePost = { ignored: next };
+    if (next) {
+      changes.removed = false;
+    }
+    return this.applyAndRefresh(episode, changes);
   }
 
   async toggleRemoved(episode: ApiEpisode, removed?: boolean): Promise<ApiEpisode> {
-    return this.applyAndRefresh(episode, { removed: removed ?? !episode.removed });
+    const next = removed ?? !episode.removed;
+    const changes: EpisodePost = { removed: next };
+    if (next) {
+      changes.ignored = false;
+    }
+    return this.applyAndRefresh(episode, changes);
   }
 
   getGuestNames(episode: ApiEpisode): string[] {

--- a/cultpodcasts/src/app/episode-update.service.ts
+++ b/cultpodcasts/src/app/episode-update.service.ts
@@ -55,12 +55,12 @@ export class EpisodeUpdateService {
     return this.applyAndRefresh(episode, { guests: [...guests, guestName] });
   }
 
-  async toggleIgnored(episode: ApiEpisode): Promise<ApiEpisode> {
-    return this.applyAndRefresh(episode, { ignored: !episode.ignored });
+  async toggleIgnored(episode: ApiEpisode, ignored?: boolean): Promise<ApiEpisode> {
+    return this.applyAndRefresh(episode, { ignored: ignored ?? !episode.ignored });
   }
 
-  async toggleRemoved(episode: ApiEpisode): Promise<ApiEpisode> {
-    return this.applyAndRefresh(episode, { removed: !episode.removed });
+  async toggleRemoved(episode: ApiEpisode, removed?: boolean): Promise<ApiEpisode> {
+    return this.applyAndRefresh(episode, { removed: removed ?? !episode.removed });
   }
 
   getGuestNames(episode: ApiEpisode): string[] {

--- a/cultpodcasts/src/app/episode-update.service.ts
+++ b/cultpodcasts/src/app/episode-update.service.ts
@@ -83,8 +83,26 @@ export class EpisodeUpdateService {
     return this.applyAndRefresh(episode, { tweeted: false });
   }
 
-  async toggleTweeted(episode: ApiEpisode): Promise<ApiEpisode> {
-    return episode.tweeted ? this.untweet(episode) : this.markTweeted(episode);
+  /** Attempt auto-tweet via publish; 400 bodies with failedTweetContent enable the manual-tweet dialog. */
+  async publishTweet(episode: ApiEpisode): Promise<EpisodePublishResponse> {
+    const podcastId = episode.podcastId;
+    if (!podcastId) {
+      throw new Error('Episode podcastId is required for updates.');
+    }
+    const headers = await this.getAuthHeaders();
+    const endpoint = new URL(`/episode/publish/${podcastId}/${episode.id}`, environment.api).toString();
+    const body: PostEpisodeModel = { tweet: true };
+    try {
+      return await firstValueFrom(
+        this.http.post<EpisodePublishResponse>(endpoint, body, { headers })
+      );
+    } catch (e: unknown) {
+      const err = e as { status?: number; error?: EpisodePublishResponse };
+      if (err.status === 400 && err.error) {
+        return err.error;
+      }
+      throw e;
+    }
   }
 
   async postBluesky(episode: ApiEpisode): Promise<ApiEpisode> {

--- a/cultpodcasts/src/app/episode-update.service.ts
+++ b/cultpodcasts/src/app/episode-update.service.ts
@@ -57,6 +57,10 @@ export class EpisodeUpdateService {
     return this.applyAndRefresh(episode, { guests: [...guests, guestName] });
   }
 
+  async setGuests(episode: ApiEpisode, guests: string[]): Promise<ApiEpisode> {
+    return this.applyAndRefresh(episode, { guests });
+  }
+
   async toggleIgnored(episode: ApiEpisode, ignored?: boolean): Promise<ApiEpisode> {
     const next = ignored ?? !episode.ignored;
     const changes: EpisodePost = { ignored: next };

--- a/cultpodcasts/src/app/episode-update.service.ts
+++ b/cultpodcasts/src/app/episode-update.service.ts
@@ -5,6 +5,8 @@ import { environment } from '../environments/environment';
 import { AuthServiceWrapper } from './auth-service-wrapper.class';
 import { ApiEpisode } from './api-episode.interface';
 import { EpisodePost } from './episode-post.interface';
+import { EpisodePublishResponse } from './episode-publish-response.interface';
+import { PostEpisodeModel } from './post-episode-model.interface';
 
 @Injectable({
   providedIn: 'root'
@@ -71,6 +73,43 @@ export class EpisodeUpdateService {
       changes.ignored = false;
     }
     return this.applyAndRefresh(episode, changes);
+  }
+
+  async markTweeted(episode: ApiEpisode): Promise<ApiEpisode> {
+    return this.applyAndRefresh(episode, { tweeted: true });
+  }
+
+  async untweet(episode: ApiEpisode): Promise<ApiEpisode> {
+    return this.applyAndRefresh(episode, { tweeted: false });
+  }
+
+  async toggleTweeted(episode: ApiEpisode): Promise<ApiEpisode> {
+    return episode.tweeted ? this.untweet(episode) : this.markTweeted(episode);
+  }
+
+  async postBluesky(episode: ApiEpisode): Promise<ApiEpisode> {
+    const podcastId = episode.podcastId;
+    if (!podcastId) {
+      throw new Error('Episode podcastId is required for updates.');
+    }
+    const headers = await this.getAuthHeaders();
+    const endpoint = new URL(`/episode/publish/${podcastId}/${episode.id}`, environment.api).toString();
+    const body: PostEpisodeModel = { blueskyPost: true };
+    const response = await firstValueFrom(
+      this.http.post<EpisodePublishResponse>(endpoint, body, { headers })
+    );
+    if (!response.blueskyPosted) {
+      throw new Error('Bluesky post failed.');
+    }
+    return this.fetchEpisode(episode.id);
+  }
+
+  async unpostBluesky(episode: ApiEpisode): Promise<ApiEpisode> {
+    return this.applyAndRefresh(episode, { bluesky: false });
+  }
+
+  async toggleBluesky(episode: ApiEpisode): Promise<ApiEpisode> {
+    return episode.bluesky ? this.unpostBluesky(episode) : this.postBluesky(episode);
   }
 
   getGuestNames(episode: ApiEpisode): string[] {

--- a/cultpodcasts/src/app/episodes-api/episodes-api.component.html
+++ b/cultpodcasts/src/app/episodes-api/episodes-api.component.html
@@ -85,7 +85,7 @@
                 (toggleIgnored)="toggleIgnored(result)" (toggleRemoved)="toggleRemoved(result)"
                 (toggleTweeted)="toggleTweeted(result)" (toggleBluesky)="toggleBluesky(result)"></app-episode-status>
         </mat-card-content>
-        <mat-card-actions>
+        <mat-card-actions class="review-actions">
             <app-episode-podcast-links [episode]="result"></app-episode-podcast-links>
             <mat-card-footer class="subjects">
                 <app-subjects [subjects]="result.subjects!" [showHidden]="true" [editable]="true"

--- a/cultpodcasts/src/app/episodes-api/episodes-api.component.html
+++ b/cultpodcasts/src/app/episodes-api/episodes-api.component.html
@@ -94,7 +94,8 @@
             @if ((result.guestPeople?.length ?? 0) > 0 || (result.guestSuggestions?.length ?? 0) > 0) {
             <mat-card-footer class="guests">
                 <app-episode-guests [guestPeople]="result.guestPeople" [guestSuggestions]="result.guestSuggestions"
-                    [editable]="true" [disabled]="isUpdating(result.id)" (removeGuest)="removeGuest(result, $event)"
+                    [editable]="true" [disabled]="isUpdating(result.id)" [loadingGuestName]="loadingGuestName(result.id)"
+                    (removeGuest)="removeGuest(result, $event)"
                     (addSuggestedGuest)="addSuggestedGuest(result, $event)"></app-episode-guests>
             </mat-card-footer>
             }

--- a/cultpodcasts/src/app/episodes-api/episodes-api.component.html
+++ b/cultpodcasts/src/app/episodes-api/episodes-api.component.html
@@ -78,7 +78,9 @@
         <mat-card-content class="resultdescription">
             <app-episode-image [apiEpisode]="result"></app-episode-image>
             <p>{{result.displayDescription}}</p>
-            <app-episode-status [episode]="result" [editable]="true" [disabled]="isUpdating(result.id)"
+            <app-episode-status [episode]="result" [editable]="true"
+                [disabled]="isUpdating(result.id) && !isLoadingIgnored(result.id) && !isLoadingRemoved(result.id)"
+                [loadingIgnored]="isLoadingIgnored(result.id)" [loadingRemoved]="isLoadingRemoved(result.id)"
                 (toggleIgnored)="toggleIgnored(result)" (toggleRemoved)="toggleRemoved(result)"></app-episode-status>
         </mat-card-content>
         <mat-card-actions>

--- a/cultpodcasts/src/app/episodes-api/episodes-api.component.html
+++ b/cultpodcasts/src/app/episodes-api/episodes-api.component.html
@@ -78,15 +78,17 @@
         <mat-card-content class="resultdescription">
             <app-episode-image [apiEpisode]="result"></app-episode-image>
             <p>{{result.displayDescription}}</p>
-            <app-episode-status [episode]="result" [editable]="true"
-                [disabled]="isUpdating(result.id) && !isStatusActionLoading(result.id)"
-                [loadingIgnored]="isLoadingIgnored(result.id)" [loadingRemoved]="isLoadingRemoved(result.id)"
-                [loadingTweeted]="isLoadingTweeted(result.id)" [loadingBluesky]="isLoadingBluesky(result.id)"
-                (toggleIgnored)="toggleIgnored(result)" (toggleRemoved)="toggleRemoved(result)"
-                (toggleTweeted)="toggleTweeted(result)" (toggleBluesky)="toggleBluesky(result)"></app-episode-status>
         </mat-card-content>
         <mat-card-actions class="review-actions">
-            <app-episode-podcast-links [episode]="result"></app-episode-podcast-links>
+            <div class="icon-column">
+                <app-episode-status [episode]="result" [editable]="true"
+                    [disabled]="isUpdating(result.id) && !isStatusActionLoading(result.id)"
+                    [loadingIgnored]="isLoadingIgnored(result.id)" [loadingRemoved]="isLoadingRemoved(result.id)"
+                    [loadingTweeted]="isLoadingTweeted(result.id)" [loadingBluesky]="isLoadingBluesky(result.id)"
+                    (toggleIgnored)="toggleIgnored(result)" (toggleRemoved)="toggleRemoved(result)"
+                    (toggleTweeted)="toggleTweeted(result)" (toggleBluesky)="toggleBluesky(result)"></app-episode-status>
+                <app-episode-podcast-links [episode]="result"></app-episode-podcast-links>
+            </div>
             <div class="footer-column">
                 <mat-card-footer class="subjects">
                     <app-subjects [subjects]="result.subjects!" [showHidden]="true" [editable]="true"

--- a/cultpodcasts/src/app/episodes-api/episodes-api.component.html
+++ b/cultpodcasts/src/app/episodes-api/episodes-api.component.html
@@ -79,9 +79,11 @@
             <app-episode-image [apiEpisode]="result"></app-episode-image>
             <p>{{result.displayDescription}}</p>
             <app-episode-status [episode]="result" [editable]="true"
-                [disabled]="isUpdating(result.id) && !isLoadingIgnored(result.id) && !isLoadingRemoved(result.id)"
+                [disabled]="isUpdating(result.id) && !isStatusActionLoading(result.id)"
                 [loadingIgnored]="isLoadingIgnored(result.id)" [loadingRemoved]="isLoadingRemoved(result.id)"
-                (toggleIgnored)="toggleIgnored(result)" (toggleRemoved)="toggleRemoved(result)"></app-episode-status>
+                [loadingTweeted]="isLoadingTweeted(result.id)" [loadingBluesky]="isLoadingBluesky(result.id)"
+                (toggleIgnored)="toggleIgnored(result)" (toggleRemoved)="toggleRemoved(result)"
+                (toggleTweeted)="toggleTweeted(result)" (toggleBluesky)="toggleBluesky(result)"></app-episode-status>
         </mat-card-content>
         <mat-card-actions>
             <app-episode-podcast-links [episode]="result"></app-episode-podcast-links>

--- a/cultpodcasts/src/app/episodes-api/episodes-api.component.html
+++ b/cultpodcasts/src/app/episodes-api/episodes-api.component.html
@@ -87,18 +87,20 @@
         </mat-card-content>
         <mat-card-actions class="review-actions">
             <app-episode-podcast-links [episode]="result"></app-episode-podcast-links>
-            <mat-card-footer class="subjects">
-                <app-subjects [subjects]="result.subjects!" [showHidden]="true" [editable]="true"
-                    [disabled]="isUpdating(result.id)" (removeSubject)="removeSubject(result, $event)"></app-subjects>
-            </mat-card-footer>
-            @if ((result.guestPeople?.length ?? 0) > 0 || (result.guestSuggestions?.length ?? 0) > 0) {
-            <mat-card-footer class="guests">
-                <app-episode-guests [guestPeople]="result.guestPeople" [guestSuggestions]="result.guestSuggestions"
-                    [editable]="true" [disabled]="isUpdating(result.id)" [loadingGuestName]="loadingGuestName(result.id)"
-                    (removeGuest)="removeGuest(result, $event)"
-                    (addSuggestedGuest)="addSuggestedGuest(result, $event)"></app-episode-guests>
-            </mat-card-footer>
-            }
+            <div class="footer-column">
+                <mat-card-footer class="subjects">
+                    <app-subjects [subjects]="result.subjects!" [showHidden]="true" [editable]="true"
+                        [disabled]="isUpdating(result.id)" (removeSubject)="removeSubject(result, $event)"></app-subjects>
+                </mat-card-footer>
+                @if ((result.guestPeople?.length ?? 0) > 0 || (result.guestSuggestions?.length ?? 0) > 0) {
+                <mat-card-footer class="guests">
+                    <app-episode-guests [guestPeople]="result.guestPeople" [guestSuggestions]="result.guestSuggestions"
+                        [editable]="true" [disabled]="isUpdating(result.id)" [loadingGuestName]="loadingGuestName(result.id)"
+                        (removeGuest)="removeGuest(result, $event)"
+                        (addSuggestedGuest)="addSuggestedGuest(result, $event)"></app-episode-guests>
+                </mat-card-footer>
+                }
+            </div>
         </mat-card-actions>
     </mat-card>
     }

--- a/cultpodcasts/src/app/episodes-api/episodes-api.component.sass
+++ b/cultpodcasts/src/app/episodes-api/episodes-api.component.sass
@@ -36,13 +36,24 @@ mat-card-header
 #error
     margin-left: 12px
 app-episode-podcast-links
-    display: inherit
+    display: flex
+    flex-wrap: wrap
     flex: 0 0 auto
+// Two-column actions row: left = icon column (status + podcast-service icons),
+// right = footer column (subjects then people). They sit SIDE BY SIDE so the
+// subjects/people footer wraps to the right of the whole icon stack rather than
+// dropping beneath it.
 mat-card-actions
+    display: flex
     flex-wrap: wrap
     align-items: flex-start
-// Footer (subjects + people) wraps to the RIGHT of the podcast-service icon
-// column instead of dropping onto a new full-width row beneath them.
+.icon-column
+    flex: 0 0 auto
+    display: flex
+    flex-direction: column
+    align-items: flex-start
+    app-episode-podcast-links
+        margin-top: 8px
 .footer-column
     flex: 1 1 auto
     min-width: 55%

--- a/cultpodcasts/src/app/episodes-api/episodes-api.component.sass
+++ b/cultpodcasts/src/app/episodes-api/episodes-api.component.sass
@@ -37,6 +37,17 @@ mat-card-header
     margin-left: 12px
 app-episode-podcast-links
     display: inherit
+    flex: 0 0 auto
+mat-card-actions
+    flex-wrap: wrap
+    align-items: flex-start
+mat-card-footer.subjects,
+mat-card-footer.guests
+    flex: 1 1 100%
+    width: 100%
+    max-width: 100%
+    margin-left: 0
+    box-sizing: border-box
 mat-card-content img,mat-card-content span.img
     max-height: 300px
     max-width: 100%

--- a/cultpodcasts/src/app/episodes-api/episodes-api.component.sass
+++ b/cultpodcasts/src/app/episodes-api/episodes-api.component.sass
@@ -41,9 +41,18 @@ app-episode-podcast-links
 mat-card-actions
     flex-wrap: wrap
     align-items: flex-start
+// Footer (subjects + people) wraps to the RIGHT of the podcast-service icon
+// column instead of dropping onto a new full-width row beneath them.
+.footer-column
+    flex: 1 1 auto
+    min-width: 55%
+    display: flex
+    flex-direction: column
+    align-items: stretch
+    box-sizing: border-box
 mat-card-footer.subjects,
 mat-card-footer.guests
-    flex: 1 1 100%
+    flex: 0 0 auto
     width: 100%
     max-width: 100%
     margin-left: 0

--- a/cultpodcasts/src/app/episodes-api/episodes-api.component.ts
+++ b/cultpodcasts/src/app/episodes-api/episodes-api.component.ts
@@ -228,15 +228,20 @@ export class EpisodesApiComponent {
     if (this.isUpdating(episode.id)) {
       return;
     }
-    const previous = episode.ignored;
-    const next = !previous;
+    const previousIgnored = episode.ignored;
+    const previousRemoved = episode.removed;
+    const next = !previousIgnored;
     episode.ignored = next;
+    if (next) {
+      episode.removed = false;
+    }
     this.runEpisodeUpdate(
       episode,
       () => this.episodeUpdate.toggleIgnored(episode, next),
       'ignored'
     ).catch(() => {
-      episode.ignored = previous;
+      episode.ignored = previousIgnored;
+      episode.removed = previousRemoved;
     });
   }
 
@@ -244,15 +249,20 @@ export class EpisodesApiComponent {
     if (this.isUpdating(episode.id)) {
       return;
     }
-    const previous = episode.removed;
-    const next = !previous;
+    const previousIgnored = episode.ignored;
+    const previousRemoved = episode.removed;
+    const next = !previousRemoved;
     episode.removed = next;
+    if (next) {
+      episode.ignored = false;
+    }
     this.runEpisodeUpdate(
       episode,
       () => this.episodeUpdate.toggleRemoved(episode, next),
       'removed'
     ).catch(() => {
-      episode.removed = previous;
+      episode.ignored = previousIgnored;
+      episode.removed = previousRemoved;
     });
   }
 

--- a/cultpodcasts/src/app/episodes-api/episodes-api.component.ts
+++ b/cultpodcasts/src/app/episodes-api/episodes-api.component.ts
@@ -63,6 +63,7 @@ export class EpisodesApiComponent {
   authRoles: string[] = [];
   updatingEpisodeId: string | null = null;
   updatingFlag: 'ignored' | 'removed' | 'tweeted' | 'bluesky' | null = null;
+  addingGuest: { [episodeId: string]: string } = {};
 
   constructor(
     private router: Router,
@@ -237,7 +238,42 @@ export class EpisodesApiComponent {
   }
 
   addSuggestedGuest(episode: ApiEpisode, guestName: string) {
-    this.runEpisodeUpdate(episode, () => this.episodeUpdate.addGuest(episode, guestName));
+    if (this.isUpdating(episode.id) || this.addingGuest[episode.id]) {
+      return;
+    }
+    const suggestion = episode.guestSuggestions?.find(x => x.person.name === guestName);
+    if (!suggestion) {
+      return;
+    }
+    const previousGuests = episode.guestPeople ? [...episode.guestPeople] : [];
+    const previousSuggestions = episode.guestSuggestions ? [...episode.guestSuggestions] : [];
+    const previousGuestNames = this.episodeUpdate.getGuestNames(episode);
+
+    episode.guestPeople = [...previousGuests, suggestion.person];
+    episode.guestSuggestions = previousSuggestions.filter(x => x.person.name !== guestName);
+    this.addingGuest[episode.id] = guestName;
+
+    const nextGuestNames = previousGuestNames.includes(guestName)
+      ? previousGuestNames
+      : [...previousGuestNames, guestName];
+
+    this.episodeUpdate.setGuests(episode, nextGuestNames)
+      .then(updated => {
+        this.episodes = this.episodeUpdate.replaceEpisode(this.episodes, updated);
+      })
+      .catch(e => {
+        console.error(e);
+        episode.guestPeople = previousGuests;
+        episode.guestSuggestions = previousSuggestions;
+        this.snackBar.open("Failed to add guest", "Ok", { duration: 5000 });
+      })
+      .finally(() => {
+        delete this.addingGuest[episode.id];
+      });
+  }
+
+  loadingGuestName(episodeId: string): string | null {
+    return this.addingGuest[episodeId] ?? null;
   }
 
   toggleIgnored(episode: ApiEpisode) {

--- a/cultpodcasts/src/app/episodes-api/episodes-api.component.ts
+++ b/cultpodcasts/src/app/episodes-api/episodes-api.component.ts
@@ -61,7 +61,7 @@ export class EpisodesApiComponent {
   sortDirection: string = sortParamDateDesc;
   authRoles: string[] = [];
   updatingEpisodeId: string | null = null;
-  updatingFlag: 'ignored' | 'removed' | null = null;
+  updatingFlag: 'ignored' | 'removed' | 'tweeted' | 'bluesky' | null = null;
 
   constructor(
     private router: Router,
@@ -180,6 +180,21 @@ export class EpisodesApiComponent {
     return this.isUpdating(episodeId) && this.updatingFlag === 'removed';
   }
 
+  isLoadingTweeted(episodeId: string): boolean {
+    return this.isUpdating(episodeId) && this.updatingFlag === 'tweeted';
+  }
+
+  isLoadingBluesky(episodeId: string): boolean {
+    return this.isUpdating(episodeId) && this.updatingFlag === 'bluesky';
+  }
+
+  isStatusActionLoading(episodeId: string): boolean {
+    return this.isLoadingIgnored(episodeId)
+      || this.isLoadingRemoved(episodeId)
+      || this.isLoadingTweeted(episodeId)
+      || this.isLoadingBluesky(episodeId);
+  }
+
   async refreshEpisode(episodeId: string) {
     try {
       const updated = await this.episodeUpdate.fetchEpisode(episodeId);
@@ -192,7 +207,7 @@ export class EpisodesApiComponent {
   private async runEpisodeUpdate(
     episode: ApiEpisode,
     action: () => Promise<ApiEpisode>,
-    flag: 'ignored' | 'removed' | null = null
+    flag: 'ignored' | 'removed' | 'tweeted' | 'bluesky' | null = null
   ) {
     if (this.isUpdating(episode.id)) {
       return;
@@ -263,6 +278,38 @@ export class EpisodesApiComponent {
     ).catch(() => {
       episode.ignored = previousIgnored;
       episode.removed = previousRemoved;
+    });
+  }
+
+  toggleTweeted(episode: ApiEpisode) {
+    if (this.isUpdating(episode.id)) {
+      return;
+    }
+    const previous = episode.tweeted;
+    const next = !previous;
+    episode.tweeted = next;
+    this.runEpisodeUpdate(
+      episode,
+      () => next ? this.episodeUpdate.markTweeted(episode) : this.episodeUpdate.untweet(episode),
+      'tweeted'
+    ).catch(() => {
+      episode.tweeted = previous;
+    });
+  }
+
+  toggleBluesky(episode: ApiEpisode) {
+    if (this.isUpdating(episode.id)) {
+      return;
+    }
+    const previous = episode.bluesky == true;
+    const next = !previous;
+    episode.bluesky = next;
+    this.runEpisodeUpdate(
+      episode,
+      () => next ? this.episodeUpdate.postBluesky(episode) : this.episodeUpdate.unpostBluesky(episode),
+      'bluesky'
+    ).catch(() => {
+      episode.bluesky = previous;
     });
   }
 

--- a/cultpodcasts/src/app/episodes-api/episodes-api.component.ts
+++ b/cultpodcasts/src/app/episodes-api/episodes-api.component.ts
@@ -28,6 +28,7 @@ import { EpisodePublishResponseSnackbarComponent } from '../episode-publish-resp
 import { PostEpisodeDialogResponse } from '../post-episode-dialog-response.interface';
 import { PodcastIndexComponent } from '../podcast-index/podcast-index.component';
 import { EpisodeUpdateService } from '../episode-update.service';
+import { ManualTweetEpisodeDialogComponent } from '../manual-tweet-episode-dialog/manual-tweet-episode-dialog.component';
 
 const sortParamDateAsc: string = "date-asc";
 const sortParamDateDesc: string = "date-desc";
@@ -285,16 +286,66 @@ export class EpisodesApiComponent {
     if (this.isUpdating(episode.id)) {
       return;
     }
-    const previous = episode.tweeted;
-    const next = !previous;
-    episode.tweeted = next;
-    this.runEpisodeUpdate(
-      episode,
-      () => next ? this.episodeUpdate.markTweeted(episode) : this.episodeUpdate.untweet(episode),
-      'tweeted'
-    ).catch(() => {
-      episode.tweeted = previous;
-    });
+    if (episode.tweeted) {
+      const previous = episode.tweeted;
+      episode.tweeted = false;
+      this.runEpisodeUpdate(
+        episode,
+        () => this.episodeUpdate.untweet(episode),
+        'tweeted'
+      ).catch(() => {
+        episode.tweeted = previous;
+      });
+      return;
+    }
+    this.runManualTweet(episode);
+  }
+
+  private async runManualTweet(episode: ApiEpisode) {
+    if (this.isUpdating(episode.id)) {
+      return;
+    }
+    if (!episode.podcastId) {
+      this.snackBar.open("Episode podcastId is required to tweet", "Ok", { duration: 5000 });
+      return;
+    }
+    this.updatingEpisodeId = episode.id;
+    this.updatingFlag = 'tweeted';
+    try {
+      const result = await this.episodeUpdate.publishTweet(episode);
+      if (result.tweeted) {
+        const updated = await this.episodeUpdate.fetchEpisode(episode.id);
+        this.episodes = this.episodeUpdate.replaceEpisode(this.episodes, updated);
+        return;
+      }
+      if (result.failedTweetContent) {
+        const dialogRef = this.dialog.open<ManualTweetEpisodeDialogComponent, { tweet: string, episodeId: string, podcastId: string }, any>(
+          ManualTweetEpisodeDialogComponent,
+          {
+            data: {
+              tweet: result.failedTweetContent,
+              episodeId: episode.id,
+              podcastId: episode.podcastId
+            },
+            disableClose: true,
+            autoFocus: true
+          }
+        );
+        const dialogResult = await firstValueFrom(dialogRef.afterClosed());
+        if (dialogResult?.updated) {
+          const updated = await this.episodeUpdate.fetchEpisode(episode.id);
+          this.episodes = this.episodeUpdate.replaceEpisode(this.episodes, updated);
+        }
+        return;
+      }
+      this.snackBar.open("Failed to tweet", "Ok", { duration: 5000 });
+    } catch (e) {
+      console.error(e);
+      this.snackBar.open("Failed to tweet", "Ok", { duration: 5000 });
+    } finally {
+      this.updatingEpisodeId = null;
+      this.updatingFlag = null;
+    }
   }
 
   toggleBluesky(episode: ApiEpisode) {

--- a/cultpodcasts/src/app/episodes-api/episodes-api.component.ts
+++ b/cultpodcasts/src/app/episodes-api/episodes-api.component.ts
@@ -61,6 +61,7 @@ export class EpisodesApiComponent {
   sortDirection: string = sortParamDateDesc;
   authRoles: string[] = [];
   updatingEpisodeId: string | null = null;
+  updatingFlag: 'ignored' | 'removed' | null = null;
 
   constructor(
     private router: Router,
@@ -171,6 +172,14 @@ export class EpisodesApiComponent {
     return this.updatingEpisodeId === episodeId;
   }
 
+  isLoadingIgnored(episodeId: string): boolean {
+    return this.isUpdating(episodeId) && this.updatingFlag === 'ignored';
+  }
+
+  isLoadingRemoved(episodeId: string): boolean {
+    return this.isUpdating(episodeId) && this.updatingFlag === 'removed';
+  }
+
   async refreshEpisode(episodeId: string) {
     try {
       const updated = await this.episodeUpdate.fetchEpisode(episodeId);
@@ -180,19 +189,26 @@ export class EpisodesApiComponent {
     }
   }
 
-  private async runEpisodeUpdate(episode: ApiEpisode, action: () => Promise<ApiEpisode>) {
+  private async runEpisodeUpdate(
+    episode: ApiEpisode,
+    action: () => Promise<ApiEpisode>,
+    flag: 'ignored' | 'removed' | null = null
+  ) {
     if (this.isUpdating(episode.id)) {
       return;
     }
     this.updatingEpisodeId = episode.id;
+    this.updatingFlag = flag;
     try {
       const updated = await action();
       this.episodes = this.episodeUpdate.replaceEpisode(this.episodes, updated);
     } catch (e) {
       console.error(e);
       this.snackBar.open("Failed to update episode", "Ok", { duration: 5000 });
+      throw e;
     } finally {
       this.updatingEpisodeId = null;
+      this.updatingFlag = null;
     }
   }
 
@@ -209,11 +225,35 @@ export class EpisodesApiComponent {
   }
 
   toggleIgnored(episode: ApiEpisode) {
-    this.runEpisodeUpdate(episode, () => this.episodeUpdate.toggleIgnored(episode));
+    if (this.isUpdating(episode.id)) {
+      return;
+    }
+    const previous = episode.ignored;
+    const next = !previous;
+    episode.ignored = next;
+    this.runEpisodeUpdate(
+      episode,
+      () => this.episodeUpdate.toggleIgnored(episode, next),
+      'ignored'
+    ).catch(() => {
+      episode.ignored = previous;
+    });
   }
 
   toggleRemoved(episode: ApiEpisode) {
-    this.runEpisodeUpdate(episode, () => this.episodeUpdate.toggleRemoved(episode));
+    if (this.isUpdating(episode.id)) {
+      return;
+    }
+    const previous = episode.removed;
+    const next = !previous;
+    episode.removed = next;
+    this.runEpisodeUpdate(
+      episode,
+      () => this.episodeUpdate.toggleRemoved(episode, next),
+      'removed'
+    ).catch(() => {
+      episode.removed = previous;
+    });
   }
 
   post(podcastId: string, episodeId: string) {

--- a/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.html
+++ b/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.html
@@ -22,9 +22,11 @@
         </button>
         }
         <mat-menu #options="matMenu">
+            @if (featureSwtichService.IsEnabled(FeatureSwitch.redditPost)) {
             <div mat-menu-item>
                 <mat-checkbox [(ngModel)]="posted" (change)="getEpisodes()">Posted</mat-checkbox>
             </div>
+            }
             <div mat-menu-item>
                 <mat-checkbox [(ngModel)]="tweeted" (change)="getEpisodes()">Tweeted</mat-checkbox>
             </div>
@@ -99,9 +101,11 @@
             <app-episode-image [apiEpisode]="result"></app-episode-image>
             <p>{{result.displayDescription}}</p>
             <app-episode-status [episode]="result" [editable]="true"
-                [disabled]="isUpdating(result.id) && !isLoadingIgnored(result.id) && !isLoadingRemoved(result.id)"
+                [disabled]="isUpdating(result.id) && !isStatusActionLoading(result.id)"
                 [loadingIgnored]="isLoadingIgnored(result.id)" [loadingRemoved]="isLoadingRemoved(result.id)"
-                (toggleIgnored)="toggleIgnored(result)" (toggleRemoved)="toggleRemoved(result)"></app-episode-status>
+                [loadingTweeted]="isLoadingTweeted(result.id)" [loadingBluesky]="isLoadingBluesky(result.id)"
+                (toggleIgnored)="toggleIgnored(result)" (toggleRemoved)="toggleRemoved(result)"
+                (toggleTweeted)="toggleTweeted(result)" (toggleBluesky)="toggleBluesky(result)"></app-episode-status>
         </mat-card-content>
         <mat-card-actions>
             <app-episode-podcast-links [episode]="result"></app-episode-podcast-links>

--- a/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.html
+++ b/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.html
@@ -98,7 +98,9 @@
         <mat-card-content class="resultdescription">
             <app-episode-image [apiEpisode]="result"></app-episode-image>
             <p>{{result.displayDescription}}</p>
-            <app-episode-status [episode]="result" [editable]="true" [disabled]="isUpdating(result.id)"
+            <app-episode-status [episode]="result" [editable]="true"
+                [disabled]="isUpdating(result.id) && !isLoadingIgnored(result.id) && !isLoadingRemoved(result.id)"
+                [loadingIgnored]="isLoadingIgnored(result.id)" [loadingRemoved]="isLoadingRemoved(result.id)"
                 (toggleIgnored)="toggleIgnored(result)" (toggleRemoved)="toggleRemoved(result)"></app-episode-status>
         </mat-card-content>
         <mat-card-actions>

--- a/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.html
+++ b/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.html
@@ -109,18 +109,20 @@
         </mat-card-content>
         <mat-card-actions class="review-actions">
             <app-episode-podcast-links [episode]="result"></app-episode-podcast-links>
-            <mat-card-footer class="subjects">
-                <app-subjects [subjects]="result.subjects!" [showHidden]="true" [editable]="true"
-                    [disabled]="isUpdating(result.id)" (removeSubject)="removeSubject(result, $event)"></app-subjects>
-            </mat-card-footer>
-            @if ((result.guestPeople?.length ?? 0) > 0 || (result.guestSuggestions?.length ?? 0) > 0) {
-            <mat-card-footer class="guests">
-                <app-episode-guests [guestPeople]="result.guestPeople" [guestSuggestions]="result.guestSuggestions"
-                    [editable]="true" [disabled]="isUpdating(result.id)" [loadingGuestName]="loadingGuestName(result.id)"
-                    (removeGuest)="removeGuest(result, $event)"
-                    (addSuggestedGuest)="addSuggestedGuest(result, $event)"></app-episode-guests>
-            </mat-card-footer>
-            }
+            <div class="footer-column">
+                <mat-card-footer class="subjects">
+                    <app-subjects [subjects]="result.subjects!" [showHidden]="true" [editable]="true"
+                        [disabled]="isUpdating(result.id)" (removeSubject)="removeSubject(result, $event)"></app-subjects>
+                </mat-card-footer>
+                @if ((result.guestPeople?.length ?? 0) > 0 || (result.guestSuggestions?.length ?? 0) > 0) {
+                <mat-card-footer class="guests">
+                    <app-episode-guests [guestPeople]="result.guestPeople" [guestSuggestions]="result.guestSuggestions"
+                        [editable]="true" [disabled]="isUpdating(result.id)" [loadingGuestName]="loadingGuestName(result.id)"
+                        (removeGuest)="removeGuest(result, $event)"
+                        (addSuggestedGuest)="addSuggestedGuest(result, $event)"></app-episode-guests>
+                </mat-card-footer>
+                }
+            </div>
         </mat-card-actions>
     </mat-card>
     }

--- a/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.html
+++ b/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.html
@@ -107,7 +107,7 @@
                 (toggleIgnored)="toggleIgnored(result)" (toggleRemoved)="toggleRemoved(result)"
                 (toggleTweeted)="toggleTweeted(result)" (toggleBluesky)="toggleBluesky(result)"></app-episode-status>
         </mat-card-content>
-        <mat-card-actions>
+        <mat-card-actions class="review-actions">
             <app-episode-podcast-links [episode]="result"></app-episode-podcast-links>
             <mat-card-footer class="subjects">
                 <app-subjects [subjects]="result.subjects!" [showHidden]="true" [editable]="true"

--- a/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.html
+++ b/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.html
@@ -116,7 +116,8 @@
             @if ((result.guestPeople?.length ?? 0) > 0 || (result.guestSuggestions?.length ?? 0) > 0) {
             <mat-card-footer class="guests">
                 <app-episode-guests [guestPeople]="result.guestPeople" [guestSuggestions]="result.guestSuggestions"
-                    [editable]="true" [disabled]="isUpdating(result.id)" (removeGuest)="removeGuest(result, $event)"
+                    [editable]="true" [disabled]="isUpdating(result.id)" [loadingGuestName]="loadingGuestName(result.id)"
+                    (removeGuest)="removeGuest(result, $event)"
                     (addSuggestedGuest)="addSuggestedGuest(result, $event)"></app-episode-guests>
             </mat-card-footer>
             }

--- a/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.html
+++ b/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.html
@@ -100,15 +100,17 @@
         <mat-card-content class="resultdescription">
             <app-episode-image [apiEpisode]="result"></app-episode-image>
             <p>{{result.displayDescription}}</p>
-            <app-episode-status [episode]="result" [editable]="true"
-                [disabled]="isUpdating(result.id) && !isStatusActionLoading(result.id)"
-                [loadingIgnored]="isLoadingIgnored(result.id)" [loadingRemoved]="isLoadingRemoved(result.id)"
-                [loadingTweeted]="isLoadingTweeted(result.id)" [loadingBluesky]="isLoadingBluesky(result.id)"
-                (toggleIgnored)="toggleIgnored(result)" (toggleRemoved)="toggleRemoved(result)"
-                (toggleTweeted)="toggleTweeted(result)" (toggleBluesky)="toggleBluesky(result)"></app-episode-status>
         </mat-card-content>
         <mat-card-actions class="review-actions">
-            <app-episode-podcast-links [episode]="result"></app-episode-podcast-links>
+            <div class="icon-column">
+                <app-episode-status [episode]="result" [editable]="true"
+                    [disabled]="isUpdating(result.id) && !isStatusActionLoading(result.id)"
+                    [loadingIgnored]="isLoadingIgnored(result.id)" [loadingRemoved]="isLoadingRemoved(result.id)"
+                    [loadingTweeted]="isLoadingTweeted(result.id)" [loadingBluesky]="isLoadingBluesky(result.id)"
+                    (toggleIgnored)="toggleIgnored(result)" (toggleRemoved)="toggleRemoved(result)"
+                    (toggleTweeted)="toggleTweeted(result)" (toggleBluesky)="toggleBluesky(result)"></app-episode-status>
+                <app-episode-podcast-links [episode]="result"></app-episode-podcast-links>
+            </div>
             <div class="footer-column">
                 <mat-card-footer class="subjects">
                     <app-subjects [subjects]="result.subjects!" [showHidden]="true" [editable]="true"

--- a/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.sass
+++ b/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.sass
@@ -36,13 +36,24 @@ mat-card-header
 #error
     margin-left: 12px
 app-episode-podcast-links
-    display: inherit
+    display: flex
+    flex-wrap: wrap
     flex: 0 0 auto
+// Two-column actions row: left = icon column (status + podcast-service icons),
+// right = footer column (subjects then people). They sit SIDE BY SIDE so the
+// subjects/people footer wraps to the right of the whole icon stack rather than
+// dropping beneath it.
 mat-card-actions
+    display: flex
     flex-wrap: wrap
     align-items: flex-start
-// Footer (subjects + people) wraps to the RIGHT of the podcast-service icon
-// column instead of dropping onto a new full-width row beneath them.
+.icon-column
+    flex: 0 0 auto
+    display: flex
+    flex-direction: column
+    align-items: flex-start
+    app-episode-podcast-links
+        margin-top: 8px
 .footer-column
     flex: 1 1 auto
     min-width: 55%

--- a/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.sass
+++ b/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.sass
@@ -41,9 +41,18 @@ app-episode-podcast-links
 mat-card-actions
     flex-wrap: wrap
     align-items: flex-start
+// Footer (subjects + people) wraps to the RIGHT of the podcast-service icon
+// column instead of dropping onto a new full-width row beneath them.
+.footer-column
+    flex: 1 1 auto
+    min-width: 55%
+    display: flex
+    flex-direction: column
+    align-items: stretch
+    box-sizing: border-box
 mat-card-footer.subjects,
 mat-card-footer.guests
-    flex: 1 1 100%
+    flex: 0 0 auto
     width: 100%
     max-width: 100%
     margin-left: 0

--- a/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.sass
+++ b/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.sass
@@ -37,3 +37,14 @@ mat-card-header
     margin-left: 12px
 app-episode-podcast-links
     display: inherit
+    flex: 0 0 auto
+mat-card-actions
+    flex-wrap: wrap
+    align-items: flex-start
+mat-card-footer.subjects,
+mat-card-footer.guests
+    flex: 1 1 100%
+    width: 100%
+    max-width: 100%
+    margin-left: 0
+    box-sizing: border-box

--- a/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.ts
+++ b/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.ts
@@ -78,6 +78,7 @@ export class OutgoingEpisodesApiComponent {
   authRoles: string[] = [];
   updatingEpisodeId: string | null = null;
   updatingFlag: 'ignored' | 'removed' | 'tweeted' | 'bluesky' | null = null;
+  addingGuest: { [episodeId: string]: string } = {};
 
   constructor(
     protected auth: AuthServiceWrapper,
@@ -231,7 +232,42 @@ export class OutgoingEpisodesApiComponent {
   }
 
   addSuggestedGuest(episode: ApiEpisode, guestName: string) {
-    this.runEpisodeUpdate(episode, () => this.episodeUpdate.addGuest(episode, guestName));
+    if (this.isUpdating(episode.id) || this.addingGuest[episode.id]) {
+      return;
+    }
+    const suggestion = episode.guestSuggestions?.find(x => x.person.name === guestName);
+    if (!suggestion) {
+      return;
+    }
+    const previousGuests = episode.guestPeople ? [...episode.guestPeople] : [];
+    const previousSuggestions = episode.guestSuggestions ? [...episode.guestSuggestions] : [];
+    const previousGuestNames = this.episodeUpdate.getGuestNames(episode);
+
+    episode.guestPeople = [...previousGuests, suggestion.person];
+    episode.guestSuggestions = previousSuggestions.filter(x => x.person.name !== guestName);
+    this.addingGuest[episode.id] = guestName;
+
+    const nextGuestNames = previousGuestNames.includes(guestName)
+      ? previousGuestNames
+      : [...previousGuestNames, guestName];
+
+    this.episodeUpdate.setGuests(episode, nextGuestNames)
+      .then(updated => {
+        this.episodes = this.episodeUpdate.replaceEpisode(this.episodes, updated);
+      })
+      .catch(e => {
+        console.error(e);
+        episode.guestPeople = previousGuests;
+        episode.guestSuggestions = previousSuggestions;
+        this.snackBar.open("Failed to add guest", "Ok", { duration: 5000 });
+      })
+      .finally(() => {
+        delete this.addingGuest[episode.id];
+      });
+  }
+
+  loadingGuestName(episodeId: string): string | null {
+    return this.addingGuest[episodeId] ?? null;
   }
 
   toggleIgnored(episode: ApiEpisode) {

--- a/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.ts
+++ b/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.ts
@@ -30,6 +30,8 @@ import { EpisodePublishResponseSnackbarComponent } from '../episode-publish-resp
 import { PostEpisodeDialogResponse } from '../post-episode-dialog-response.interface';
 import { EpisodeGuestsComponent } from '../episode-guests/episode-guests.component';
 import { EpisodeUpdateService } from '../episode-update.service';
+import { FeatureSwitch } from '../feature-switch.enum';
+import { FeatureSwtichService } from '../feature-switch-service';
 
 const sortParamDateAsc: string = "date-asc";
 const sortParamDateDesc: string = "date-desc";
@@ -60,6 +62,7 @@ const daysKey: string = "pref.outgoing-episodes.days";
 export class OutgoingEpisodesApiComponent {
   sortParamDateAsc: string = sortParamDateAsc;
   sortParamDateDesc: string = sortParamDateDesc;
+  protected FeatureSwitch = FeatureSwitch;
 
   episodes: ApiEpisode[] | undefined;
   error: boolean = false;
@@ -73,7 +76,7 @@ export class OutgoingEpisodesApiComponent {
   token: string = "";
   authRoles: string[] = [];
   updatingEpisodeId: string | null = null;
-  updatingFlag: 'ignored' | 'removed' | null = null;
+  updatingFlag: 'ignored' | 'removed' | 'tweeted' | 'bluesky' | null = null;
 
   constructor(
     protected auth: AuthServiceWrapper,
@@ -82,7 +85,8 @@ export class OutgoingEpisodesApiComponent {
     private dialog: MatDialog,
     private snackBar: MatSnackBar,
     private siteService: SiteService,
-    private episodeUpdate: EpisodeUpdateService
+    private episodeUpdate: EpisodeUpdateService,
+    protected featureSwtichService: FeatureSwtichService
   ) {
     this.auth.roles.subscribe(roles => this.authRoles = roles);
   }
@@ -170,6 +174,21 @@ export class OutgoingEpisodesApiComponent {
     return this.isUpdating(episodeId) && this.updatingFlag === 'removed';
   }
 
+  isLoadingTweeted(episodeId: string): boolean {
+    return this.isUpdating(episodeId) && this.updatingFlag === 'tweeted';
+  }
+
+  isLoadingBluesky(episodeId: string): boolean {
+    return this.isUpdating(episodeId) && this.updatingFlag === 'bluesky';
+  }
+
+  isStatusActionLoading(episodeId: string): boolean {
+    return this.isLoadingIgnored(episodeId)
+      || this.isLoadingRemoved(episodeId)
+      || this.isLoadingTweeted(episodeId)
+      || this.isLoadingBluesky(episodeId);
+  }
+
   async refreshEpisode(episodeId: string) {
     try {
       const updated = await this.episodeUpdate.fetchEpisode(episodeId);
@@ -182,7 +201,7 @@ export class OutgoingEpisodesApiComponent {
   private async runEpisodeUpdate(
     episode: ApiEpisode,
     action: () => Promise<ApiEpisode>,
-    flag: 'ignored' | 'removed' | null = null
+    flag: 'ignored' | 'removed' | 'tweeted' | 'bluesky' | null = null
   ) {
     if (this.isUpdating(episode.id)) {
       return;
@@ -256,6 +275,38 @@ export class OutgoingEpisodesApiComponent {
     });
   }
 
+  toggleTweeted(episode: ApiEpisode) {
+    if (this.isUpdating(episode.id)) {
+      return;
+    }
+    const previous = episode.tweeted;
+    const next = !previous;
+    episode.tweeted = next;
+    this.runEpisodeUpdate(
+      episode,
+      () => next ? this.episodeUpdate.markTweeted(episode) : this.episodeUpdate.untweet(episode),
+      'tweeted'
+    ).catch(() => {
+      episode.tweeted = previous;
+    });
+  }
+
+  toggleBluesky(episode: ApiEpisode) {
+    if (this.isUpdating(episode.id)) {
+      return;
+    }
+    const previous = episode.bluesky == true;
+    const next = !previous;
+    episode.bluesky = next;
+    this.runEpisodeUpdate(
+      episode,
+      () => next ? this.episodeUpdate.postBluesky(episode) : this.episodeUpdate.unpostBluesky(episode),
+      'bluesky'
+    ).catch(() => {
+      episode.bluesky = previous;
+    });
+  }
+
   post(podcastId: string, episodeId: string) {
     const dialogRef = this.dialog
       .open<PostEpisodeDialogComponent, any, PostEpisodeDialogResponse>(PostEpisodeDialogComponent, {
@@ -292,7 +343,7 @@ export class OutgoingEpisodesApiComponent {
       url.searchParams.append("days", this.days.toString());
     if (this.tweeted)
       url.searchParams.append("tweeted", this.tweeted.toString());
-    if (this.posted)
+    if (this.featureSwtichService.IsEnabled(FeatureSwitch.redditPost) && this.posted)
       url.searchParams.append("posted", this.posted.toString());
     if (this.blueskyPosted)
       url.searchParams.append("blueskyPosted", this.blueskyPosted.toString())

--- a/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.ts
+++ b/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.ts
@@ -218,15 +218,20 @@ export class OutgoingEpisodesApiComponent {
     if (this.isUpdating(episode.id)) {
       return;
     }
-    const previous = episode.ignored;
-    const next = !previous;
+    const previousIgnored = episode.ignored;
+    const previousRemoved = episode.removed;
+    const next = !previousIgnored;
     episode.ignored = next;
+    if (next) {
+      episode.removed = false;
+    }
     this.runEpisodeUpdate(
       episode,
       () => this.episodeUpdate.toggleIgnored(episode, next),
       'ignored'
     ).catch(() => {
-      episode.ignored = previous;
+      episode.ignored = previousIgnored;
+      episode.removed = previousRemoved;
     });
   }
 
@@ -234,15 +239,20 @@ export class OutgoingEpisodesApiComponent {
     if (this.isUpdating(episode.id)) {
       return;
     }
-    const previous = episode.removed;
-    const next = !previous;
+    const previousIgnored = episode.ignored;
+    const previousRemoved = episode.removed;
+    const next = !previousRemoved;
     episode.removed = next;
+    if (next) {
+      episode.ignored = false;
+    }
     this.runEpisodeUpdate(
       episode,
       () => this.episodeUpdate.toggleRemoved(episode, next),
       'removed'
     ).catch(() => {
-      episode.removed = previous;
+      episode.ignored = previousIgnored;
+      episode.removed = previousRemoved;
     });
   }
 

--- a/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.ts
+++ b/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.ts
@@ -73,6 +73,7 @@ export class OutgoingEpisodesApiComponent {
   token: string = "";
   authRoles: string[] = [];
   updatingEpisodeId: string | null = null;
+  updatingFlag: 'ignored' | 'removed' | null = null;
 
   constructor(
     protected auth: AuthServiceWrapper,
@@ -161,6 +162,14 @@ export class OutgoingEpisodesApiComponent {
     return this.updatingEpisodeId === episodeId;
   }
 
+  isLoadingIgnored(episodeId: string): boolean {
+    return this.isUpdating(episodeId) && this.updatingFlag === 'ignored';
+  }
+
+  isLoadingRemoved(episodeId: string): boolean {
+    return this.isUpdating(episodeId) && this.updatingFlag === 'removed';
+  }
+
   async refreshEpisode(episodeId: string) {
     try {
       const updated = await this.episodeUpdate.fetchEpisode(episodeId);
@@ -170,19 +179,26 @@ export class OutgoingEpisodesApiComponent {
     }
   }
 
-  private async runEpisodeUpdate(episode: ApiEpisode, action: () => Promise<ApiEpisode>) {
+  private async runEpisodeUpdate(
+    episode: ApiEpisode,
+    action: () => Promise<ApiEpisode>,
+    flag: 'ignored' | 'removed' | null = null
+  ) {
     if (this.isUpdating(episode.id)) {
       return;
     }
     this.updatingEpisodeId = episode.id;
+    this.updatingFlag = flag;
     try {
       const updated = await action();
       this.episodes = this.episodeUpdate.replaceEpisode(this.episodes, updated);
     } catch (e) {
       console.error(e);
       this.snackBar.open("Failed to update episode", "Ok", { duration: 5000 });
+      throw e;
     } finally {
       this.updatingEpisodeId = null;
+      this.updatingFlag = null;
     }
   }
 
@@ -199,11 +215,35 @@ export class OutgoingEpisodesApiComponent {
   }
 
   toggleIgnored(episode: ApiEpisode) {
-    this.runEpisodeUpdate(episode, () => this.episodeUpdate.toggleIgnored(episode));
+    if (this.isUpdating(episode.id)) {
+      return;
+    }
+    const previous = episode.ignored;
+    const next = !previous;
+    episode.ignored = next;
+    this.runEpisodeUpdate(
+      episode,
+      () => this.episodeUpdate.toggleIgnored(episode, next),
+      'ignored'
+    ).catch(() => {
+      episode.ignored = previous;
+    });
   }
 
   toggleRemoved(episode: ApiEpisode) {
-    this.runEpisodeUpdate(episode, () => this.episodeUpdate.toggleRemoved(episode));
+    if (this.isUpdating(episode.id)) {
+      return;
+    }
+    const previous = episode.removed;
+    const next = !previous;
+    episode.removed = next;
+    this.runEpisodeUpdate(
+      episode,
+      () => this.episodeUpdate.toggleRemoved(episode, next),
+      'removed'
+    ).catch(() => {
+      episode.removed = previous;
+    });
   }
 
   post(podcastId: string, episodeId: string) {

--- a/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.ts
+++ b/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.ts
@@ -32,6 +32,7 @@ import { EpisodeGuestsComponent } from '../episode-guests/episode-guests.compone
 import { EpisodeUpdateService } from '../episode-update.service';
 import { FeatureSwitch } from '../feature-switch.enum';
 import { FeatureSwtichService } from '../feature-switch-service';
+import { ManualTweetEpisodeDialogComponent } from '../manual-tweet-episode-dialog/manual-tweet-episode-dialog.component';
 
 const sortParamDateAsc: string = "date-asc";
 const sortParamDateDesc: string = "date-desc";
@@ -279,16 +280,66 @@ export class OutgoingEpisodesApiComponent {
     if (this.isUpdating(episode.id)) {
       return;
     }
-    const previous = episode.tweeted;
-    const next = !previous;
-    episode.tweeted = next;
-    this.runEpisodeUpdate(
-      episode,
-      () => next ? this.episodeUpdate.markTweeted(episode) : this.episodeUpdate.untweet(episode),
-      'tweeted'
-    ).catch(() => {
-      episode.tweeted = previous;
-    });
+    if (episode.tweeted) {
+      const previous = episode.tweeted;
+      episode.tweeted = false;
+      this.runEpisodeUpdate(
+        episode,
+        () => this.episodeUpdate.untweet(episode),
+        'tweeted'
+      ).catch(() => {
+        episode.tweeted = previous;
+      });
+      return;
+    }
+    this.runManualTweet(episode);
+  }
+
+  private async runManualTweet(episode: ApiEpisode) {
+    if (this.isUpdating(episode.id)) {
+      return;
+    }
+    if (!episode.podcastId) {
+      this.snackBar.open("Episode podcastId is required to tweet", "Ok", { duration: 5000 });
+      return;
+    }
+    this.updatingEpisodeId = episode.id;
+    this.updatingFlag = 'tweeted';
+    try {
+      const result = await this.episodeUpdate.publishTweet(episode);
+      if (result.tweeted) {
+        const updated = await this.episodeUpdate.fetchEpisode(episode.id);
+        this.episodes = this.episodeUpdate.replaceEpisode(this.episodes, updated);
+        return;
+      }
+      if (result.failedTweetContent) {
+        const dialogRef = this.dialog.open<ManualTweetEpisodeDialogComponent, { tweet: string, episodeId: string, podcastId: string }, any>(
+          ManualTweetEpisodeDialogComponent,
+          {
+            data: {
+              tweet: result.failedTweetContent,
+              episodeId: episode.id,
+              podcastId: episode.podcastId
+            },
+            disableClose: true,
+            autoFocus: true
+          }
+        );
+        const dialogResult = await firstValueFrom(dialogRef.afterClosed());
+        if (dialogResult?.updated) {
+          const updated = await this.episodeUpdate.fetchEpisode(episode.id);
+          this.episodes = this.episodeUpdate.replaceEpisode(this.episodes, updated);
+        }
+        return;
+      }
+      this.snackBar.open("Failed to tweet", "Ok", { duration: 5000 });
+    } catch (e) {
+      console.error(e);
+      this.snackBar.open("Failed to tweet", "Ok", { duration: 5000 });
+    } finally {
+      this.updatingEpisodeId = null;
+      this.updatingFlag = null;
+    }
   }
 
   toggleBluesky(episode: ApiEpisode) {

--- a/cultpodcasts/src/app/subjects/subjects.component.sass
+++ b/cultpodcasts/src/app/subjects/subjects.component.sass
@@ -7,7 +7,7 @@
         padding-left: 8px
         padding-bottom: 6px
         display: inline-flex
-        align-items: center
+        align-items: baseline
         gap: 0
         a
             color: var(--mat-theme-text-secondary)
@@ -16,10 +16,19 @@
         a:hover 
             text-decoration: none
         .remove-btn
-            width: 28px
-            height: 28px
-            line-height: 28px
+            --mdc-icon-button-state-layer-size: 22px
+            --mdc-icon-button-icon-size: 14px
+            width: 22px
+            height: 22px
+            padding: 0
+            margin: 0 0 0 1px
+            line-height: 1
+            vertical-align: baseline
+            display: inline-flex
+            align-items: center
+            justify-content: center
             mat-icon
-                font-size: 16px
-                width: 16px
-                height: 16px
+                font-size: 14px
+                width: 14px
+                height: 14px
+                line-height: 14px

--- a/cultpodcasts/src/app/subjects/subjects.component.sass
+++ b/cultpodcasts/src/app/subjects/subjects.component.sass
@@ -6,7 +6,8 @@
     .subject
         padding-left: 8px
         padding-bottom: 6px
-        display: inline-flex
+        display: flex
+        justify-content: flex-end
         align-items: baseline
         gap: 0
         a

--- a/cultpodcasts/src/app/subjects/subjects.component.sass
+++ b/cultpodcasts/src/app/subjects/subjects.component.sass
@@ -1,26 +1,10 @@
-// Public pages (non-editable) use the historical dd9dd09 inline layout: the host
-// shrinks to content and is right-aligned by the footer's text-align, subjects
-// flow inline and wrap. Review/outgoing (editable) stack one-per-line via
-// :host(.editable).
+// Subjects always stack one-per-line, on both public and editable (review/
+// outgoing) cards. The remove X only renders when editable (template @if
+// editable), so public pages get the same stacked names without the button.
 :host
     text-align: right
     padding-right: 2px
     margin-left: auto
-    display: inline-block
-    .subject
-        padding-left: 8px
-        padding-bottom: 6px
-        display: inline-flex
-        align-items: center
-        gap: 0
-        a
-            color: var(--mat-theme-text-secondary)
-            text-decoration: dashed underline 1px
-            text-underline-offset: 5px
-        a:hover
-            text-decoration: none
-
-:host(.editable)
     display: flex
     flex-direction: column
     align-items: stretch
@@ -34,8 +18,16 @@
         align-self: stretch
         width: 100%
         box-sizing: border-box
+        padding-left: 8px
+        padding-bottom: 6px
+        gap: 0
         a
+            color: var(--mat-theme-text-secondary)
+            text-decoration: dashed underline 1px
+            text-underline-offset: 5px
             line-height: 1.25
+        a:hover
+            text-decoration: none
         .remove-btn
             --mdc-icon-button-state-layer-size: 20px
             --mdc-icon-button-icon-size: 14px

--- a/cultpodcasts/src/app/subjects/subjects.component.sass
+++ b/cultpodcasts/src/app/subjects/subjects.component.sass
@@ -1,7 +1,26 @@
+// Public pages (non-editable) use the historical dd9dd09 inline layout: the host
+// shrinks to content and is right-aligned by the footer's text-align, subjects
+// flow inline and wrap. Review/outgoing (editable) stack one-per-line via
+// :host(.editable).
 :host
     text-align: right
     padding-right: 2px
     margin-left: auto
+    display: inline-block
+    .subject
+        padding-left: 8px
+        padding-bottom: 6px
+        display: inline-flex
+        align-items: center
+        gap: 0
+        a
+            color: var(--mat-theme-text-secondary)
+            text-decoration: dashed underline 1px
+            text-underline-offset: 5px
+        a:hover
+            text-decoration: none
+
+:host(.editable)
     display: flex
     flex-direction: column
     align-items: stretch
@@ -15,16 +34,8 @@
         align-self: stretch
         width: 100%
         box-sizing: border-box
-        padding-left: 8px
-        padding-bottom: 6px
-        gap: 0
         a
-            color: var(--mat-theme-text-secondary)
-            text-decoration: dashed underline 1px
-            text-underline-offset: 5px
             line-height: 1.25
-        a:hover
-            text-decoration: none
         .remove-btn
             --mdc-icon-button-state-layer-size: 20px
             --mdc-icon-button-icon-size: 14px

--- a/cultpodcasts/src/app/subjects/subjects.component.ts
+++ b/cultpodcasts/src/app/subjects/subjects.component.ts
@@ -11,10 +11,7 @@ import { MatIconModule } from '@angular/material/icon';
     MatIconModule
   ],
   templateUrl: './subjects.component.html',
-  styleUrl: './subjects.component.sass',
-  host: {
-    '[class.editable]': 'editable'
-  }
+  styleUrl: './subjects.component.sass'
 })
 export class SubjectsComponent {
   @Input({ required: true })

--- a/cultpodcasts/src/app/subjects/subjects.component.ts
+++ b/cultpodcasts/src/app/subjects/subjects.component.ts
@@ -11,7 +11,10 @@ import { MatIconModule } from '@angular/material/icon';
     MatIconModule
   ],
   templateUrl: './subjects.component.html',
-  styleUrl: './subjects.component.sass'
+  styleUrl: './subjects.component.sass',
+  host: {
+    '[class.editable]': 'editable'
+  }
 })
 export class SubjectsComponent {
   @Input({ required: true })

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -51,6 +51,21 @@ mat-card-actions.review-actions {
     margin-top: 14px;
 }
 
+// Public result cards (every non-editable mat-card-actions: homepage, search,
+// podcast, subject, episode, bookmarks, discovery). Subjects get their own
+// full-width row ordered ABOVE the podcast-service buttons — i.e. directly under
+// the description — while chips flow inline (app-subjects :host is inline-block).
+mat-card-actions:not(.review-actions) {
+    flex-wrap: wrap;
+
+    mat-card-footer.subjects {
+        order: -1;
+        flex-basis: 100%;
+        width: 100%;
+        margin-bottom: 6px;
+    }
+}
+
 #cta-button {
     text-align: center;
     margin-bottom: 1rem;

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -36,12 +36,22 @@ p {
     line-height: 1.3em;
 }
 
-mat-card-footer.subjects {
+mat-card-footer.subjects,
+mat-card-footer.guests {
+    flex: 1 1 100%;
     width: 100%;
+    max-width: 100%;
+    margin-left: 0;
     text-align: right;
     display: flex;
     flex-direction: column;
     align-items: stretch;
+    box-sizing: border-box;
+}
+
+mat-card-actions {
+    flex-wrap: wrap;
+    align-items: flex-start;
 }
 
 #cta-button {

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -54,6 +54,31 @@ mat-card-actions {
     align-items: flex-start;
 }
 
+// Review (/episodes) + outgoing cards only. Root cause of the "subjects pushed
+// down" band: mat-card-footer.subjects is flex 1 1 100%, so inside the wrapping
+// actions row it wraps BELOW the full-height podcast-links (YouTube) icon row.
+// Here we top-align the row and let subjects grow ALONGSIDE the YouTube icons so
+// it rises to the top of the actions block; guests still wraps to its own row.
+// margin-top separates the YouTube/podcast-service icons from the Twitter/Bluesky
+// row that sits directly above (in the status cluster).
+mat-card-actions.review-actions {
+    align-items: flex-start;
+    margin-top: 14px;
+
+    app-episode-podcast-links {
+        flex: 0 0 auto;
+    }
+
+    mat-card-footer.subjects {
+        flex: 1 1 auto;
+        min-width: 55%;
+    }
+
+    mat-card-footer.guests {
+        flex: 1 1 100%;
+    }
+}
+
 #cta-button {
     text-align: center;
     margin-bottom: 1rem;

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -56,8 +56,10 @@ mat-card-actions.review-actions {
 // LEFT and the stacked subjects list on the RIGHT of the same row, top-aligned
 // so the first subject shares the buttons' top Y. Subjects stay one-per-line
 // (app-subjects :host is a right-aligned flex column, matching editable review
-// minus the remove X).
-mat-card-actions:not(.review-actions) {
+// minus the remove X). Selector qualified with `mat-card .mdc-card__actions` so
+// its specificity beats the shared `mat-card .mdc-card__actions { align-items:
+// end }` rule below (which would otherwise bottom-align the buttons).
+mat-card .mdc-card__actions:not(.review-actions) {
     flex-direction: row;
     flex-wrap: nowrap;
     align-items: flex-start;

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -54,7 +54,8 @@ mat-card-actions.review-actions {
 // Public result cards (every non-editable mat-card-actions: homepage, search,
 // podcast, subject, episode, bookmarks, discovery). Subjects get their own
 // full-width row ordered ABOVE the podcast-service buttons — i.e. directly under
-// the description — while chips flow inline (app-subjects :host is inline-block).
+// the description — with subject chips stacked one-per-line (app-subjects :host
+// is a right-aligned flex column, matching editable review minus the remove X).
 mat-card-actions:not(.review-actions) {
     flex-wrap: wrap;
 

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -52,18 +52,24 @@ mat-card-actions.review-actions {
 }
 
 // Public result cards (every non-editable mat-card-actions: homepage, search,
-// podcast, subject, episode, bookmarks, discovery). Subjects get their own
-// full-width row ordered ABOVE the podcast-service buttons — i.e. directly under
-// the description — with subject chips stacked one-per-line (app-subjects :host
-// is a right-aligned flex column, matching editable review minus the remove X).
+// podcast, subject, episode, bookmarks, discovery). Service buttons sit on the
+// LEFT and the stacked subjects list on the RIGHT of the same row, top-aligned
+// so the first subject shares the buttons' top Y. Subjects stay one-per-line
+// (app-subjects :host is a right-aligned flex column, matching editable review
+// minus the remove X).
 mat-card-actions:not(.review-actions) {
-    flex-wrap: wrap;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    align-items: flex-start;
+
+    app-episode-links {
+        flex: 0 0 auto;
+    }
 
     mat-card-footer.subjects {
-        order: -1;
-        flex-basis: 100%;
-        width: 100%;
-        margin-bottom: 6px;
+        flex: 1 1 auto;
+        width: auto;
+        margin: 0;
     }
 }
 

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -54,29 +54,13 @@ mat-card-actions {
     align-items: flex-start;
 }
 
-// Review (/episodes) + outgoing cards only. Root cause of the "subjects pushed
-// down" band: mat-card-footer.subjects is flex 1 1 100%, so inside the wrapping
-// actions row it wraps BELOW the full-height podcast-links (YouTube) icon row.
-// Here we top-align the row and let subjects grow ALONGSIDE the YouTube icons so
-// it rises to the top of the actions block; guests still wraps to its own row.
-// margin-top separates the YouTube/podcast-service icons from the Twitter/Bluesky
-// row that sits directly above (in the status cluster).
+// Review (/episodes) + outgoing cards only. margin-top separates the podcast-
+// service icons (YouTube etc.) from the Twitter/Bluesky row in the status
+// cluster above. The subjects/people footer-column layout (footer wraps to the
+// RIGHT of the icon column) lives in the two components' scoped sass.
 mat-card-actions.review-actions {
     align-items: flex-start;
     margin-top: 14px;
-
-    app-episode-podcast-links {
-        flex: 0 0 auto;
-    }
-
-    mat-card-footer.subjects {
-        flex: 1 1 auto;
-        min-width: 55%;
-    }
-
-    mat-card-footer.guests {
-        flex: 1 1 100%;
-    }
 }
 
 #cta-button {

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -38,26 +38,14 @@ p {
 
 mat-card-footer.subjects,
 mat-card-footer.guests {
-    flex: 1 1 100%;
     width: 100%;
-    max-width: 100%;
-    margin-left: 0;
     text-align: right;
-    display: flex;
-    flex-direction: column;
-    align-items: stretch;
-    box-sizing: border-box;
-}
-
-mat-card-actions {
-    flex-wrap: wrap;
-    align-items: flex-start;
 }
 
 // Review (/episodes) + outgoing cards only. margin-top separates the podcast-
 // service icons (YouTube etc.) from the Twitter/Bluesky row in the status
-// cluster above. The subjects/people footer-column layout (footer wraps to the
-// RIGHT of the icon column) lives in the two components' scoped sass.
+// cluster above. The two-column actions layout (icons left, subjects/people
+// right) and its flex-wrap live in the two components' scoped sass.
 mat-card-actions.review-actions {
     align-items: flex-start;
     margin-top: 14px;

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -250,8 +250,8 @@ mat-card:not(.selected) {
 }
 
 mat-card-actions {
-    a[mat-icon-button]:not(.remove-btn),
-    button[mat-icon-button]:not(.remove-btn) {
+    a[mat-icon-button]:not(.remove-btn):not(.add-btn),
+    button[mat-icon-button]:not(.remove-btn):not(.add-btn) {
         margin-right: 25px;
         transform: scale(1.2);
     }
@@ -260,8 +260,8 @@ mat-card-actions {
 @media screen and (max-width: 600px) {
     mat-card-actions {
 
-        a[mat-icon-button]:not(.remove-btn),
-        button[mat-icon-button]:not(.remove-btn) {
+        a[mat-icon-button]:not(.remove-btn):not(.add-btn),
+        button[mat-icon-button]:not(.remove-btn):not(.add-btn) {
             margin-right: 18px;
         }
     }
@@ -276,8 +276,8 @@ mat-card-actions {
 @media screen and (max-width: 400px) {
     mat-card-actions {
 
-        a[mat-icon-button]:not(.remove-btn),
-        button[mat-icon-button]:not(.remove-btn) {
+        a[mat-icon-button]:not(.remove-btn):not(.add-btn),
+        button[mat-icon-button]:not(.remove-btn):not(.add-btn) {
             margin-right: 12px;
         }
     }


### PR DESCRIPTION
## Summary

Polishes the review (`/episodes`) and outgoing episode card UI from #415: tighter subject/guest remove (X) controls, guest **names only** (no handles or match metadata), ignore/removed icons on a separate row from social share icons, and optimistic toggle + spinner while the API confirms.

## Changes

- Shrink subject and guest remove `mat-icon-button` (22px layer / 14px icon) and baseline-align with dashed underline text
- `app-episode-guests`: render `person.name` / `suggestion.person.name` only (drop Twitter/Bluesky handles and match-term suffixes)
- Split `app-episode-status` into a social row (Reddit/Twitter/Bluesky) and a flags row (ignored/removed)
- Optimistically flip ignored/removed icons on click; overlay `mat-spinner` until HTTP succeeds; revert icon on failure
- Bump package version `1.9.911` → `1.9.912`

## Test plan

- [ ] On `/episodes` review card: subject X icons sit inline with subject text (not vertically offset); hit target still usable on mobile
- [ ] Guests row shows **names only** — no `(@handle)` or match-term clutter; suggested guests likewise name-only + Add
- [ ] Social icons (Reddit/Twitter/Bluesky) on one row; eye + removed icons on a row below
- [ ] Click ignored: icon flips immediately and shows spinner until request completes
- [ ] Click removed: same optimistic + spinner behaviour
- [ ] Force/API error (or offline): icon reverts and snackbar shows failure
- [ ] Same checks on Outgoing episodes cards
