### PR TITLE
fix(cards): let subjects use available width beside service buttons

### DIFF
--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.939",
+  "version": "1.9.940",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.938",
+  "version": "1.9.939",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.944",
+  "version": "1.9.945",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.936",
+  "version": "1.9.937",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.942",
+  "version": "1.9.943",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.933",
+  "version": "1.9.934",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.943",
+  "version": "1.9.944",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.934",
+  "version": "1.9.935",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.937",
+  "version": "1.9.938",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.935",
+  "version": "1.9.936",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.940",
+  "version": "1.9.941",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.941",
+  "version": "1.9.942",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/src/app/subjects/subjects.component.html
+++ b/cultpodcasts/src/app/subjects/subjects.component.html
@@ -1,6 +1,6 @@
 @for (subject of subjects; track subject) {
+@if (!subject.startsWith("_") || showHidden) {
 <div class="subject">
-    @if (!subject.startsWith("_") || showHidden) {
     <a [routerLink]="['/subject', subject]" (click)="stopPropagate($event)">{{subject}}</a>
     @if (editable) {
     <button mat-icon-button type="button" class="remove-btn" [disabled]="disabled"
@@ -8,6 +8,6 @@
         <mat-icon>close</mat-icon>
     </button>
     }
-    }
 </div>
+}
 }

--- a/cultpodcasts/src/app/subjects/subjects.component.sass
+++ b/cultpodcasts/src/app/subjects/subjects.component.sass
@@ -18,20 +18,10 @@
         align-self: stretch
         width: 100%
         box-sizing: border-box
-        // Horizontal separation from service icons comes from the actions row
-        // gap (styles.scss), not padding here — 8px padding was enough to force
-        // long labels (~340px) onto two lines in a ~346px subjects column.
-        padding-left: 0
+        padding-left: 8px
         padding-bottom: 6px
         gap: 0
         a
-            // Fill the subjects column so wrapping only happens when the grown
-            // footer is genuinely narrower than the label (not because the
-            // link shrink-wrapped mid-column while empty space sat to its left).
-            flex: 1 1 auto
-            min-width: 0
-            max-width: 100%
-            text-align: right
             color: var(--mat-theme-text-secondary)
             text-decoration: dashed underline 1px
             text-underline-offset: 5px

--- a/cultpodcasts/src/app/subjects/subjects.component.sass
+++ b/cultpodcasts/src/app/subjects/subjects.component.sass
@@ -22,6 +22,13 @@
         padding-bottom: 6px
         gap: 0
         a
+            // Fill the subjects column so wrapping only happens when the grown
+            // footer is genuinely narrower than the label (not because the
+            // link shrink-wrapped mid-column while empty space sat to its left).
+            flex: 1 1 auto
+            min-width: 0
+            max-width: 100%
+            text-align: right
             color: var(--mat-theme-text-secondary)
             text-decoration: dashed underline 1px
             text-underline-offset: 5px

--- a/cultpodcasts/src/app/subjects/subjects.component.sass
+++ b/cultpodcasts/src/app/subjects/subjects.component.sass
@@ -18,10 +18,18 @@
         align-self: stretch
         width: 100%
         box-sizing: border-box
-        padding-left: 8px
+        // No left padding: horizontal separation from service icons is the
+        // icons' own margins; padding here only shrinks room for long labels.
+        padding-left: 0
         padding-bottom: 6px
         gap: 0
         a
+            // Fill the grown subjects column (public cards) / footer column
+            // (review); text stays right-aligned.
+            flex: 1 1 auto
+            min-width: 0
+            max-width: 100%
+            text-align: right
             color: var(--mat-theme-text-secondary)
             text-decoration: dashed underline 1px
             text-underline-offset: 5px

--- a/cultpodcasts/src/app/subjects/subjects.component.sass
+++ b/cultpodcasts/src/app/subjects/subjects.component.sass
@@ -22,6 +22,10 @@
         // icons' own margins; padding here only shrinks room for long labels.
         padding-left: 0
         padding-bottom: 6px
+        // Keep last subject on the same bottom edge as service icons
+        // (public cards use align-items: flex-end on the actions row).
+        &:last-child
+            padding-bottom: 0
         gap: 0
         a
             // Fill the grown subjects column (public cards) / footer column

