### PR TITLE
fix(cards): bottom-align podcast-service buttons on public result cards

### DIFF
--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.930",
+  "version": "1.9.931",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -53,16 +53,16 @@ mat-card-actions.review-actions {
 
 // Public result cards (every non-editable mat-card-actions: homepage, search,
 // podcast, subject, episode, bookmarks, discovery). Service buttons sit on the
-// LEFT and the stacked subjects list on the RIGHT of the same row, top-aligned
-// so the first subject shares the buttons' top Y. Subjects stay one-per-line
-// (app-subjects :host is a right-aligned flex column, matching editable review
-// minus the remove X). Selector qualified with `mat-card .mdc-card__actions` so
-// its specificity beats the shared `mat-card .mdc-card__actions { align-items:
-// end }` rule below (which would otherwise bottom-align the buttons).
+// LEFT and the stacked subjects list on the RIGHT of the same row, bottom-aligned
+// so the service buttons sit at the bottom of the card, level with the last
+// subject. Subjects stay one-per-line (app-subjects :host is a right-aligned flex
+// column, matching editable review minus the remove X). Selector qualified with
+// `mat-card .mdc-card__actions` so it matches the shared `mat-card
+// .mdc-card__actions { align-items: end }` intent below.
 mat-card .mdc-card__actions:not(.review-actions) {
     flex-direction: row;
     flex-wrap: nowrap;
-    align-items: flex-start;
+    align-items: flex-end;
 
     app-episode-links {
         flex: 0 0 auto;


### PR DESCRIPTION
## Problem
On every public result surface (homepage, search, podcast, subject, episode, bookmarks, discovery), the podcast-service buttons (YouTube, Spotify, Apple, share) were **top-aligned** with the first subject/tag, leaving empty space below them when the subjects list stacked taller than the single button row.

## Fix
Changed the shared public-card actions rule in \styles.scss\ from \lign-items: flex-start\ to \lign-items: flex-end\, so the service buttons sit at the **bottom** of the card, level with the last subject. The two-column layout (buttons left, subjects stacked right, one-per-line) is preserved — only the vertical alignment changed.

Single shared rule (\mat-card .mdc-card__actions:not(.review-actions)\) so it applies consistently across all public pages; editable review cards (\.review-actions\) are unaffected.

## Version
Bumped \1.9.930\ -> \1.9.931\ (required for website PRs into main).

## Notes
Do not merge / do not deploy until reviewed.

Made with [Cursor](https://cursor.com)