### PR TITLE
feat(admin): Discovery Schedule dialog

### DIFF
--- a/cultpodcasts/src/app/discovery-schedule/discovery-schedule.component.html
+++ b/cultpodcasts/src/app/discovery-schedule/discovery-schedule.component.html
@@ -1,0 +1,48 @@
+<h2 mat-dialog-title>Discovery Schedule (UK)</h2>
+
+<mat-dialog-content>
+  @if (isLoading || isSaving) {
+  <mat-spinner style="margin:0 auto;" mode="indeterminate"></mat-spinner>
+  } @else {
+  @if (isInError) {
+  <p id="error">{{ errorMessage || "An error occurred" }}</p>
+  }
+
+  <p class="hint">
+    Timer checks every 30 minutes. Discovery runs when UK local time matches a selected slot
+    (±15 minutes). Defaults are 08:00 and 22:00 UK.
+  </p>
+
+  @if (isDefault) {
+  <p class="default-note">Showing code defaults — no Cosmos schedule document yet. Save to persist.</p>
+  }
+
+  <div class="enabled-row">
+    <mat-slide-toggle [(ngModel)]="enabled">Enabled</mat-slide-toggle>
+  </div>
+
+  <div class="slots" role="group" aria-label="UK run times">
+    @for (slot of slotChoices; track slot) {
+    <button type="button" class="slot"
+      [class.selected]="isSelected(slot)"
+      (click)="toggleSlot(slot)">{{ slot }}</button>
+    }
+  </div>
+
+  @if (nextRuns.length > 0) {
+  <div class="preview">
+    <h3>Next runs</h3>
+    <ul>
+      @for (run of nextRuns; track run.slotId) {
+      <li>{{ formatNextRun(run) }}</li>
+      }
+    </ul>
+  </div>
+  }
+  }
+</mat-dialog-content>
+
+<mat-dialog-actions>
+  <button mat-raised-button (click)="close()" [disabled]="isSaving">Close</button>
+  <button mat-raised-button color="primary" [disabled]="!canSave" (click)="onSave()">Save</button>
+</mat-dialog-actions>

--- a/cultpodcasts/src/app/discovery-schedule/discovery-schedule.component.sass
+++ b/cultpodcasts/src/app/discovery-schedule/discovery-schedule.component.sass
@@ -1,0 +1,42 @@
+#error
+  font-size: 1em
+  color: #b00020
+
+.hint, .default-note
+  font-size: 0.9em
+  margin: 0 0 0.75em
+
+.default-note
+  color: #6a4c00
+
+.enabled-row
+  margin-bottom: 0.75em
+
+.slots
+  display: grid
+  grid-template-columns: repeat(6, minmax(0, 1fr))
+  gap: 0.35em
+  max-width: 36em
+
+.slot
+  border: 1px solid #888
+  background: transparent
+  padding: 0.35em 0.2em
+  font: inherit
+  cursor: pointer
+
+  &.selected
+    background: #333
+    color: #fff
+    border-color: #333
+
+.preview
+  margin-top: 1em
+
+  h3
+    margin: 0 0 0.35em
+    font-size: 1em
+
+  ul
+    margin: 0
+    padding-left: 1.2em

