### PR TITLE
feat(search): expand loss-less image tokens (drop maxres->hqdefault fallback)

### DIFF
--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.930",
+  "version": "1.9.931",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.931",
+  "version": "1.9.932",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/src/app/search-result-links.spec.ts
+++ b/cultpodcasts/src/app/search-result-links.spec.ts
@@ -1,4 +1,4 @@
-import { appleUrl, episodeImageUrl, spotifyUrl, youtubeUrl } from "./search-result-links";
+import { appleUrl, episodeImageUrl, expandImage, spotifyUrl, youtubeUrl } from "./search-result-links";
 import { SearchResult } from "./search-result.interface";
 import { HomepageEpisode } from "./homepage-episode.interface";
 
@@ -23,9 +23,16 @@ describe("search-result-links", () => {
     expect(appleUrl(searchResult)?.toString()).toBe("https://podcasts.apple.com/podcast/id1234567890?i=987654321");
   });
 
-  it("derives YouTube thumbnail when image is omitted", () => {
+  it("derives YouTube thumbnail from legacy youtubeImageVariant when image is omitted", () => {
     expect(episodeImageUrl(searchResult)?.toString())
       .toBe("https://i.ytimg.com/vi/yt123456789/hqdefault.jpg");
+  });
+
+  it("expands a compacted image token, preferring it over the legacy variant", () => {
+    // "Marbury Vale Broadcasting" — the sddefault thumbnail was probed and compacted to "ys".
+    const withToken: SearchResult = { ...searchResult, image: "ys", youtubeImageVariant: "hq" };
+    expect(episodeImageUrl(withToken)?.toString())
+      .toBe("https://i.ytimg.com/vi/yt123456789/sddefault.jpg");
   });
 
   it("keeps opaque homepage URLs unchanged", () => {
@@ -62,5 +69,35 @@ describe("search-result-links", () => {
     expect(appleUrl(incomplete)).toBeUndefined();
     expect(youtubeUrl(incomplete)).toBeUndefined();
     expect(episodeImageUrl(incomplete)).toBeUndefined();
+  });
+
+  describe("expandImage (loss-less compaction inverse)", () => {
+    it("expands every YouTube quality code back to its exact filename", () => {
+      const cases: Record<string, string> = {
+        yx: "maxresdefault",
+        ys: "sddefault",
+        yh: "hqdefault",
+        ym: "mqdefault",
+        yd: "default"
+      };
+      for (const [token, quality] of Object.entries(cases)) {
+        expect(expandImage(token, "griffinsong42")?.toString())
+          .toBe(`https://i.ytimg.com/vi/griffinsong42/${quality}.jpg`);
+      }
+    });
+
+    it("expands Spotify and Apple tokens verbatim", () => {
+      expect(expandImage("sab6765ferngully00cover", undefined)?.toString())
+        .toBe("https://i.scdn.co/image/ab6765ferngully00cover");
+      expect(expandImage("a3Music/draymoor/600x600bb.jpg", undefined)?.toString())
+        .toBe("https://is3-ssl.mzstatic.com/image/thumb/Music/draymoor/600x600bb.jpg");
+    });
+
+    it("returns full URLs unchanged and ignores unusable input", () => {
+      expect(expandImage("https://feeds.saltandcinder.example/art.jpg", undefined)?.toString())
+        .toBe("https://feeds.saltandcinder.example/art.jpg");
+      expect(expandImage("yx", undefined)).toBeUndefined(); // youtube token needs youtubeId
+      expect(expandImage(undefined, "griffinsong42")).toBeUndefined();
+    });
   });
 });

--- a/cultpodcasts/src/app/search-result-links.spec.ts
+++ b/cultpodcasts/src/app/search-result-links.spec.ts
@@ -13,8 +13,7 @@ describe("search-result-links", () => {
     spotifyId: "spotify123",
     youtubeId: "yt123456789",
     appleId: "987654321",
-    podcastAppleId: "1234567890",
-    youtubeImageVariant: "hq"
+    podcastAppleId: "1234567890"
   };
 
   it("reconstructs platform URLs from compact ids", () => {
@@ -23,14 +22,9 @@ describe("search-result-links", () => {
     expect(appleUrl(searchResult)?.toString()).toBe("https://podcasts.apple.com/podcast/id1234567890?i=987654321");
   });
 
-  it("derives YouTube thumbnail from legacy youtubeImageVariant when image is omitted", () => {
-    expect(episodeImageUrl(searchResult)?.toString())
-      .toBe("https://i.ytimg.com/vi/yt123456789/hqdefault.jpg");
-  });
-
-  it("expands a compacted image token, preferring it over the legacy variant", () => {
+  it("expands a compacted image token to its exact thumbnail URL", () => {
     // "Marbury Vale Broadcasting" — the sddefault thumbnail was probed and compacted to "ys".
-    const withToken: SearchResult = { ...searchResult, image: "ys", youtubeImageVariant: "hq" };
+    const withToken: SearchResult = { ...searchResult, image: "ys" };
     expect(episodeImageUrl(withToken)?.toString())
       .toBe("https://i.ytimg.com/vi/yt123456789/sddefault.jpg");
   });
@@ -61,8 +55,7 @@ describe("search-result-links", () => {
       ...searchResult,
       spotifyId: undefined,
       appleId: undefined,
-      youtubeId: undefined,
-      youtubeImageVariant: undefined
+      youtubeId: undefined
     };
 
     expect(spotifyUrl(incomplete)).toBeUndefined();

--- a/cultpodcasts/src/app/search-result-links.ts
+++ b/cultpodcasts/src/app/search-result-links.ts
@@ -31,20 +31,70 @@ export function appleUrl(episode: SearchDisplayEpisode): URL | undefined {
 }
 
 export function episodeImageUrl(episode: SearchDisplayEpisode): URL | undefined {
-  const image = toUrl(episode.image);
-  if (image) {
-    return image;
-  }
-  if (isHomepageEpisode(episode) || !episode.youtubeId || !episode.youtubeImageVariant) {
-    return undefined;
+  // Homepage episodes come from a feed that always carries full image URLs.
+  if (isHomepageEpisode(episode)) {
+    return toUrl(episode.image);
   }
 
+  const expanded = expandImage(episode.image, episode.youtubeId);
+  if (expanded) {
+    return expanded;
+  }
+
+  // Legacy fallback: documents indexed before the loss-less compaction scheme carry the coarse
+  // youtubeImageVariant (maxres/sd/hq) with an empty image. Expand it until they re-merge.
+  if (!episode.youtubeId || !episode.youtubeImageVariant) {
+    return undefined;
+  }
   const variant = {
     maxres: "maxresdefault",
     sd: "sddefault",
     hq: "hqdefault"
   }[episode.youtubeImageVariant];
   return toUrl(`https://i.ytimg.com/vi/${encodeURIComponent(episode.youtubeId)}/${variant}.jpg`);
+}
+
+const youtubeQualityByCode: Record<string, string> = {
+  x: "maxresdefault",
+  s: "sddefault",
+  h: "hqdefault",
+  m: "mqdefault",
+  d: "default"
+};
+
+// Loss-less inverse of the search index's image compaction (RPP `SearchEpisodeImage`). `image` holds
+// either a full URL (used as-is) or a short token whose first character is the platform sigil:
+//   y{q}       -> https://i.ytimg.com/vi/{youtubeId}/{quality}.jpg   (x/s/h/m/d)
+//   s{id}      -> https://i.scdn.co/image/{id}
+//   a{n}{path} -> https://is{n}-ssl.mzstatic.com/image/thumb/{path}
+// The exact URL that was selected/probed at index time is reconstructed byte-for-byte; there is no
+// maxres->hqdefault guessing.
+export function expandImage(image: URL | string | undefined, youtubeId: string | undefined): URL | undefined {
+  if (!image) {
+    return undefined;
+  }
+  const value = image instanceof URL ? image.toString() : image;
+  if (value.startsWith("http")) {
+    return toUrl(value);
+  }
+
+  const payload = value.slice(1);
+  switch (value[0]) {
+    case "y": {
+      const quality = youtubeQualityByCode[payload];
+      return quality && youtubeId
+        ? toUrl(`https://i.ytimg.com/vi/${encodeURIComponent(youtubeId)}/${quality}.jpg`)
+        : undefined;
+    }
+    case "s":
+      return payload ? toUrl(`https://i.scdn.co/image/${payload}`) : undefined;
+    case "a":
+      return payload
+        ? toUrl(`https://is${payload[0]}-ssl.mzstatic.com/image/thumb/${payload.slice(1)}`)
+        : undefined;
+    default:
+      return undefined;
+  }
 }
 
 export function toUrl(value: URL | string | undefined): URL | undefined {

--- a/cultpodcasts/src/app/search-result-links.ts
+++ b/cultpodcasts/src/app/search-result-links.ts
@@ -36,22 +36,7 @@ export function episodeImageUrl(episode: SearchDisplayEpisode): URL | undefined 
     return toUrl(episode.image);
   }
 
-  const expanded = expandImage(episode.image, episode.youtubeId);
-  if (expanded) {
-    return expanded;
-  }
-
-  // Legacy fallback: documents indexed before the loss-less compaction scheme carry the coarse
-  // youtubeImageVariant (maxres/sd/hq) with an empty image. Expand it until they re-merge.
-  if (!episode.youtubeId || !episode.youtubeImageVariant) {
-    return undefined;
-  }
-  const variant = {
-    maxres: "maxresdefault",
-    sd: "sddefault",
-    hq: "hqdefault"
-  }[episode.youtubeImageVariant];
-  return toUrl(`https://i.ytimg.com/vi/${encodeURIComponent(episode.youtubeId)}/${variant}.jpg`);
+  return expandImage(episode.image, episode.youtubeId);
 }
 
 const youtubeQualityByCode: Record<string, string> = {

--- a/cultpodcasts/src/app/search-result.interface.ts
+++ b/cultpodcasts/src/app/search-result.interface.ts
@@ -13,5 +13,4 @@ export interface SearchResult {
   internetArchive?: URL | string;
   subjects?: string[];
   image?: URL | string;
-  youtubeImageVariant?: "maxres" | "sd" | "hq";
 }


### PR DESCRIPTION
## Expand loss-less image tokens + full removal of `youtubeImageVariant`

### What changed vs the earlier approach

The earlier version of this branch added a client `youtubeThumbnailFallback()` + `<img> (error)` handler that swapped a failed `maxresdefault`/`sddefault` to `hqdefault`. **That approach was rejected**: the search index had already probed and selected a working YouTube URL, and compacting it to a coarse `maxres`/`sd`/`hq` token lost that detail, so the client reconstructed a tier that 404s to a grey placeholder. Guessing `maxres`→`hqdefault` on the client is a band-aid over lost data.

This branch mirrors the **loss-less** compaction in RPP #894 and now **fully removes `youtubeImageVariant`** — it is no longer kept as a legacy fallback.

### The change

- `expandImage(image, youtubeId)` in `search-result-links.ts` — the inverse of the index's loss-less compaction. `image` holds either a full URL (used as-is) or a compact token whose first char is the platform sigil:
  - `y{q}` → `https://i.ytimg.com/vi/{youtubeId}/{quality}.jpg` (`x`=maxresdefault, `s`=sddefault, `h`=hqdefault, `m`=mqdefault, `d`=default)
  - `s{id}` → `https://i.scdn.co/image/{id}`
  - `a{n}{path}` → `https://is{n}-ssl.mzstatic.com/image/thumb/{path}`
- `episodeImageUrl` now returns the expanded token/URL only. The coarse `youtubeImageVariant` (maxres/sd/hq) **legacy fallback is removed**.
- `youtubeImageVariant` **removed** from the `SearchResult` interface and from all tests (no spec sets or asserts it).
- The reconstructed URL is **byte-identical** to the one selected/probed at index time, so there is no placeholder to fall back from.

### ⚠️ Reindex required after deploy

Existing search documents still carry the old `youtubeImageVariant` field/values. Because the client no longer reads it, a **full search reindex (or index recreate)** is required (driven by RPP #894) so every document gets a lossless `image` token/URL.

**Deployment order:**
1. Ship **this website PR** first — it understands lossless `image` tokens and no longer needs `youtubeImageVariant`.
2. Update the **indexer / data-source** (RPP #894) so the field is no longer written/projected.
3. **Reset + full reindex** (or recreate the index) so every document gets a lossless `image` token/URL without relying on `youtubeImageVariant`.

### Tests / build

- `expandImage` unit tests: all 5 YouTube quality codes round-trip, Spotify + Apple tokens expand verbatim, full URLs pass through, unusable input returns undefined; `episodeImageUrl` expands the token. **7 specs pass** (`ng test --include search-result-links.spec.ts`).
- `tsc --noEmit` clean.

### Version

- Bumped to **`1.9.932`**.

### Notes

- Pairs with RPP #894 (loss-less index compaction). No client fallback guessing; no `youtubeImageVariant`.
- Do not merge/deploy without approval. Not deployed from local to prod.
