### PR TITLE
Fix Person Organization checkbox end-to-end

### DIFF
--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.911",
+  "version": "1.9.912",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/src/app/edit-person-dialog/edit-person-dialog.component.ts
+++ b/cultpodcasts/src/app/edit-person-dialog/edit-person-dialog.component.ts
@@ -19,6 +19,7 @@ import {
   getEffectiveSortKey,
   guessSortName,
   looksLikeOrganization,
+  organizationSortName,
   sortNameForPersist,
   stripLeadingThe
 } from '../person-sort';
@@ -69,7 +70,10 @@ export class EditPersonDialogComponent {
     if (this.create) {
       this.originalPerson = { id: '', name: '' };
       const initialName = this.personName ?? '';
-      const initialGuess = guessSortName(initialName);
+      const initialOrg = looksLikeOrganization(initialName);
+      const initialGuess = initialOrg
+        ? organizationSortName(initialName)
+        : guessSortName(initialName);
       this.form = new FormGroup<PersonForm>({
         name: new FormControl(initialName, { nonNullable: true, validators: [Validators.required] }),
         sortName: new FormControl(initialGuess, { nonNullable: false }),
@@ -77,12 +81,10 @@ export class EditPersonDialogComponent {
         twitterHandle: new FormControl('', { nonNullable: false }),
         blueskyHandle: new FormControl('', { nonNullable: false })
       });
-      this.useFullNameForSorting.setValue(
-        !!initialGuess && looksLikeOrganization(initialName),
-        { emitEvent: false }
-      );
+      this.useFullNameForSorting.setValue(initialOrg, { emitEvent: false });
       this.sortNameManuallyEdited = false;
       this.wireSortControls();
+      this.applySortNameEnabledState(initialOrg);
       this.isLoading = false;
       return;
     }
@@ -105,14 +107,18 @@ export class EditPersonDialogComponent {
             const name = resp.name ?? '';
             const storedSort = resp.sortName?.trim() ?? '';
             const guess = guessSortName(name);
-            const orgKey = stripLeadingThe(name.trim());
-            const isOrgFullName =
+            const orgKey = organizationSortName(name);
+            const persistedOrg = !!resp.isOrganization;
+            const heuristicOrg =
               looksLikeOrganization(name) &&
               !!storedSort &&
               (storedSort === orgKey || storedSort === name.trim());
-            const displaySort = storedSort || guess;
+            const isOrg = persistedOrg || heuristicOrg;
+            const displaySort = isOrg
+              ? (storedSort || orgKey || guess)
+              : (storedSort || guess);
             this.sortNameManuallyEdited =
-              !!storedSort && !isOrgFullName && storedSort !== guess;
+              !isOrg && !!storedSort && storedSort !== guess;
             this.form = new FormGroup<PersonForm>({
               name: new FormControl(name, { nonNullable: true, validators: [Validators.required] }),
               sortName: new FormControl(displaySort, { nonNullable: false }),
@@ -120,8 +126,9 @@ export class EditPersonDialogComponent {
               twitterHandle: new FormControl(resp.twitterHandle ?? '', { nonNullable: false }),
               blueskyHandle: new FormControl(resp.blueskyHandle ?? '', { nonNullable: false })
             });
-            this.useFullNameForSorting.setValue(isOrgFullName, { emitEvent: false });
+            this.useFullNameForSorting.setValue(isOrg, { emitEvent: false });
             this.wireSortControls();
+            this.applySortNameEnabledState(isOrg);
             this.isLoading = false;
           },
           error: e => {
@@ -135,6 +142,17 @@ export class EditPersonDialogComponent {
     });
   }
 
+  private applySortNameEnabledState(organization: boolean) {
+    if (!this.form) {
+      return;
+    }
+    if (organization) {
+      this.form.controls.sortName.disable({ emitEvent: false });
+    } else {
+      this.form.controls.sortName.enable({ emitEvent: false });
+    }
+  }
+
   private wireSortControls() {
     this.useFullNameForSorting.valueChanges.subscribe(checked => {
       if (!this.form || this.syncingSort) {
@@ -143,10 +161,11 @@ export class EditPersonDialogComponent {
       this.syncingSort = true;
       this.sortNameManuallyEdited = false;
       if (checked) {
-        this.form.controls.sortName.setValue(guessSortName(this.form.controls.name.value));
+        this.form.controls.sortName.setValue(organizationSortName(this.form.controls.name.value));
       } else {
         this.form.controls.sortName.setValue(deriveSortKeyFromName(this.form.controls.name.value));
       }
+      this.applySortNameEnabledState(!!checked);
       this.syncingSort = false;
     });
 
@@ -156,7 +175,7 @@ export class EditPersonDialogComponent {
       }
       if (this.useFullNameForSorting.value) {
         this.syncingSort = true;
-        this.form.controls.sortName.setValue(guessSortName(name));
+        this.form.controls.sortName.setValue(organizationSortName(name));
         this.syncingSort = false;
         return;
       }
@@ -167,13 +186,17 @@ export class EditPersonDialogComponent {
         const orgGuess = looksLikeOrganization(name);
         if (this.useFullNameForSorting.value !== orgGuess) {
           this.useFullNameForSorting.setValue(orgGuess, { emitEvent: false });
+          this.applySortNameEnabledState(orgGuess);
+          if (orgGuess) {
+            this.form.controls.sortName.setValue(organizationSortName(name));
+          }
         }
         this.syncingSort = false;
       }
     });
 
     this.form?.controls.sortName.valueChanges.subscribe(sortName => {
-      if (!this.form || this.syncingSort) {
+      if (!this.form || this.syncingSort || this.useFullNameForSorting.value) {
         return;
       }
       this.sortNameManuallyEdited = true;
@@ -184,6 +207,7 @@ export class EditPersonDialogComponent {
       if (this.useFullNameForSorting.value !== isOrg) {
         this.syncingSort = true;
         this.useFullNameForSorting.setValue(isOrg);
+        this.applySortNameEnabledState(isOrg);
         this.syncingSort = false;
       }
     });
@@ -250,15 +274,17 @@ export class EditPersonDialogComponent {
     }
 
     const name = this.translateForEntity(this.form!.controls.name)!;
+    const isOrganization = this.useFullNameForSorting.value;
     const persistedSort = sortNameForPersist(
       name,
       this.form!.controls.sortName.value,
-      this.useFullNameForSorting.value
+      isOrganization
     );
     const update: Person = {
       id: this.personId ?? '',
       name,
       sortName: persistedSort ?? '',
+      isOrganization,
       aliases: this.translateForEntityA(this.form!.controls.aliases),
       twitterHandle: this.translateForEntity(this.form!.controls.twitterHandle),
       blueskyHandle: this.translateForEntity(this.form!.controls.blueskyHandle)
@@ -295,11 +321,16 @@ export class EditPersonDialogComponent {
     return JSON.stringify(a) == JSON.stringify(b);
   }
 
+  isSameBool(a: boolean | null | undefined, b: boolean | null | undefined): boolean {
+    return !!a === !!b;
+  }
+
   getChanges(prev: Person, now: Person): Partial<Person> & { name?: string } {
     if (this.create) {
       return {
         name: now.name,
         sortName: now.sortName || null,
+        isOrganization: !!now.isOrganization,
         aliases: now.aliases,
         twitterHandle: now.twitterHandle,
         blueskyHandle: now.blueskyHandle
@@ -308,6 +339,9 @@ export class EditPersonDialogComponent {
 
     const changes: Partial<Person> = {};
     if (!this.isSame(prev.sortName, now.sortName)) changes.sortName = now.sortName ?? '';
+    if (!this.isSameBool(prev.isOrganization, now.isOrganization)) {
+      changes.isOrganization = !!now.isOrganization;
+    }
     if (!this.isSameA(prev.aliases, now.aliases)) changes.aliases = now.aliases;
     if (!this.isSame(prev.twitterHandle, now.twitterHandle)) changes.twitterHandle = now.twitterHandle ?? '';
     if (!this.isSame(prev.blueskyHandle, now.blueskyHandle)) changes.blueskyHandle = now.blueskyHandle ?? '';

--- a/cultpodcasts/src/app/person-sort.ts
+++ b/cultpodcasts/src/app/person-sort.ts
@@ -145,12 +145,23 @@ export function comparePeopleBySortKey(a: Person, b: Person): number {
 
 /**
  * Persist null ONLY when effective key equals last-token surname default.
- * Org path: StripLeadingThe(Name). Keep other overrides.
+ * Explicit useFullName (organization checkbox): always StripLeadingThe(Name).
+ * Heuristic org path: same full-name key. Keep other overrides.
  */
 export function sortNameForPersist(name: string, sortName: string | null | undefined, useFullName: boolean): string | null {
   const trimmedName = name?.trim() ?? '';
   const lastToken = deriveSortKeyFromName(trimmedName);
-  const isOrg = useFullName || looksLikeOrganization(trimmedName);
+
+  // Curator organization flag: force full-name key even when Sort name still shows a surname.
+  if (useFullName) {
+    const orgKey = stripLeadingThe(trimmedName);
+    if (!orgKey || orgKey === lastToken) {
+      return null;
+    }
+    return orgKey;
+  }
+
+  const isOrg = looksLikeOrganization(trimmedName);
   const orgKey = isOrg ? stripLeadingThe(trimmedName) : '';
 
   let effective = sortName?.trim() ?? '';
@@ -175,4 +186,9 @@ export function sortNameForPersist(name: string, sortName: string | null | undef
     return null;
   }
   return effective;
+}
+
+/** Sort-name value to show when Organization is checked (full name, strip leading The). */
+export function organizationSortName(name: string | null | undefined): string {
+  return stripLeadingThe(name?.trim() ?? '');
 }

--- a/cultpodcasts/src/app/person.interface.ts
+++ b/cultpodcasts/src/app/person.interface.ts
@@ -2,6 +2,8 @@ export interface Person {
     id: string;
     name: string;
     sortName?: string | null;
+    /** Curator flag: sort using full name; round-trips via API as isOrganization. */
+    isOrganization?: boolean | null;
     aliases?: string[] | null;
     twitterHandle?: string | null;
     blueskyHandle?: string | null;


### PR DESCRIPTION
## Summary
- Checking Organization sets Sort name to full name immediately and **disables** the Sort name input
- Persist/consume API field `isOrganization` so Edit round-trips the checkbox
- `sortNameForPersist` with org flag always stores full-name key (fixes surname-only persist for people like `Mira Voss`)
- Bump package.json to 1.9.912

Depends on RPP API PR: https://github.com/cultpodcasts/RedditPodcastPoster/pull/892

## Test plan
- [ ] Add Person, check Organization — Sort name = full Name, input disabled
- [ ] Uncheck — Sort name re-enabled with last-token derivation
- [ ] Save org person — Cosmos has `isOrganization: true` and full-name `sortName`
- [ ] Re-open Edit — checkbox checked, Sort name disabled
- [ ] Cloudflare passthrough needs no change (JSON body relay)