--- a/cultpodcasts/src/app/discovery-schedule/discovery-schedule.component.ts
+++ b/cultpodcasts/src/app/discovery-schedule/discovery-schedule.component.ts
@@ -1,0 +1,194 @@
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Component } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
+import { firstValueFrom } from 'rxjs';
+import { environment } from './../../environments/environment';
+import { AuthServiceWrapper } from '../auth-service-wrapper.class';
+import { DiscoverySchedule, DiscoveryScheduleNextRun, DiscoveryScheduleUpdate } from './discovery-schedule.interface';
+
+@Component({
+  selector: 'app-discovery-schedule',
+  imports: [
+    MatDialogModule,
+    MatProgressSpinnerModule,
+    MatButtonModule,
+    MatSlideToggleModule,
+    FormsModule
+  ],
+  templateUrl: './discovery-schedule.component.html',
+  styleUrl: './discovery-schedule.component.sass'
+})
+export class DiscoveryScheduleComponent {
+  readonly slotChoices: string[] = DiscoveryScheduleComponent.buildSlotChoices();
+
+  isLoading = true;
+  isSaving = false;
+  isInError = false;
+  errorMessage = '';
+  enabled = true;
+  isDefault = false;
+  timeZoneId = 'GMT Standard Time';
+  selected = new Set<string>(['08:00', '22:00']);
+  nextRuns: DiscoveryScheduleNextRun[] = [];
+
+  constructor(
+    private auth: AuthServiceWrapper,
+    private http: HttpClient,
+    private dialogRef: MatDialogRef<DiscoveryScheduleComponent, { saved?: boolean }>
+  ) { }
+
+  async ngOnInit() {
+    await this.load();
+  }
+
+  close() {
+    this.dialogRef.close({ saved: false });
+  }
+
+  isSelected(slot: string): boolean {
+    return this.selected.has(slot);
+  }
+
+  toggleSlot(slot: string) {
+    if (this.selected.has(slot)) {
+      this.selected.delete(slot);
+    } else {
+      this.selected.add(slot);
+    }
+    this.selected = new Set(this.selected);
+  }
+
+  get canSave(): boolean {
+    return !this.isLoading && !this.isSaving && this.selected.size > 0;
+  }
+
+  async onSave() {
+    if (!this.canSave) {
+      return;
+    }
+
+    this.isSaving = true;
+    this.isInError = false;
+    this.errorMessage = '';
+
+    const body: DiscoveryScheduleUpdate = {
+      runTimes: [...this.selected].sort(),
+      enabled: this.enabled,
+      timeZoneId: this.timeZoneId
+    };
+
+    try {
+      const headers = await this.authHeaders();
+      if (!headers) {
+        this.isInError = true;
+        this.errorMessage = 'Could not get admin token.';
+        this.isSaving = false;
+        return;
+      }
+
+      const resp = await firstValueFrom(
+        this.http.put<DiscoverySchedule>(
+          new URL('/discovery-schedule', environment.api).toString(),
+          body,
+          { headers, observe: 'response' }
+        )
+      );
+
+      if (resp.status === 200 && resp.body) {
+        this.apply(resp.body);
+        this.isSaving = false;
+        this.dialogRef.close({ saved: true });
+        return;
+      }
+
+      this.isInError = true;
+      this.errorMessage = 'Save failed.';
+      this.isSaving = false;
+    } catch (error: any) {
+      console.error(error);
+      this.isInError = true;
+      this.errorMessage = error?.error?.error ?? 'Save failed.';
+      this.isSaving = false;
+    }
+  }
+
+  private async load() {
+    this.isLoading = true;
+    this.isInError = false;
+    this.errorMessage = '';
+
+    try {
+      const headers = await this.authHeaders();
+      if (!headers) {
+        this.isInError = true;
+        this.errorMessage = 'Could not get admin token.';
+        this.isLoading = false;
+        return;
+      }
+
+      const resp = await firstValueFrom(
+        this.http.get<DiscoverySchedule>(
+          new URL('/discovery-schedule', environment.api).toString(),
+          { headers, observe: 'response' }
+        )
+      );
+
+      if (resp.status === 200 && resp.body) {
+        this.apply(resp.body);
+      } else {
+        this.isInError = true;
+        this.errorMessage = 'Failed to load schedule.';
+      }
+    } catch (error) {
+      console.error(error);
+      this.isInError = true;
+      this.errorMessage = 'Failed to load schedule.';
+    } finally {
+      this.isLoading = false;
+    }
+  }
+
+  private apply(schedule: DiscoverySchedule) {
+    this.enabled = schedule.enabled;
+    this.isDefault = schedule.isDefault;
+    this.timeZoneId = schedule.timeZoneId;
+    this.selected = new Set(schedule.runTimes ?? []);
+    this.nextRuns = schedule.nextRuns ?? [];
+  }
+
+  private async authHeaders(): Promise<HttpHeaders | undefined> {
+    try {
+      const token = await firstValueFrom(this.auth.authService.getAccessTokenSilently({
+        authorizationParams: {
+          audience: `https://api.cultpodcasts.com/`,
+          scope: 'admin'
+        }
+      }));
+      if (!token) {
+        return undefined;
+      }
+      return new HttpHeaders().set('Authorization', 'Bearer ' + token);
+    } catch (e) {
+      console.error(e);
+      return undefined;
+    }
+  }
+
+  private static buildSlotChoices(): string[] {
+    const slots: string[] = [];
+    for (let hour = 0; hour < 24; hour++) {
+      for (const minute of [0, 30]) {
+        slots.push(`${hour.toString().padStart(2, '0')}:${minute.toString().padStart(2, '0')}`);
+      }
+    }
+    return slots;
+  }
+
+  formatNextRun(run: DiscoveryScheduleNextRun): string {
+    return run.slotId;
+  }
+}

