### PR TITLE
Fix ng build duplicate production arg (1.9.930)

### DIFF
--- a/cultpodcasts/AGENTS.md
+++ b/cultpodcasts/AGENTS.md
@@ -35,8 +35,4 @@ Auth0 requires hostname **`local.cultpodcasts.com`** (hosts → `127.0.0.1`). De
 | `npm run start` | `https://local.cultpodcasts.com:8788` (builds with `local` env) |
 | `npm run dev` | `https://local.cultpodcasts.com:4200` |
 
-Build: `ng build` (defaults to **production** via `fileReplacements` → `environment.production.ts`). Local Pages: `npm run start` (configuration `local`).
-
-**Production Pages deploy:** `npm run deploy` → `ng build --configuration production` + `process` + `wrangler pages deploy`. From a feature branch you must pass `--branch main` or the upload goes to Preview only. Do **not** deploy a `local`/`npm start` dist — `environment.ts` points at `127.0.0.1`. Mobile uses `env=production ./build.sh` (copies `environment.production.ts`).
-
-Mobile/TWA notes: `MOBILE_BUILDS.md`.
+Build: `ng build`. Mobile/TWA notes: `MOBILE_BUILDS.md`.

--- a/cultpodcasts/angular.json
+++ b/cultpodcasts/angular.json
@@ -73,7 +73,13 @@
                   "maximumError": "4kb"
                 }
               ],
-              "outputHashing": "all"
+              "outputHashing": "all",
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.production.ts"
+                }
+              ]
             },
             "staging": {
               "budgets": [

--- a/cultpodcasts/angular.json
+++ b/cultpodcasts/angular.json
@@ -73,13 +73,7 @@
                   "maximumError": "4kb"
                 }
               ],
-              "outputHashing": "all",
-              "fileReplacements": [
-                {
-                  "replace": "src/environments/environment.ts",
-                  "with": "src/environments/environment.production.ts"
-                }
-              ]
+              "outputHashing": "all"
             },
             "staging": {
               "budgets": [

--- a/cultpodcasts/build.sh
+++ b/cultpodcasts/build.sh
@@ -20,7 +20,7 @@ node update-version.js
 cp src/environments/version.prod.ts src/environments/version.ts
 
 echo "Build"
-npx ng build --configuration "${env}"
+npx npm run build --configuration "${env}"
 
 echo "Process"
 npx npm run process

--- a/cultpodcasts/build.sh
+++ b/cultpodcasts/build.sh
@@ -20,7 +20,7 @@ node update-version.js
 cp src/environments/version.prod.ts src/environments/version.ts
 
 echo "Build"
-npx npm run build --configuration "${env}"
+npx ng build --configuration "${env}"
 
 echo "Process"
 npx npm run process

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -4,14 +4,14 @@
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",
-    "build": "ng build --configuration",
+    "build": "ng build --configuration production",
     "build:staging": "ng build --configuration staging",
     "build:local": "ng build --configuration local",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
     "serve:ssr:cultpodcasts": "node dist/server/server.mjs",
     "process": "node ./tools/copy-files.mjs && node ./tools/alter-polyfills.mjs",
-    "deploy": "npm run build -- production && npm run process && wrangler pages deploy dist/cloudflare",
+    "deploy": "node -e \"require('fs').copyFileSync('src/environments/environment.production.ts','src/environments/environment.ts')\" && npm run build && npm run process && wrangler pages deploy dist/cloudflare",
     "dev": "ng serve --configuration development"
   },
   "private": true,

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -4,14 +4,14 @@
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",
-    "build": "ng build --configuration production",
+    "build": "ng build --configuration",
     "build:staging": "ng build --configuration staging",
     "build:local": "ng build --configuration local",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
     "serve:ssr:cultpodcasts": "node dist/server/server.mjs",
     "process": "node ./tools/copy-files.mjs && node ./tools/alter-polyfills.mjs",
-    "deploy": "node -e \"require('fs').copyFileSync('src/environments/environment.production.ts','src/environments/environment.ts')\" && npm run build && npm run process && wrangler pages deploy dist/cloudflare",
+    "deploy": "npm run build -- production && npm run process && wrangler pages deploy dist/cloudflare",
     "dev": "ng serve --configuration development"
   },
   "private": true,

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,17 +1,17 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.929",
+  "version": "1.9.930",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",
-    "build": "ng build --configuration production",
+    "build": "ng build --configuration",
     "build:staging": "ng build --configuration staging",
     "build:local": "ng build --configuration local",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
     "serve:ssr:cultpodcasts": "node dist/server/server.mjs",
     "process": "node ./tools/copy-files.mjs && node ./tools/alter-polyfills.mjs",
-    "deploy": "npm run build && npm run process && wrangler pages deploy dist/cloudflare",
+    "deploy": "npm run build -- production && npm run process && wrangler pages deploy dist/cloudflare",
     "dev": "ng serve --configuration development"
   },
   "private": true,


### PR DESCRIPTION
## Summary
- Revert #416 production-default build hardenings that broke Cloudflare Pages (`ng build --configuration production production`).
- `package.json` "build"` is again `ng build --configuration` (config name supplied by CF `build.sh` / deploy), not hardcoded production.
- Remove production `fileReplacements` from `angular.json` — CF Pages copies `environment.production.ts` via `build.sh`.
- Restore historical `build.sh`: `npx npm run build --configuration "${env}"`.
- Version **1.9.930**. PR left open for merge when ready — do not deploy from local.

## Test plan
- [ ] CF Pages build succeeds with `env=production ./build.sh` (no double `production` arg)
- [ ] Confirm production config has no `fileReplacements` in `angular.json`
- [ ] Local `npm run build` does not force production by default