### PR TITLE
fix(search): prefer YouTube thumbnail over stale image field

### DIFF
--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.930",
+  "version": "1.9.931",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/src/app/search-result-links.spec.ts
+++ b/cultpodcasts/src/app/search-result-links.spec.ts
@@ -28,6 +28,30 @@ describe("search-result-links", () => {
       .toBe("https://i.ytimg.com/vi/yt123456789/hqdefault.jpg");
   });
 
+  it("prefers the YouTube thumbnail over a stale image when a variant is present", () => {
+    const withStaleImage: SearchResult = {
+      ...searchResult,
+      youtubeId: "abcDEF12345",
+      youtubeImageVariant: "maxres",
+      image: "https://i.scdn.co/image/staleCoverArt"
+    };
+
+    expect(episodeImageUrl(withStaleImage)?.toString())
+      .toBe("https://i.ytimg.com/vi/abcDEF12345/maxresdefault.jpg");
+  });
+
+  it("falls back to image when no YouTube variant is present", () => {
+    const audioOnly: SearchResult = {
+      ...searchResult,
+      youtubeId: undefined,
+      youtubeImageVariant: undefined,
+      image: "https://i.scdn.co/image/audioOnlyCover"
+    };
+
+    expect(episodeImageUrl(audioOnly)?.toString())
+      .toBe("https://i.scdn.co/image/audioOnlyCover");
+  });
+
   it("keeps opaque homepage URLs unchanged", () => {
     const homepage: HomepageEpisode = {
       id: "id",

--- a/cultpodcasts/src/app/search-result-links.ts
+++ b/cultpodcasts/src/app/search-result-links.ts
@@ -31,10 +31,19 @@ export function appleUrl(episode: SearchDisplayEpisode): URL | undefined {
 }
 
 export function episodeImageUrl(episode: SearchDisplayEpisode): URL | undefined {
-  const image = toUrl(episode.image);
-  if (image) {
-    return image;
+  // A YouTube image-variant is only ever set when the episode's YouTube image is a
+  // standard i.ytimg.com thumbnail, which the index encodes compactly (nulling `image`).
+  // Prefer that reconstructed thumbnail: it matches the backend's YouTube-first image
+  // priority and is robust to a stale `image` value that the incremental search indexer
+  // cannot clear once a YouTube image is merged onto an existing episode.
+  const youtubeThumbnail = youtubeThumbnailUrl(episode);
+  if (youtubeThumbnail) {
+    return youtubeThumbnail;
   }
+  return toUrl(episode.image);
+}
+
+function youtubeThumbnailUrl(episode: SearchDisplayEpisode): URL | undefined {
   if (isHomepageEpisode(episode) || !episode.youtubeId || !episode.youtubeImageVariant) {
     return undefined;
   }


### PR DESCRIPTION
## Root cause

Episode `29f24d85-7ac0-4f0b-9a3e-77844c17c8a7` (*"God, Law, and the Cult of Power…"*, Cults, Culture & Coercion) showed the **podcast cover art** on its episode page and search card instead of the merged **YouTube** `maxresdefault` thumbnail — even though the YouTube URL/icon rendered correctly.

The YouTube merge onto the audio-only episode worked. The gap is in **image display**:

1. **Stale `image` in the search index.** The Cosmos → Azure Cognitive Search indexer projects `image = null` when the episode's YouTube image is a standard `i.ytimg.com` thumbnail (it is encoded compactly as `youtubeImageVariant`). But the incremental (high-water-mark on `_ts`) indexer performs a **merge**, and a `null` in the source **does not clear** an already-indexed field. So after the YouTube merge the search doc ended up with an impossible combination:
   - `image`: `https://i.scdn.co/image/ab6765630000ba8ae0b703a696bdaa4fd284618a` (stale Spotify cover art)
   - `youtubeImageVariant`: `maxres`
   - `youtubeId`: `ln_jF32E8F0`
2. **The website preferred `image`.** `episodeImageUrl()` returned `image` first and only reconstructed the YouTube thumbnail as a fallback, so the stale cover art won.

## Fix

`episodeImageUrl()` now prefers the reconstructed YouTube thumbnail whenever `youtubeId` + `youtubeImageVariant` are present, falling back to `image` otherwise. This matches the backend's YouTube-first image priority (`youtube ?? spotify ?? apple ?? other`) and is robust to the stale-`image` index state the incremental indexer cannot clear.

**No regression risk:** `image` (non-null) and `youtubeImageVariant` (non-null) only ever co-occur in the stale-index state — in a freshly-projected doc the variant path always nulls `image`.

## Tests

`search-result-links.spec.ts` (fictional data): added coverage that the YouTube thumbnail wins over a stale `image` when a variant is present, and that `image` is still used when no variant exists. All 6 specs pass headless.

## Notes / not included
- Does **not** deploy and makes **no** production Cosmos writes.
- The stale `image` values already in the index are cosmetic-only after this client fix; a search index reset + full reindex would also clear them, but that is an operational action out of scope here.