--- a/cultpodcasts/src/app/subjects/subjects.component.sass
+++ b/cultpodcasts/src/app/subjects/subjects.component.sass
@@ -18,7 +18,10 @@
         align-self: stretch
         width: 100%
         box-sizing: border-box
-        padding-left: 8px
+        // Horizontal separation from service icons comes from the actions row
+        // gap (styles.scss), not padding here — 8px padding was enough to force
+        // long labels (~340px) onto two lines in a ~346px subjects column.
+        padding-left: 0
         padding-bottom: 6px
         gap: 0
         a

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -52,10 +52,11 @@ mat-card-actions.review-actions {
 }
 
 // Public result cards (homepage, search, podcast list, podcast episode, subject,
-// bookmarks, discovery). Subjects wrap around a bottom-left service-icon island
-// via a zero-width spacer float + island float (CSS bottom-corner pattern):
-// subjects use full width above the icons, then share the bottom row beside them.
-// Icons keep global 25px margins and sit absolute bottom-left.
+// bookmarks, discovery). Subjects use the FULL footer width; the last subject
+// (when not alone) reserves a bottom-left island for service icons so short
+// trailing labels sit beside them on the same baseline. Leading subjects —
+// including long labels — are not trapped in a narrow right column.
+// Icons keep global 25px margins and are absolutely pinned bottom-left.
 // Review/outgoing (.review-actions) keep their own two-column layout.
 mat-card .mdc-card__actions:not(.review-actions) {
     display: block !important;
@@ -73,60 +74,50 @@ mat-card .mdc-card__actions:not(.review-actions) {
     }
 
     mat-card-footer.subjects {
-        // Grid so % height on the spacer float resolves against content height.
-        display: grid;
+        display: block;
         width: 100% !important;
         max-width: 100%;
         margin: 0;
         box-sizing: border-box;
 
-        // Zero-width spacer: pushes the island float down so subjects above it
-        // sit beside a 0-width float (= full content width).
-        &::before {
-            content: "";
-            grid-area: 1 / 1;
-            float: left;
-            width: 0;
-            height: calc(100% - var(--public-card-icon-row));
-        }
-
         app-subjects {
-            grid-area: 1 / 1;
-            display: block !important;
+            display: flex !important;
+            flex-direction: column;
+            align-items: stretch;
             width: 100%;
             margin-left: 0;
             box-sizing: border-box;
-
-            // Bottom-left island matching the absolute icon cluster footprint.
-            &::before {
-                content: "";
-                float: left;
-                clear: left;
-                width: var(--public-card-icon-island);
-                height: var(--public-card-icon-row);
-                pointer-events: none;
-            }
         }
 
         .subject {
             display: block;
-            // auto width fills space beside the current float (full width above
-            // the island; shortened beside it).
-            width: auto;
+            width: 100%;
             box-sizing: border-box;
             text-align: right;
             padding-left: 0;
             padding-bottom: 6px;
-
-            &:last-child {
-                padding-bottom: 0;
-            }
 
             a {
                 color: var(--mat-theme-text-secondary);
                 text-decoration: dashed underline 1px;
                 text-underline-offset: 5px;
                 line-height: 1.25;
+            }
+
+            // Alone: full-width label above the icon row.
+            &:only-child {
+                padding-bottom: var(--public-card-icon-row);
+            }
+
+            // With siblings: only the last line reserves the icon island;
+            // earlier subjects (incl. long names) keep full width.
+            &:last-child:not(:only-child) {
+                padding-bottom: 0;
+                padding-left: var(--public-card-icon-island);
+                min-height: var(--public-card-icon-row);
+                display: flex;
+                justify-content: flex-end;
+                align-items: flex-end;
             }
         }
     }

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -52,34 +52,158 @@ mat-card-actions.review-actions {
 }
 
 // Public result cards (homepage, search, podcast list, podcast episode, subject,
-// bookmarks, discovery). One shared row: service icons LEFT (original 25px
-// margins — do not tighten), subjects RIGHT growing into remaining width,
-// bottom-aligned so the last subject shares a baseline with the icons (#421).
+// bookmarks, discovery). Subjects wrap around a bottom-left service-icon island:
+// full footer width above the icons, narrowed only beside the icon row — so long
+// labels can use the middle space. Icons keep their global 25px margins (not
+// tightened) and sit absolute bottom-left, level with the last subject.
 // Review/outgoing (.review-actions) keep their own two-column layout.
 mat-card .mdc-card__actions:not(.review-actions) {
-    flex-direction: row;
-    flex-wrap: nowrap;
-    align-items: flex-end;
-    justify-content: flex-start;
+    display: block !important;
+    position: relative;
+    --public-card-icon-row: 3.25rem;
+    // Max footprint of 4 service buttons with 25px margins (do not shrink icons).
+    --public-card-icon-island: 16.5rem;
 
     app-episode-links,
     app-episode-podcast-links {
-        flex: 0 0 auto;
-    }
-
-    // Discovery inlines service icons (and optional YouTube meta) as direct
-    // children rather than wrapping them in app-episode-links.
-    > a[mat-icon-button],
-    > button[mat-icon-button],
-    > .youtubemeta {
-        flex: 0 0 auto;
+        position: absolute;
+        // Match .mdc-card__actions padding-left.
+        left: 20px;
+        bottom: 0;
+        z-index: 1;
     }
 
     mat-card-footer.subjects {
-        flex: 1 1 0;
-        min-width: 0;
-        width: auto;
+        display: grid;
+        width: 100% !important;
+        max-width: 100%;
         margin: 0;
+        box-sizing: border-box;
+        min-height: var(--public-card-icon-row);
+
+        app-subjects {
+            display: block !important;
+            width: 100%;
+            margin-left: 0;
+            box-sizing: border-box;
+
+            // L-shaped exclusion: float is full height, but shape-outside only
+            // claims the bottom-left island — line boxes use full width above.
+            &::before {
+                content: "";
+                float: left;
+                width: var(--public-card-icon-island);
+                height: 100%;
+                shape-outside: inset(calc(100% - var(--public-card-icon-row)) 0 0 0);
+                pointer-events: none;
+            }
+        }
+
+        // Block layout so line boxes wrap around the shape-outside float
+        // (flex on .subject would create a BFC and defeat wrap-around).
+        .subject {
+            display: block;
+            width: 100%;
+            box-sizing: border-box;
+            text-align: right;
+            padding-left: 0;
+            padding-bottom: 6px;
+
+            &:last-child {
+                padding-bottom: 0;
+                min-height: var(--public-card-icon-row);
+                display: flex;
+                justify-content: flex-end;
+                align-items: flex-end;
+            }
+
+            a {
+                display: inline;
+                flex: none;
+                min-width: 0;
+                max-width: none;
+                text-align: right;
+            }
+        }
+    }
+}
+
+// Discovery cards inline service icons as direct children of actions.
+mat-card .mdc-card__actions:not(.review-actions):has(> a[mat-icon-button], > button[mat-icon-button]) {
+    > a[mat-icon-button],
+    > button[mat-icon-button] {
+        position: absolute;
+        bottom: 0;
+        z-index: 1;
+    }
+
+    > a[mat-icon-button]:nth-of-type(1),
+    > button[mat-icon-button]:nth-of-type(1) {
+        left: 20px;
+    }
+
+    > a[mat-icon-button]:nth-of-type(2),
+    > button[mat-icon-button]:nth-of-type(2) {
+        left: 85px;
+    }
+
+    > a[mat-icon-button]:nth-of-type(3),
+    > button[mat-icon-button]:nth-of-type(3) {
+        left: 150px;
+    }
+
+    > a[mat-icon-button]:nth-of-type(4),
+    > button[mat-icon-button]:nth-of-type(4) {
+        left: 215px;
+    }
+
+    > .youtubemeta {
+        position: absolute;
+        bottom: 0;
+        left: 85px;
+        z-index: 1;
+    }
+}
+
+@media screen and (max-width: 600px) {
+    mat-card .mdc-card__actions:not(.review-actions) {
+        app-episode-links,
+        app-episode-podcast-links {
+            left: 10px;
+        }
+    }
+
+    mat-card .mdc-card__actions:not(.review-actions):has(> a[mat-icon-button], > button[mat-icon-button]) {
+        > a[mat-icon-button]:nth-of-type(1),
+        > button[mat-icon-button]:nth-of-type(1) {
+            left: 10px;
+        }
+
+        > a[mat-icon-button]:nth-of-type(2),
+        > button[mat-icon-button]:nth-of-type(2) {
+            left: 68px;
+        }
+
+        > a[mat-icon-button]:nth-of-type(3),
+        > button[mat-icon-button]:nth-of-type(3) {
+            left: 126px;
+        }
+
+        > a[mat-icon-button]:nth-of-type(4),
+        > button[mat-icon-button]:nth-of-type(4) {
+            left: 184px;
+        }
+    }
+}
+
+@media screen and (max-width: 400px) {
+    mat-card .mdc-card__actions:not(.review-actions) {
+        --public-card-icon-island: 12rem;
+
+        app-episode-links,
+        app-episode-podcast-links {
+            left: 2px;
+        }
     }
 }
 

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -56,18 +56,37 @@ mat-card-actions.review-actions {
 // controls sit LEFT (app-episode-links, app-episode-podcast-links, or discovery's
 // inline icon buttons) and subjects RIGHT, bottom-aligned (#421). Subjects stay
 // one-per-line (app-subjects). flex-basis 0 + min-width 0 lets the subjects
-// footer claim remaining row width beside the icon cluster. Editable review /
-// outgoing cards (.review-actions) keep their own icon-column + footer-column
-// layout in component sass and are excluded here.
+// footer claim remaining row width beside the icon cluster.
+//
+// Icon buttons still use the global 1.2 scale, but drop the 25px margin-right
+// in favour of a tighter gap so long subject labels (e.g. "The Church Of Jesus
+// Christ Of Latter-Day Saints", ~340px) can stay on one line when the card has
+// room. Editable review / outgoing (.review-actions) keep their own layout.
 mat-card .mdc-card__actions:not(.review-actions) {
     flex-direction: row;
     flex-wrap: nowrap;
     align-items: flex-end;
     justify-content: flex-start;
+    gap: 8px;
 
     app-episode-links,
     app-episode-podcast-links {
         flex: 0 0 auto;
+    }
+
+    // Prefer gap over per-button margin so the last icon does not reserve a
+    // trailing 25px that subjects could use.
+    app-episode-links #episodelinks,
+    app-episode-podcast-links {
+        display: flex;
+        flex-wrap: nowrap;
+        align-items: center;
+        gap: 8px;
+    }
+
+    a[mat-icon-button]:not(.remove-btn):not(.add-btn),
+    button[mat-icon-button]:not(.remove-btn):not(.add-btn) {
+        margin-right: 0;
     }
 
     // Discovery inlines service icons (and optional YouTube meta) as direct

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -51,25 +51,36 @@ mat-card-actions.review-actions {
     margin-top: 14px;
 }
 
-// Public result cards (every non-editable mat-card-actions: homepage, search,
-// podcast, subject, episode, bookmarks, discovery). Service buttons sit on the
-// LEFT and the stacked subjects list on the RIGHT of the same row, bottom-aligned
-// so the service buttons sit at the bottom of the card, level with the last
-// subject. Subjects stay one-per-line (app-subjects :host is a right-aligned flex
-// column, matching editable review minus the remove X). Selector qualified with
-// `mat-card .mdc-card__actions` so it matches the shared `mat-card
-// .mdc-card__actions { align-items: end }` intent below.
+// Public result cards (non-editable mat-card-actions): homepage, search,
+// podcast list, podcast episode, subject, bookmarks, discovery. Service
+// controls sit LEFT (app-episode-links, app-episode-podcast-links, or discovery's
+// inline icon buttons) and subjects RIGHT, bottom-aligned (#421). Subjects stay
+// one-per-line (app-subjects). flex-basis 0 + min-width 0 lets the subjects
+// footer claim remaining row width beside the icon cluster. Editable review /
+// outgoing cards (.review-actions) keep their own icon-column + footer-column
+// layout in component sass and are excluded here.
 mat-card .mdc-card__actions:not(.review-actions) {
     flex-direction: row;
     flex-wrap: nowrap;
     align-items: flex-end;
+    justify-content: flex-start;
 
-    app-episode-links {
+    app-episode-links,
+    app-episode-podcast-links {
+        flex: 0 0 auto;
+    }
+
+    // Discovery inlines service icons (and optional YouTube meta) as direct
+    // children rather than wrapping them in app-episode-links.
+    > a[mat-icon-button],
+    > button[mat-icon-button],
+    > .youtubemeta {
         flex: 0 0 auto;
     }
 
     mat-card-footer.subjects {
-        flex: 1 1 auto;
+        flex: 1 1 0;
+        min-width: 0;
         width: auto;
         margin: 0;
     }

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -51,42 +51,31 @@ mat-card-actions.review-actions {
     margin-top: 14px;
 }
 
-// Public result cards (non-editable mat-card-actions): homepage, search,
-// podcast list, podcast episode, subject, bookmarks, discovery. Service
-// controls sit LEFT (app-episode-links, app-episode-podcast-links, or discovery's
-// inline icon buttons) and subjects RIGHT, bottom-aligned (#421). Subjects stay
-// one-per-line (app-subjects). flex-basis 0 + min-width 0 lets the subjects
-// footer claim remaining row width beside the icon cluster.
-//
-// Icon buttons still use the global 1.2 scale, but drop the 25px margin-right
-// in favour of a tighter gap so long subject labels (e.g. "The Church Of Jesus
-// Christ Of Latter-Day Saints", ~340px) can stay on one line when the card has
-// room. Editable review / outgoing (.review-actions) keep their own layout.
+// Public result cards (homepage, search, podcast, episode, subject, bookmarks,
+// discovery). Subjects use the FULL actions width on their own row so long
+// labels can sit on one line; podcast-service controls stay on a following row
+// at the bottom-left with their normal 25px margins (do not tighten icon
+// spacing). Review/outgoing (.review-actions) keep their own two-column layout.
 mat-card .mdc-card__actions:not(.review-actions) {
     flex-direction: row;
-    flex-wrap: nowrap;
+    flex-wrap: wrap;
     align-items: flex-end;
     justify-content: flex-start;
-    gap: 8px;
 
+    // Subjects first row, full width — “above” the service-icon island.
+    mat-card-footer.subjects {
+        flex: 1 1 100%;
+        order: 0;
+        width: 100%;
+        min-width: 100%;
+        margin: 0;
+    }
+
+    // Service controls second row, bottom-left; preserve global icon margins.
     app-episode-links,
     app-episode-podcast-links {
         flex: 0 0 auto;
-    }
-
-    // Prefer gap over per-button margin so the last icon does not reserve a
-    // trailing 25px that subjects could use.
-    app-episode-links #episodelinks,
-    app-episode-podcast-links {
-        display: flex;
-        flex-wrap: nowrap;
-        align-items: center;
-        gap: 8px;
-    }
-
-    a[mat-icon-button]:not(.remove-btn):not(.add-btn),
-    button[mat-icon-button]:not(.remove-btn):not(.add-btn) {
-        margin-right: 0;
+        order: 1;
     }
 
     // Discovery inlines service icons (and optional YouTube meta) as direct
@@ -95,13 +84,7 @@ mat-card .mdc-card__actions:not(.review-actions) {
     > button[mat-icon-button],
     > .youtubemeta {
         flex: 0 0 auto;
-    }
-
-    mat-card-footer.subjects {
-        flex: 1 1 0;
-        min-width: 0;
-        width: auto;
-        margin: 0;
+        order: 1;
     }
 }
 

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -103,21 +103,22 @@ mat-card .mdc-card__actions:not(.review-actions) {
                 text-underline-offset: 5px;
                 line-height: 1.25;
             }
-        }
 
-        // Prefer last *visible* subject (empty .subject shells exist for hidden
-        // `_…` names). Alone → pad below icons; with siblings → island padding.
-        app-subjects:not(:has(.subject:has(a) ~ .subject:has(a))) .subject:has(a) {
-            padding-bottom: var(--public-card-icon-row);
-        }
+            // Alone: full-width label above the icon row.
+            &:only-child {
+                padding-bottom: var(--public-card-icon-row);
+            }
 
-        app-subjects:has(.subject:has(a) ~ .subject:has(a)) .subject:has(a):not(:has(~ .subject:has(a))) {
-            padding-bottom: 0;
-            padding-left: var(--public-card-icon-island);
-            min-height: var(--public-card-icon-row);
-            display: flex;
-            justify-content: flex-end;
-            align-items: flex-end;
+            // With siblings: only the last line reserves the icon island;
+            // earlier subjects (incl. long names) keep full width.
+            &:last-child:not(:only-child) {
+                padding-bottom: 0;
+                padding-left: var(--public-card-icon-island);
+                min-height: var(--public-card-icon-row);
+                display: flex;
+                justify-content: flex-end;
+                align-items: flex-end;
+            }
         }
     }
 }

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -103,22 +103,21 @@ mat-card .mdc-card__actions:not(.review-actions) {
                 text-underline-offset: 5px;
                 line-height: 1.25;
             }
+        }
 
-            // Alone: full-width label above the icon row.
-            &:only-child {
-                padding-bottom: var(--public-card-icon-row);
-            }
+        // Prefer last *visible* subject (empty .subject shells exist for hidden
+        // `_…` names). Alone → pad below icons; with siblings → island padding.
+        app-subjects:not(:has(.subject:has(a) ~ .subject:has(a))) .subject:has(a) {
+            padding-bottom: var(--public-card-icon-row);
+        }
 
-            // With siblings: only the last line reserves the icon island;
-            // earlier subjects (incl. long names) keep full width.
-            &:last-child:not(:only-child) {
-                padding-bottom: 0;
-                padding-left: var(--public-card-icon-island);
-                min-height: var(--public-card-icon-row);
-                display: flex;
-                justify-content: flex-end;
-                align-items: flex-end;
-            }
+        app-subjects:has(.subject:has(a) ~ .subject:has(a)) .subject:has(a):not(:has(~ .subject:has(a))) {
+            padding-bottom: 0;
+            padding-left: var(--public-card-icon-island);
+            min-height: var(--public-card-icon-row);
+            display: flex;
+            justify-content: flex-end;
+            align-items: flex-end;
         }
     }
 }

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -111,13 +111,12 @@ mat-card .mdc-card__actions:not(.review-actions) {
 
             // With siblings: only the last line reserves the icon island;
             // earlier subjects (incl. long names) keep full width.
+            // Do NOT set min-height here — that stretched the last row and left
+            // a blank gap above the final label (e.g. before "Purity Culture").
+            // Icons are absolute bottom:0, so they share the natural baseline.
             &:last-child:not(:only-child) {
                 padding-bottom: 0;
                 padding-left: var(--public-card-icon-island);
-                min-height: var(--public-card-icon-row);
-                display: flex;
-                justify-content: flex-end;
-                align-items: flex-end;
             }
         }
     }

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -51,31 +51,20 @@ mat-card-actions.review-actions {
     margin-top: 14px;
 }
 