--- a/cultpodcasts/src/app/discovery-schedule/discovery-schedule.interface.ts
+++ b/cultpodcasts/src/app/discovery-schedule/discovery-schedule.interface.ts
@@ -1,0 +1,19 @@
+export interface DiscoveryScheduleNextRun {
+  slotId: string;
+  slotStartUtc: string;
+  slotStartUk: string;
+}
+
+export interface DiscoverySchedule {
+  runTimes: string[];
+  timeZoneId: string;
+  enabled: boolean;
+  isDefault: boolean;
+  nextRuns: DiscoveryScheduleNextRun[];
+}
+
+export interface DiscoveryScheduleUpdate {
+  runTimes: string[];
+  enabled: boolean;
+  timeZoneId?: string;
+}

--- a/cultpodcasts/src/app/toolbar/toolbar.component.html
+++ b/cultpodcasts/src/app/toolbar/toolbar.component.html
@@ -54,6 +54,10 @@
           <mat-icon class="material-symbols-outlined">list_alt_add</mat-icon>
           <span>Add Term</span>
         </a>
+        <a (click)="openDiscoverySchedule()" mat-menu-item>
+          <mat-icon class="material-symbols-outlined">schedule</mat-icon>
+          <span>Discovery Schedule</span>
+        </a>
         }
         <a (click)="logout()" mat-menu-item>
           <mat-icon>logout</mat-icon>
@@ -105,6 +109,10 @@
       <a (click)="addTerm()" mat-menu-item>
         <mat-icon class="material-symbols-outlined">list_alt_add</mat-icon>
         <span>Add Term</span>
+      </a>
+      <a (click)="openDiscoverySchedule()" mat-menu-item>
+        <mat-icon class="material-symbols-outlined">schedule</mat-icon>
+        <span>Discovery Schedule</span>
       </a>
       }
       @if (featureSwtichService.IsEnabled(FeatureSwitch.auth0)) {

--- a/cultpodcasts/src/app/toolbar/toolbar.component.ts
+++ b/cultpodcasts/src/app/toolbar/toolbar.component.ts
@@ -19,6 +19,7 @@ import { FirstLoginNoticeComponent } from '../first-login-notice/first-login-not
 import { RunSearchIndexerComponent } from '../run-search-indexer/run-search-indexer.component';
 import { PublishHomepageComponent } from '../publish-homepage/publish-homepage.component';
 import { AddTermComponent } from '../add-term/add-term.component';
+import { DiscoveryScheduleComponent } from '../discovery-schedule/discovery-schedule.component';
 import { IndexerState } from '../indexer-state.interface';
 import { SubmitUrlOriginResponseSnackbarComponent } from '../submit-url-origin-response-snackbar/submit-url-origin-response-snackbar.component';
 import { MatBadgeModule } from '@angular/material/badge';
@@ -221,6 +222,20 @@ export class ToolbarComponent {
     dialogRef.afterClosed().subscribe(async result => {
       if (result.updated) {
         let snackBarRef = this.snackBar.open(`Term '${result.term}' added`, "Ok", { duration: 10000 });
+      }
+    });
+  }
+
+  openDiscoverySchedule() {
+    const dialogRef = this.dialog.open(DiscoveryScheduleComponent, {
+      disableClose: true,
+      autoFocus: true,
+      width: '40em',
+      maxWidth: '95vw'
+    });
+    dialogRef.afterClosed().subscribe(result => {
+      if (result?.saved) {
+        this.snackBar.open('Discovery schedule saved', 'Ok', { duration: 5000 });
       }
     });
   }


### PR DESCRIPTION
## Summary
- Add admin Discovery Schedule dialog (GET/PUT schedule via API worker).
- Expose menu entry from the toolbar for curators/admins.

## Test plan
- [ ] Local stack: website + Api worker + api-infra with discovery-schedule endpoint configured.
- [ ] Open Discovery Schedule from admin menu; load existing windows; save changes; confirm snackbar.
- [ ] Invalid/empty windows show UI validation / error handling without silent success.

Made with [Cursor](https://cursor.com)