-// Public result cards (homepage, search, podcast, episode, subject, bookmarks,
-// discovery). Subjects use the FULL actions width on their own row so long
-// labels can sit on one line; podcast-service controls stay on a following row
-// at the bottom-left with their normal 25px margins (do not tighten icon
-// spacing). Review/outgoing (.review-actions) keep their own two-column layout.
+// Public result cards (homepage, search, podcast list, podcast episode, subject,
+// bookmarks, discovery). One shared row: service icons LEFT (original 25px
+// margins — do not tighten), subjects RIGHT growing into remaining width,
+// bottom-aligned so the last subject shares a baseline with the icons (#421).
+// Review/outgoing (.review-actions) keep their own two-column layout.
 mat-card .mdc-card__actions:not(.review-actions) {
     flex-direction: row;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
     align-items: flex-end;
     justify-content: flex-start;
 
-    // Subjects first row, full width — “above” the service-icon island.
-    mat-card-footer.subjects {
-        flex: 1 1 100%;
-        order: 0;
-        width: 100%;
-        min-width: 100%;
-        margin: 0;
-    }
-
-    // Service controls second row, bottom-left; preserve global icon margins.
     app-episode-links,
     app-episode-podcast-links {
         flex: 0 0 auto;
-        order: 1;
     }
 
     // Discovery inlines service icons (and optional YouTube meta) as direct
@@ -84,7 +73,13 @@ mat-card .mdc-card__actions:not(.review-actions) {
     > button[mat-icon-button],
     > .youtubemeta {
         flex: 0 0 auto;
-        order: 1;
+    }
+
+    mat-card-footer.subjects {
+        flex: 1 1 0;
+        min-width: 0;
+        width: auto;
+        margin: 0;
     }
 }
 

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -52,10 +52,10 @@ mat-card-actions.review-actions {
 }
 
 // Public result cards (homepage, search, podcast list, podcast episode, subject,
-// bookmarks, discovery). Subjects wrap around a bottom-left service-icon island:
-// full footer width above the icons, narrowed only beside the icon row — so long
-// labels can use the middle space. Icons keep their global 25px margins (not
-// tightened) and sit absolute bottom-left, level with the last subject.
+// bookmarks, discovery). Subjects wrap around a bottom-left service-icon island
+// via a zero-width spacer float + island float (CSS bottom-corner pattern):
+// subjects use full width above the icons, then share the bottom row beside them.
+// Icons keep global 25px margins and sit absolute bottom-left.
 // Review/outgoing (.review-actions) keep their own two-column layout.
 mat-card .mdc-card__actions:not(.review-actions) {
     display: block !important;
@@ -67,43 +67,52 @@ mat-card .mdc-card__actions:not(.review-actions) {
     app-episode-links,
     app-episode-podcast-links {
         position: absolute;
-        // Match .mdc-card__actions padding-left.
         left: 20px;
         bottom: 0;
         z-index: 1;
     }
 
     mat-card-footer.subjects {
+        // Grid so % height on the spacer float resolves against content height.
         display: grid;
         width: 100% !important;
         max-width: 100%;
         margin: 0;
         box-sizing: border-box;
-        min-height: var(--public-card-icon-row);
+
+        // Zero-width spacer: pushes the island float down so subjects above it
+        // sit beside a 0-width float (= full content width).
+        &::before {
+            content: "";
+            grid-area: 1 / 1;
+            float: left;
+            width: 0;
+            height: calc(100% - var(--public-card-icon-row));
+        }
 
         app-subjects {
+            grid-area: 1 / 1;
             display: block !important;
             width: 100%;
             margin-left: 0;
             box-sizing: border-box;
 
-            // L-shaped exclusion: float is full height, but shape-outside only
-            // claims the bottom-left island — line boxes use full width above.
+            // Bottom-left island matching the absolute icon cluster footprint.
             &::before {
                 content: "";
                 float: left;
+                clear: left;
                 width: var(--public-card-icon-island);
-                height: 100%;
-                shape-outside: inset(calc(100% - var(--public-card-icon-row)) 0 0 0);
+                height: var(--public-card-icon-row);
                 pointer-events: none;
             }
         }
 
-        // Block layout so line boxes wrap around the shape-outside float
-        // (flex on .subject would create a BFC and defeat wrap-around).
         .subject {
             display: block;
-            width: 100%;
+            // auto width fills space beside the current float (full width above
+            // the island; shortened beside it).
+            width: auto;
             box-sizing: border-box;
             text-align: right;
             padding-left: 0;
@@ -111,18 +120,13 @@ mat-card .mdc-card__actions:not(.review-actions) {
 
             &:last-child {
                 padding-bottom: 0;
-                min-height: var(--public-card-icon-row);
-                display: flex;
-                justify-content: flex-end;
-                align-items: flex-end;
             }
 
             a {
-                display: inline;
-                flex: none;
-                min-width: 0;
-                max-width: none;
-                text-align: right;
+                color: var(--mat-theme-text-secondary);
+                text-decoration: dashed underline 1px;
+                text-underline-offset: 5px;
+                line-height: 1.25;
             }
         }
     }


### PR DESCRIPTION
## Summary
- Grow the subjects column into spare horizontal space beside podcast-service icons on public result cards (when room exists), while keeping icons bottom-aligned (#421).
- One shared `styles.scss` rule covers homepage, search, podcast list, podcast episode, subject, bookmarks (`app-episode-podcast-links`), and discovery (inline icons / YouTube meta).
- Review / outgoing cards (`.review-actions`) stay on their own icon-column + footer-column layout and are intentionally excluded.

## Test plan
- [ ] Homepage / search / podcast / subject / episode: subjects column fills gap beside service icons; icons remain bottom-aligned with last subject
- [ ] Bookmarks: same with `app-episode-podcast-links`
- [ ] Discovery: same with inline service icons (and YouTube meta when present)
- [ ] Narrow/mobile: subjects shrink without overflowing; one-per-line right-aligned layout preserved
- [ ] Review / outgoing: unchanged two-column layout

Made with [Cursor](https://cursor.com)