### PR TITLE
fix(cards): close single-subject footer gap on all public cards

### DIFF
--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.957",
+  "version": "1.9.958",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.950",
+  "version": "1.9.951",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.961",
+  "version": "1.9.962",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.946",
+  "version": "1.9.947",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.960",
+  "version": "1.9.961",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.945",
+  "version": "1.9.946",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.948",
+  "version": "1.9.949",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.952",
+  "version": "1.9.953",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.956",
+  "version": "1.9.957",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.954",
+  "version": "1.9.955",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.955",
+  "version": "1.9.956",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.959",
+  "version": "1.9.960",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.962",
+  "version": "1.9.963",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.953",
+  "version": "1.9.954",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.947",
+  "version": "1.9.948",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.958",
+  "version": "1.9.959",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.949",
+  "version": "1.9.950",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.951",
+  "version": "1.9.952",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/src/app/bookmarks-api/bookmarks-api.component.sass
+++ b/cultpodcasts/src/app/bookmarks-api/bookmarks-api.component.sass
@@ -3,7 +3,7 @@
 .result
     border: 1px black solid
     margin-bottom: 10px
-    padding: 2px 6px 16px
+    padding: 2px 6px 10px
     h3
         font-weight: bold
         margin-bottom: 2px

--- a/cultpodcasts/src/app/bookmarks-api/bookmarks-api.component.sass
+++ b/cultpodcasts/src/app/bookmarks-api/bookmarks-api.component.sass
@@ -3,7 +3,7 @@
 .result
     border: 1px black solid
     margin-bottom: 10px
-    padding: 2px 6px 14px
+    padding: 2px 6px 16px
     h3
         font-weight: bold
         margin-bottom: 2px

--- a/cultpodcasts/src/app/bookmarks-api/bookmarks-api.component.sass
+++ b/cultpodcasts/src/app/bookmarks-api/bookmarks-api.component.sass
@@ -3,7 +3,7 @@
 .result
     border: 1px black solid
     margin-bottom: 10px
-    padding: 2px 6px
+    padding: 2px 6px 14px
     h3
         font-weight: bold
         margin-bottom: 2px

--- a/cultpodcasts/src/app/discovery-item/discovery-item.component.sass
+++ b/cultpodcasts/src/app/discovery-item/discovery-item.component.sass
@@ -1,7 +1,7 @@
 mat-card
     border: 1px black solid
     margin-bottom: 10px
-    padding: 2px 6px
+    padding: 2px 6px 14px
     h3
         font-weight: bold
         margin-bottom: 2px

--- a/cultpodcasts/src/app/discovery-item/discovery-item.component.sass
+++ b/cultpodcasts/src/app/discovery-item/discovery-item.component.sass
@@ -1,7 +1,7 @@
 mat-card
     border: 1px black solid
     margin-bottom: 10px
-    padding: 2px 6px 16px
+    padding: 2px 6px 10px
     h3
         font-weight: bold
         margin-bottom: 2px

--- a/cultpodcasts/src/app/discovery-item/discovery-item.component.sass
+++ b/cultpodcasts/src/app/discovery-item/discovery-item.component.sass
@@ -1,7 +1,7 @@
 mat-card
     border: 1px black solid
     margin-bottom: 10px
-    padding: 2px 6px 14px
+    padding: 2px 6px 16px
     h3
         font-weight: bold
         margin-bottom: 2px

--- a/cultpodcasts/src/app/homepage-api/homepage-api.component.sass
+++ b/cultpodcasts/src/app/homepage-api/homepage-api.component.sass
@@ -32,7 +32,7 @@
     .result
         border: 1px black solid
         margin-bottom: 10px
-        padding: 2px 6px
+        padding: 2px 6px 14px
         h3
             font-weight: bold
             margin-bottom: 2px

--- a/cultpodcasts/src/app/homepage-api/homepage-api.component.sass
+++ b/cultpodcasts/src/app/homepage-api/homepage-api.component.sass
@@ -32,7 +32,7 @@
     .result
         border: 1px black solid
         margin-bottom: 10px
-        padding: 2px 6px 14px
+        padding: 2px 6px 16px
         h3
             font-weight: bold
             margin-bottom: 2px

--- a/cultpodcasts/src/app/homepage-api/homepage-api.component.sass
+++ b/cultpodcasts/src/app/homepage-api/homepage-api.component.sass
@@ -32,7 +32,7 @@
     .result
         border: 1px black solid
         margin-bottom: 10px
-        padding: 2px 6px 16px
+        padding: 2px 6px 10px
         h3
             font-weight: bold
             margin-bottom: 2px

--- a/cultpodcasts/src/app/podcast-api/podcast-api.component.sass
+++ b/cultpodcasts/src/app/podcast-api/podcast-api.component.sass
@@ -3,7 +3,7 @@
 .result
     border: 1px black solid
     margin-bottom: 10px
-    padding: 2px 6px 16px
+    padding: 2px 6px 10px
     h3
         font-weight: bold
         margin-bottom: 2px

--- a/cultpodcasts/src/app/podcast-api/podcast-api.component.sass
+++ b/cultpodcasts/src/app/podcast-api/podcast-api.component.sass
@@ -3,7 +3,7 @@
 .result
     border: 1px black solid
     margin-bottom: 10px
-    padding: 2px 6px 14px
+    padding: 2px 6px 16px
     h3
         font-weight: bold
         margin-bottom: 2px

--- a/cultpodcasts/src/app/podcast-api/podcast-api.component.sass
+++ b/cultpodcasts/src/app/podcast-api/podcast-api.component.sass
@@ -3,7 +3,7 @@
 .result
     border: 1px black solid
     margin-bottom: 10px
-    padding: 2px 6px
+    padding: 2px 6px 14px
     h3
         font-weight: bold
         margin-bottom: 2px

--- a/cultpodcasts/src/app/podcast-episode/podcast-episode.component.sass
+++ b/cultpodcasts/src/app/podcast-episode/podcast-episode.component.sass
@@ -3,7 +3,7 @@
 .result
     border: 1px black solid
     margin-bottom: 10px
-    padding: 2px 6px 16px
+    padding: 2px 6px 10px
     h3
         font-weight: bold
         margin-bottom: 2px

--- a/cultpodcasts/src/app/podcast-episode/podcast-episode.component.sass
+++ b/cultpodcasts/src/app/podcast-episode/podcast-episode.component.sass
@@ -3,7 +3,7 @@
 .result
     border: 1px black solid
     margin-bottom: 10px
-    padding: 2px 6px 14px
+    padding: 2px 6px 16px
     h3
         font-weight: bold
         margin-bottom: 2px

--- a/cultpodcasts/src/app/podcast-episode/podcast-episode.component.sass
+++ b/cultpodcasts/src/app/podcast-episode/podcast-episode.component.sass
@@ -3,7 +3,7 @@
 .result
     border: 1px black solid
     margin-bottom: 10px
-    padding: 2px 6px
+    padding: 2px 6px 14px
     h3
         font-weight: bold
         margin-bottom: 2px

--- a/cultpodcasts/src/app/search-api/search-api.component.sass
+++ b/cultpodcasts/src/app/search-api/search-api.component.sass
@@ -3,7 +3,7 @@
 .result
     border: 1px black solid
     margin-bottom: 10px
-    padding: 2px 6px 16px
+    padding: 2px 6px 10px
     h3
         font-weight: bold
         margin-bottom: 2px

--- a/cultpodcasts/src/app/search-api/search-api.component.sass
+++ b/cultpodcasts/src/app/search-api/search-api.component.sass
@@ -3,7 +3,7 @@
 .result
     border: 1px black solid
     margin-bottom: 10px
-    padding: 2px 6px 14px
+    padding: 2px 6px 16px
     h3
         font-weight: bold
         margin-bottom: 2px

--- a/cultpodcasts/src/app/search-api/search-api.component.sass
+++ b/cultpodcasts/src/app/search-api/search-api.component.sass
@@ -3,7 +3,7 @@
 .result
     border: 1px black solid
     margin-bottom: 10px
-    padding: 2px 6px
+    padding: 2px 6px 14px
     h3
         font-weight: bold
         margin-bottom: 2px

--- a/cultpodcasts/src/app/subject-api/subject-api.component.sass
+++ b/cultpodcasts/src/app/subject-api/subject-api.component.sass
@@ -3,7 +3,7 @@
 .result
     border: 1px black solid
     margin-bottom: 10px
-    padding: 2px 6px 16px
+    padding: 2px 6px 10px
     h3
         font-weight: bold
         margin-bottom: 2px

--- a/cultpodcasts/src/app/subject-api/subject-api.component.sass
+++ b/cultpodcasts/src/app/subject-api/subject-api.component.sass
@@ -3,7 +3,7 @@
 .result
     border: 1px black solid
     margin-bottom: 10px
-    padding: 2px 6px 14px
+    padding: 2px 6px 16px
     h3
         font-weight: bold
         margin-bottom: 2px

--- a/cultpodcasts/src/app/subject-api/subject-api.component.sass
+++ b/cultpodcasts/src/app/subject-api/subject-api.component.sass
@@ -3,7 +3,7 @@
 .result
     border: 1px black solid
     margin-bottom: 10px
-    padding: 2px 6px
+    padding: 2px 6px 14px
     h3
         font-weight: bold
         margin-bottom: 2px

--- a/cultpodcasts/src/app/subjects/subjects.component.sass
+++ b/cultpodcasts/src/app/subjects/subjects.component.sass
@@ -22,8 +22,6 @@
         // icons' own margins; padding here only shrinks room for long labels.
         padding-left: 0
         padding-bottom: 6px
-        // Keep last subject on the same bottom edge as service icons
-        // (public cards use align-items: flex-end on the actions row).
         &:last-child
             padding-bottom: 0
         gap: 0

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -61,7 +61,7 @@ mat-card-actions.review-actions {
 // subject (that left a hole above it).
 // Review/outgoing (.review-actions) keep their own two-column layout.
 mat-card:has(> .mdc-card__actions:not(.review-actions)) {
-    padding-bottom: 16px;
+    padding-bottom: 10px;
 }
 
 mat-card .mdc-card__actions:not(.review-actions) {
@@ -73,16 +73,18 @@ mat-card .mdc-card__actions:not(.review-actions) {
     --public-card-icon-row: var(--mdc-icon-button-state-layer-size, 40px);
     // Natural last-subject line box (matches .subject a line-height ≈ 1.25).
     --public-card-subject-line: 20px;
-    // Keep icons clear of the card/actions bottom edge (also absorbs scale(1.2)).
-    --public-card-footer-clearance: 14px;
+    // Keep icons clear of the card/actions bottom edge (~10px visible gap).
+    --public-card-footer-clearance: 10px;
     // Shift icons relative to that clearance so icon mid == last-subject mid.
     --public-card-icon-mid-nudge: calc((var(--public-card-icon-row) - var(--public-card-subject-line)) / 2);
     min-height: var(--public-card-icon-row);
     // Lifts in-flow subjects with the icons; abspos bottom uses the same token.
     padding-bottom: var(--public-card-footer-clearance);
+    // Space beneath description before the icon/subject footer row.
+    padding-top: 8px;
     --public-card-icon-island: 16.5rem;
 
-    // No subjects: breathe between description and the icon row.
+    // No subjects: extra breathe between description and the icon row.
     &:not(:has(.subject)) {
         padding-top: 22px;
         min-height: calc(var(--public-card-icon-row) + 22px + var(--public-card-footer-clearance));

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -81,8 +81,8 @@ mat-card .mdc-card__actions:not(.review-actions) {
 
     // No subjects: breathe between description and the icon row.
     &:not(:has(.subject)) {
-        padding-top: 14px;
-        min-height: calc(var(--public-card-icon-row) + 14px);
+        padding-top: 22px;
+        min-height: calc(var(--public-card-icon-row) + 22px);
     }
 
     app-episode-links,

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -149,13 +149,14 @@ mat-card .mdc-card__actions:not(.review-actions) {
                 padding-left: var(--public-card-icon-island);
             }
 
-            // Match icon-row height so text mid-aligns with buttons; fills min-height
-            // without a dead band under the description.
+            // Icon-tall row under the shared desc gap so buttons don't invade
+            // description; text at the TOP of that row so it matches multi's
+            // first-subject line (centering put labels ~10px lower than 2+).
             &:only-child {
                 padding-left: 0;
                 min-height: var(--public-card-icon-row);
                 display: flex;
-                align-items: center;
+                align-items: flex-start;
                 justify-content: flex-end;
             }
         }

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -68,7 +68,9 @@ mat-card .mdc-card__actions:not(.review-actions) {
     min-height: var(--mdc-icon-button-state-layer-size, 40px);
     // Space under icons + subject baseline so they clear the card border.
     // Absolute icons use the same value for `bottom` (abspos ignores padding).
-    --public-card-actions-inset: 10px;
+    // 16px (not 10): icon buttons use transform:scale(1.2), which extends the
+    // visual past the layout box toward the card edge.
+    --public-card-actions-inset: 16px;
     padding-bottom: var(--public-card-actions-inset);
     // Max footprint of 4 service buttons with 25px margins (do not shrink icons).
     --public-card-icon-island: 16.5rem;

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -52,15 +52,21 @@ mat-card-actions.review-actions {
 }
 
 // Public result cards (homepage, search, podcast list, podcast episode, subject,
-// bookmarks, discovery). Subjects use the FULL footer width; the last subject
-// (including when alone) reserves a bottom-left island for service icons so
-// short trailing labels sit beside them on the same baseline. Leading subjects
-// — including long labels — are not trapped in a narrow right column.
-// Icons keep global 25px margins and are absolutely pinned bottom-left.
+// bookmarks, discovery) — ONE shared rule for all of these surfaces.
+// Subjects use the FULL footer width; the last subject (including when alone)
+// reserves a bottom-left island for service icons so labels sit beside them on
+// the same baseline. Leading subjects keep full width.
+// Icons stay absolutely pinned bottom-left. The actions row is a column flex
+// with justify-end + icon-sized min-height so a lone short subject is pulled
+// down onto the icon baseline (no padding-bottom dead band under the label).
 // Review/outgoing (.review-actions) keep their own two-column layout.
 mat-card .mdc-card__actions:not(.review-actions) {
-    display: block !important;
+    display: flex !important;
+    flex-direction: column;
+    justify-content: flex-end;
+    align-items: stretch;
     position: relative;
+    min-height: var(--mdc-icon-button-state-layer-size, 40px);
     // Max footprint of 4 service buttons with 25px margins (do not shrink icons).
     --public-card-icon-island: 16.5rem;
 
@@ -103,24 +109,15 @@ mat-card .mdc-card__actions:not(.review-actions) {
                 line-height: 1.25;
             }
 
-            // Last line (alone or with siblings) reserves the icon island and
-            // shares the natural baseline with absolute bottom:0 icons.
+            // Last line (alone or with siblings) reserves the icon island.
             // Earlier siblings keep full width. Do NOT set min-height on the
-            // multi-subject last line — that stretched the row and left a blank
-            // band above the final label (e.g. before "Purity Culture").
+            // subject row — that stretched multi-subject last lines and left a
+            // blank band above the final label. Do NOT use padding-bottom to
+            // reserve the icon row — that left a dead band under a lone subject
+            // on homepage / search / discovery.
             &:last-child {
                 padding-bottom: 0;
                 padding-left: var(--public-card-icon-island);
-            }
-
-            // Lone subject: row must be tall enough for absolute icons, with the
-            // label centered on the icon mid-line (same band as youtube-stats).
-            // Avoid padding-bottom reserves — those left a dead band under the label.
-            &:only-child {
-                min-height: var(--mdc-icon-button-state-layer-size, 40px);
-                display: flex;
-                align-items: center;
-                justify-content: flex-end;
             }
         }
     }

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -149,14 +149,13 @@ mat-card .mdc-card__actions:not(.review-actions) {
                 padding-left: var(--public-card-icon-island);
             }
 
-            // Icon-tall row under the shared desc gap so buttons don't invade
-            // description; text at the TOP of that row so it matches multi's
-            // first-subject line (centering put labels ~10px lower than 2+).
+            // Icon-tall row under the shared 8px desc gap; center the label so it
+            // shares a mid-line with the abspos icon buttons (same as multi last-subject).
             &:only-child {
                 padding-left: 0;
                 min-height: var(--public-card-icon-row);
                 display: flex;
-                align-items: flex-start;
+                align-items: center;
                 justify-content: flex-end;
             }
         }

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -53,13 +53,12 @@ mat-card-actions.review-actions {
 
 // Public result cards (homepage, search, podcast list, podcast episode, subject,
 // bookmarks, discovery) — ONE shared rule for all of these surfaces.
-// Subjects use the FULL footer width; the last subject (including when alone)
-// reserves a bottom-left island for service icons so labels sit beside them on
-// the same baseline. Leading subjects keep full width.
-// Icons stay absolutely pinned bottom-left. The actions row is a column flex
-// with justify-end + icon-sized min-height so a lone short subject is pulled
-// down onto the icon baseline (no padding-bottom dead band under the label).
-// Review/outgoing (.review-actions) keep their own two-column layout.
+// Subjects use the FULL footer width; only the last subject when siblings exist
+// reserves a bottom-left island for service icons. A lone subject stays full
+// width (like a leading multi-subject line) so long labels use the middle;
+// actions flex-end + min-height keep it on the icon baseline with no dead band.
+// Icons stay absolutely pinned bottom-left. Review/outgoing (.review-actions)
+// keep their own two-column layout.
 mat-card .mdc-card__actions:not(.review-actions) {
     display: flex !important;
     flex-direction: column;
@@ -109,15 +108,21 @@ mat-card .mdc-card__actions:not(.review-actions) {
                 line-height: 1.25;
             }
 
-            // Last line (alone or with siblings) reserves the icon island.
-            // Earlier siblings keep full width. Do NOT set min-height on the
-            // subject row — that stretched multi-subject last lines and left a
-            // blank band above the final label. Do NOT use padding-bottom to
-            // reserve the icon row — that left a dead band under a lone subject
-            // on homepage / search / discovery.
-            &:last-child {
+            // With siblings: only the last line reserves the icon island.
+            // Earlier siblings (and a lone subject) keep FULL footer width so
+            // long labels can use the middle — same as #423 flow-around.
+            // Do NOT set min-height on the subject row (blank band above label).
+            // Do NOT use padding-bottom to reserve the icon row (vertical dead
+            // band). Actions flex-end + min-height keep only-child on the icon
+            // baseline without a narrow right column.
+            &:last-child:not(:only-child) {
                 padding-bottom: 0;
                 padding-left: var(--public-card-icon-island);
+            }
+
+            &:only-child {
+                padding-bottom: 0;
+                padding-left: 0;
             }
         }
     }

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -55,14 +55,12 @@ mat-card-actions.review-actions {
 // bookmarks, discovery) — ONE shared rule for all of these surfaces.
 // Subjects use the FULL footer width; only the last subject when siblings exist
 // reserves a bottom-left island for service icons. A lone subject stays full
-// width (like a leading multi-subject line) so long labels use the middle.
-// Last subject (and Discovery youtube-stats) are vertically centered on the
-// icon-button mid-line — not parked on the icon bottom edge.
-// Icons stay absolutely pinned bottom-left. Bottom clearance is padding on the
-// card itself — never lift icons with a separate absolute `bottom` inset.
+// width. Last subject keeps NATURAL line height (uniform gaps with siblings);
+// service icons / youtube-stats are nudged so their mid-line matches that last
+// line — do NOT min-height the last subject (that left a hole above it).
+// Bottom clearance is padding on the card itself.
 // Review/outgoing (.review-actions) keep their own two-column layout.
 mat-card:has(> .mdc-card__actions:not(.review-actions)) {
-    // Keeps the shared icon+subject band clear of the card bottom border.
     padding-bottom: 16px;
 }
 
@@ -73,14 +71,19 @@ mat-card .mdc-card__actions:not(.review-actions) {
     align-items: stretch;
     position: relative;
     --public-card-icon-row: var(--mdc-icon-button-state-layer-size, 40px);
+    // Natural last-subject line box (matches .subject a line-height ≈ 1.25).
+    --public-card-subject-line: 20px;
+    // Shift icons down so icon mid == last-subject mid.
+    --public-card-icon-mid-nudge: calc((var(--public-card-icon-row) - var(--public-card-subject-line)) / 2);
     min-height: var(--public-card-icon-row);
-    // Material defaults ~8px padding-bottom; abspos bottom:0 sits on the
-    // padding edge while in-flow subjects end above it. Zero it so the last
-    // subject row and icons share the same bottom band; card padding-bottom
-    // provides clearance from the card border.
     padding-bottom: 0;
-    // Max footprint of 4 service buttons with 25px margins (do not shrink icons).
     --public-card-icon-island: 16.5rem;
+
+    // No subjects: breathe between description and the icon row.
+    &:not(:has(.subject)) {
+        padding-top: 14px;
+        min-height: calc(var(--public-card-icon-row) + 14px);
+    }
 
     app-episode-links,
     app-episode-podcast-links {
@@ -88,6 +91,14 @@ mat-card .mdc-card__actions:not(.review-actions) {
         left: 20px;
         bottom: 0;
         z-index: 1;
+    }
+
+    &:has(.subject) {
+
+        app-episode-links,
+        app-episode-podcast-links {
+            bottom: calc(-1 * var(--public-card-icon-mid-nudge));
+        }
     }
 
     mat-card-footer.subjects {
@@ -112,6 +123,7 @@ mat-card .mdc-card__actions:not(.review-actions) {
             box-sizing: border-box;
             text-align: right;
             padding-left: 0;
+            // Uniform gap between subject lines (including before the last).
             padding-bottom: 6px;
 
             a {
@@ -121,19 +133,11 @@ mat-card .mdc-card__actions:not(.review-actions) {
                 line-height: 1.25;
             }
 
-            // Last line matches icon-button height and centers the label on the
-            // icon mid-line. Use center (not flex-end) — flex-end parked text
-            // under the icons; min-height alone with flex-end also left a blank
-            // band above multi-subject last labels.
+            // Natural height only — no min-height (avoids a hole above last label).
             &:last-child {
                 padding-bottom: 0;
-                min-height: var(--public-card-icon-row);
-                display: flex;
-                align-items: center;
-                justify-content: flex-end;
             }
 
-            // With siblings: reserve the icon island. Alone: full width.
             &:last-child:not(:only-child) {
                 padding-left: var(--public-card-icon-island);
             }
@@ -152,6 +156,18 @@ mat-card .mdc-card__actions:not(.review-actions):has(> a[mat-icon-button], > but
         position: absolute;
         bottom: 0;
         z-index: 1;
+    }
+
+    &:has(.subject) {
+
+        > a[mat-icon-button],
+        > button[mat-icon-button] {
+            bottom: calc(-1 * var(--public-card-icon-mid-nudge));
+        }
+
+        > .youtubemeta {
+            bottom: calc(-1 * var(--public-card-icon-mid-nudge));
+        }
     }
 
     > a[mat-icon-button]:nth-of-type(1),
@@ -174,7 +190,6 @@ mat-card .mdc-card__actions:not(.review-actions):has(> a[mat-icon-button], > but
         left: 215px;
     }
 
-    // Same mid-line as last subject / service icons.
     > .youtubemeta {
         position: absolute;
         bottom: 0;

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -67,7 +67,9 @@ mat-card:has(> .mdc-card__actions:not(.review-actions)) {
 mat-card .mdc-card__actions:not(.review-actions) {
     display: flex !important;
     flex-direction: column;
-    justify-content: flex-end;
+    // flex-start keeps padding-top as the desc→footer gap (flex-end + min-height
+    // used to park a lone subject at the bottom and open a hole under the description).
+    justify-content: flex-start;
     align-items: stretch;
     position: relative;
     --public-card-icon-row: var(--mdc-icon-button-state-layer-size, 40px);
@@ -92,16 +94,16 @@ mat-card .mdc-card__actions:not(.review-actions) {
     app-episode-podcast-links {
         position: absolute;
         left: 20px;
-        // Default (no subjects): sit on the clearance inset.
+        // Default (no subjects / only-child icon-tall row): sit on the clearance inset.
         bottom: var(--public-card-footer-clearance);
         z-index: 1;
     }
 
-    &:has(.subject) {
+    // Multi-subject: last line is ~20px; nudge icons so mid matches that line.
+    &:has(.subject:not(:only-child)) {
 
         app-episode-links,
         app-episode-podcast-links {
-            // clearance lifts the band; subtract mid-nudge so icon mid matches text.
             bottom: calc(var(--public-card-footer-clearance) - var(--public-card-icon-mid-nudge));
         }
     }
@@ -147,8 +149,14 @@ mat-card .mdc-card__actions:not(.review-actions) {
                 padding-left: var(--public-card-icon-island);
             }
 
+            // Match icon-row height so text mid-aligns with buttons; fills min-height
+            // without a dead band under the description.
             &:only-child {
                 padding-left: 0;
+                min-height: var(--public-card-icon-row);
+                display: flex;
+                align-items: center;
+                justify-content: flex-end;
             }
         }
     }
@@ -163,7 +171,8 @@ mat-card .mdc-card__actions:not(.review-actions):has(> a[mat-icon-button], > but
         z-index: 1;
     }
 
-    &:has(.subject) {
+    // Multi-subject only — only-child row is icon-tall so no mid-nudge.
+    &:has(.subject:not(:only-child)) {
 
         > a[mat-icon-button],
         > button[mat-icon-button] {

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -60,36 +60,34 @@ mat-card-actions.review-actions {
 // so their mid-line matches the last subject — do NOT min-height the last
 // subject (that left a hole above it).
 // Review/outgoing (.review-actions) keep their own two-column layout.
+// Public / Discovery card footer contract:
+// - Card padding-bottom = icon→card-bottom clearance (~10px) for 0 / 1 / 2+ subjects.
+// - Icons are absolute bottom:0 (never nudged); subjects mid-align to them.
+// - padding-top = desc→footer gap (8px).
+// - only-child: full-width icon-tall row, label centered with icons.
+// - 2+: leading subjects full width; last subject has icon-island inset; uniform 6px gaps.
 mat-card:has(> .mdc-card__actions:not(.review-actions)) {
-    padding-bottom: 10px;
+    --public-card-footer-clearance: 10px;
+    padding-bottom: var(--public-card-footer-clearance);
 }
 
 mat-card .mdc-card__actions:not(.review-actions) {
     display: flex !important;
     flex-direction: column;
-    // flex-start keeps padding-top as the desc→footer gap (flex-end + min-height
-    // used to park a lone subject at the bottom and open a hole under the description).
     justify-content: flex-start;
     align-items: stretch;
     position: relative;
     --public-card-icon-row: var(--mdc-icon-button-state-layer-size, 40px);
-    // Natural last-subject line box (matches .subject a line-height ≈ 1.25).
     --public-card-subject-line: 20px;
-    // Visible icon→card-bottom gap comes from mat-card padding-bottom (10px).
-    --public-card-footer-clearance: 10px;
-    // Used when lifting in-flow last subject into the icon mid-line (multi only).
+    // Half (icon-row − subject-line): multi pad-bottom so last-line mid == icon mid.
     --public-card-icon-mid-nudge: calc((var(--public-card-icon-row) - var(--public-card-subject-line)) / 2);
-    // Space beneath description — same for 0 / 1 / 2+ subjects (multi is the reference).
     --public-card-desc-gap: 8px;
+    --public-card-icon-island: 16.5rem;
     box-sizing: border-box;
-    // Icon row sits below the desc gap; card padding supplies bottom clearance.
     min-height: calc(var(--public-card-desc-gap) + var(--public-card-icon-row));
     padding-top: var(--public-card-desc-gap);
     padding-bottom: 0;
-    --public-card-icon-island: 16.5rem;
 
-    // Icons always flush to the actions bottom so icon→card-bottom is identical
-    // for 0 / 1 / 2+ (card padding-bottom = 10px clearance). Do not nudge icons.
     app-episode-links,
     app-episode-podcast-links {
         position: absolute;
@@ -98,11 +96,10 @@ mat-card .mdc-card__actions:not(.review-actions) {
         z-index: 1;
     }
 
-    // Multi-subject: lift in-flow subjects so last-line mid matches icon mid
-    // (icons stay at bottom: 0).
+    // Multi: lift the subject stack so the last line shares the icon mid-line.
     &:has(.subject:not(:only-child)) {
-        padding-bottom: var(--public-card-footer-clearance);
-        min-height: calc(var(--public-card-desc-gap) + var(--public-card-icon-row) + var(--public-card-footer-clearance));
+        padding-bottom: var(--public-card-icon-mid-nudge);
+        min-height: calc(var(--public-card-desc-gap) + var(--public-card-icon-row) + var(--public-card-icon-mid-nudge));
     }
 
     mat-card-footer.subjects {
@@ -127,7 +124,6 @@ mat-card .mdc-card__actions:not(.review-actions) {
             box-sizing: border-box;
             text-align: right;
             padding-left: 0;
-            // Uniform gap between subject lines (including before the last).
             padding-bottom: 6px;
 
             a {
@@ -137,19 +133,17 @@ mat-card .mdc-card__actions:not(.review-actions) {
                 line-height: 1.25;
             }
 
-            // Natural height only — no min-height (avoids a hole above last label).
             &:last-child {
                 padding-bottom: 0;
             }
 
+            // Flow-around: reserve horizontal space beside abspos icons.
             &:last-child:not(:only-child) {
                 padding-left: var(--public-card-icon-island);
             }
 
-            // Icon-tall row under the shared 8px desc gap; center the label so it
-            // shares a mid-line with icons fixed at bottom: 0.
+            // Lone subject: full width + share mid-line with icon row.
             &:only-child {
-                padding-left: 0;
                 min-height: var(--public-card-icon-row);
                 display: flex;
                 align-items: center;
@@ -164,7 +158,6 @@ mat-card .mdc-card__actions:not(.review-actions):has(> a[mat-icon-button], > but
     > a[mat-icon-button],
     > button[mat-icon-button] {
         position: absolute;
-        // Same fixed bottom as homepage links — card padding is the clearance.
         bottom: 0;
         z-index: 1;
     }

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -55,15 +55,15 @@ mat-card-actions.review-actions {
 // bookmarks, discovery) — ONE shared rule for all of these surfaces.
 // Subjects use the FULL footer width; only the last subject when siblings exist
 // reserves a bottom-left island for service icons. A lone subject stays full
-// width (like a leading multi-subject line) so long labels use the middle;
-// actions flex-end + min-height keep it on the icon baseline with no dead band.
-// Icons stay absolutely pinned bottom-left of the actions row (same baseline as
-// subjects). Bottom clearance from the card edge is padding on the card itself
-// — never lift icons with a separate absolute `bottom` inset.
+// width (like a leading multi-subject line) so long labels use the middle.
+// Last subject (and Discovery youtube-stats) are vertically centered on the
+// icon-button mid-line — not parked on the icon bottom edge.
+// Icons stay absolutely pinned bottom-left. Bottom clearance is padding on the
+// card itself — never lift icons with a separate absolute `bottom` inset.
 // Review/outgoing (.review-actions) keep their own two-column layout.
 mat-card:has(> .mdc-card__actions:not(.review-actions)) {
-    // Keeps icons+subjects (shared baseline) clear of the card bottom border.
-    padding-bottom: 12px;
+    // Keeps the shared icon+subject band clear of the card bottom border.
+    padding-bottom: 16px;
 }
 
 mat-card .mdc-card__actions:not(.review-actions) {
@@ -72,11 +72,12 @@ mat-card .mdc-card__actions:not(.review-actions) {
     justify-content: flex-end;
     align-items: stretch;
     position: relative;
-    min-height: var(--mdc-icon-button-state-layer-size, 40px);
+    --public-card-icon-row: var(--mdc-icon-button-state-layer-size, 40px);
+    min-height: var(--public-card-icon-row);
     // Material defaults ~8px padding-bottom; abspos bottom:0 sits on the
-    // padding edge while in-flow subjects end above it — that splits the
-    // baseline. Zero it so icons + subjects share the content bottom; card
-    // padding-bottom (above) provides clearance from the card border.
+    // padding edge while in-flow subjects end above it. Zero it so the last
+    // subject row and icons share the same bottom band; card padding-bottom
+    // provides clearance from the card border.
     padding-bottom: 0;
     // Max footprint of 4 service buttons with 25px margins (do not shrink icons).
     --public-card-icon-island: 16.5rem;
@@ -120,20 +121,24 @@ mat-card .mdc-card__actions:not(.review-actions) {
                 line-height: 1.25;
             }
 
-            // With siblings: only the last line reserves the icon island.
-            // Earlier siblings (and a lone subject) keep FULL footer width so
-            // long labels can use the middle — same as #423 flow-around.
-            // Do NOT set min-height on the subject row (blank band above label).
-            // Do NOT use padding-bottom to reserve the icon row (vertical dead
-            // band). Actions flex-end + min-height keep only-child on the icon
-            // baseline without a narrow right column.
-            &:last-child:not(:only-child) {
+            // Last line matches icon-button height and centers the label on the
+            // icon mid-line. Use center (not flex-end) — flex-end parked text
+            // under the icons; min-height alone with flex-end also left a blank
+            // band above multi-subject last labels.
+            &:last-child {
                 padding-bottom: 0;
+                min-height: var(--public-card-icon-row);
+                display: flex;
+                align-items: center;
+                justify-content: flex-end;
+            }
+
+            // With siblings: reserve the icon island. Alone: full width.
+            &:last-child:not(:only-child) {
                 padding-left: var(--public-card-icon-island);
             }
 
             &:only-child {
-                padding-bottom: 0;
                 padding-left: 0;
             }
         }
@@ -169,14 +174,15 @@ mat-card .mdc-card__actions:not(.review-actions):has(> a[mat-icon-button], > but
         left: 215px;
     }
 
-    // Match icon-button height and center meta so Members/Views sit on the
-    // icon mid-line with subjects (a short bottom:0 box sat too low).
+    // Same mid-line as last subject / service icons.
     > .youtubemeta {
         position: absolute;
         bottom: 0;
         left: 85px;
         z-index: 1;
-        height: var(--mdc-icon-button-state-layer-size, 40px);
+        height: var(--public-card-icon-row);
+        display: flex;
+        flex-direction: column;
         justify-content: center;
         box-sizing: border-box;
     }

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -73,6 +73,11 @@ mat-card .mdc-card__actions:not(.review-actions) {
     align-items: stretch;
     position: relative;
     min-height: var(--mdc-icon-button-state-layer-size, 40px);
+    // Material defaults ~8px padding-bottom; abspos bottom:0 sits on the
+    // padding edge while in-flow subjects end above it — that splits the
+    // baseline. Zero it so icons + subjects share the content bottom; card
+    // padding-bottom (above) provides clearance from the card border.
+    padding-bottom: 0;
     // Max footprint of 4 service buttons with 25px margins (do not shrink icons).
     --public-card-icon-island: 16.5rem;
 

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -77,18 +77,16 @@ mat-card .mdc-card__actions:not(.review-actions) {
     --public-card-footer-clearance: 10px;
     // Shift icons relative to that clearance so icon mid == last-subject mid.
     --public-card-icon-mid-nudge: calc((var(--public-card-icon-row) - var(--public-card-subject-line)) / 2);
-    min-height: var(--public-card-icon-row);
+    // Space beneath description — same for 0 / 1 / 2+ subjects (multi is the reference).
+    --public-card-desc-gap: 8px;
+    box-sizing: border-box;
+    // Tall enough that abspos icons sit entirely below the desc gap (only-child
+    // used to let 40px icons poke up into the description).
+    min-height: calc(var(--public-card-desc-gap) + var(--public-card-icon-row) + var(--public-card-footer-clearance));
     // Lifts in-flow subjects with the icons; abspos bottom uses the same token.
     padding-bottom: var(--public-card-footer-clearance);
-    // Space beneath description before the icon/subject footer row.
-    padding-top: 8px;
+    padding-top: var(--public-card-desc-gap);
     --public-card-icon-island: 16.5rem;
-
-    // No subjects: extra breathe between description and the icon row.
-    &:not(:has(.subject)) {
-        padding-top: 22px;
-        min-height: calc(var(--public-card-icon-row) + 22px + var(--public-card-footer-clearance));
-    }
 
     app-episode-links,
     app-episode-podcast-links {

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -53,15 +53,14 @@ mat-card-actions.review-actions {
 
 // Public result cards (homepage, search, podcast list, podcast episode, subject,
 // bookmarks, discovery). Subjects use the FULL footer width; the last subject
-// (when not alone) reserves a bottom-left island for service icons so short
-// trailing labels sit beside them on the same baseline. Leading subjects —
-// including long labels — are not trapped in a narrow right column.
+// (including when alone) reserves a bottom-left island for service icons so
+// short trailing labels sit beside them on the same baseline. Leading subjects
+// — including long labels — are not trapped in a narrow right column.
 // Icons keep global 25px margins and are absolutely pinned bottom-left.
 // Review/outgoing (.review-actions) keep their own two-column layout.
 mat-card .mdc-card__actions:not(.review-actions) {
     display: block !important;
     position: relative;
-    --public-card-icon-row: 3.25rem;
     // Max footprint of 4 service buttons with 25px margins (do not shrink icons).
     --public-card-icon-island: 16.5rem;
 
@@ -104,19 +103,24 @@ mat-card .mdc-card__actions:not(.review-actions) {
                 line-height: 1.25;
             }
 
-            // Alone: full-width label above the icon row.
-            &:only-child {
-                padding-bottom: var(--public-card-icon-row);
-            }
-
-            // With siblings: only the last line reserves the icon island;
-            // earlier subjects (incl. long names) keep full width.
-            // Do NOT set min-height here — that stretched the last row and left
-            // a blank gap above the final label (e.g. before "Purity Culture").
-            // Icons are absolute bottom:0, so they share the natural baseline.
-            &:last-child:not(:only-child) {
+            // Last line (alone or with siblings) reserves the icon island and
+            // shares the natural baseline with absolute bottom:0 icons.
+            // Earlier siblings keep full width. Do NOT set min-height on the
+            // multi-subject last line — that stretched the row and left a blank
+            // band above the final label (e.g. before "Purity Culture").
+            &:last-child {
                 padding-bottom: 0;
                 padding-left: var(--public-card-icon-island);
+            }
+
+            // Lone subject: row must be tall enough for absolute icons, with the
+            // label centered on the icon mid-line (same band as youtube-stats).
+            // Avoid padding-bottom reserves — those left a dead band under the label.
+            &:only-child {
+                min-height: var(--mdc-icon-button-state-layer-size, 40px);
+                display: flex;
+                align-items: center;
+                justify-content: flex-end;
             }
         }
     }
@@ -151,11 +155,16 @@ mat-card .mdc-card__actions:not(.review-actions):has(> a[mat-icon-button], > but
         left: 215px;
     }
 
+    // Match icon-button height and center meta so Members/Views sit on the
+    // icon mid-line with subjects (a short bottom:0 box sat too low).
     > .youtubemeta {
         position: absolute;
         bottom: 0;
         left: 85px;
         z-index: 1;
+        height: var(--mdc-icon-button-state-layer-size, 40px);
+        justify-content: center;
+        box-sizing: border-box;
     }
 }
 
@@ -186,6 +195,10 @@ mat-card .mdc-card__actions:not(.review-actions):has(> a[mat-icon-button], > but
         > a[mat-icon-button]:nth-of-type(4),
         > button[mat-icon-button]:nth-of-type(4) {
             left: 184px;
+        }
+
+        > .youtubemeta {
+            left: 68px;
         }
     }
 }

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -75,37 +75,34 @@ mat-card .mdc-card__actions:not(.review-actions) {
     --public-card-icon-row: var(--mdc-icon-button-state-layer-size, 40px);
     // Natural last-subject line box (matches .subject a line-height ≈ 1.25).
     --public-card-subject-line: 20px;
-    // Keep icons clear of the card/actions bottom edge (~10px visible gap).
+    // Visible icon→card-bottom gap comes from mat-card padding-bottom (10px).
     --public-card-footer-clearance: 10px;
-    // Shift icons relative to that clearance so icon mid == last-subject mid.
+    // Used when lifting in-flow last subject into the icon mid-line (multi only).
     --public-card-icon-mid-nudge: calc((var(--public-card-icon-row) - var(--public-card-subject-line)) / 2);
     // Space beneath description — same for 0 / 1 / 2+ subjects (multi is the reference).
     --public-card-desc-gap: 8px;
     box-sizing: border-box;
-    // Tall enough that abspos icons sit entirely below the desc gap (only-child
-    // used to let 40px icons poke up into the description).
-    min-height: calc(var(--public-card-desc-gap) + var(--public-card-icon-row) + var(--public-card-footer-clearance));
-    // Lifts in-flow subjects with the icons; abspos bottom uses the same token.
-    padding-bottom: var(--public-card-footer-clearance);
+    // Icon row sits below the desc gap; card padding supplies bottom clearance.
+    min-height: calc(var(--public-card-desc-gap) + var(--public-card-icon-row));
     padding-top: var(--public-card-desc-gap);
+    padding-bottom: 0;
     --public-card-icon-island: 16.5rem;
 
+    // Icons always flush to the actions bottom so icon→card-bottom is identical
+    // for 0 / 1 / 2+ (card padding-bottom = 10px clearance). Do not nudge icons.
     app-episode-links,
     app-episode-podcast-links {
         position: absolute;
         left: 20px;
-        // Default (no subjects / only-child icon-tall row): sit on the clearance inset.
-        bottom: var(--public-card-footer-clearance);
+        bottom: 0;
         z-index: 1;
     }
 
-    // Multi-subject: last line is ~20px; nudge icons so mid matches that line.
+    // Multi-subject: lift in-flow subjects so last-line mid matches icon mid
+    // (icons stay at bottom: 0).
     &:has(.subject:not(:only-child)) {
-
-        app-episode-links,
-        app-episode-podcast-links {
-            bottom: calc(var(--public-card-footer-clearance) - var(--public-card-icon-mid-nudge));
-        }
+        padding-bottom: var(--public-card-footer-clearance);
+        min-height: calc(var(--public-card-desc-gap) + var(--public-card-icon-row) + var(--public-card-footer-clearance));
     }
 
     mat-card-footer.subjects {
@@ -150,7 +147,7 @@ mat-card .mdc-card__actions:not(.review-actions) {
             }
 
             // Icon-tall row under the shared 8px desc gap; center the label so it
-            // shares a mid-line with the abspos icon buttons (same as multi last-subject).
+            // shares a mid-line with icons fixed at bottom: 0.
             &:only-child {
                 padding-left: 0;
                 min-height: var(--public-card-icon-row);
@@ -167,21 +164,9 @@ mat-card .mdc-card__actions:not(.review-actions):has(> a[mat-icon-button], > but
     > a[mat-icon-button],
     > button[mat-icon-button] {
         position: absolute;
-        bottom: var(--public-card-footer-clearance);
+        // Same fixed bottom as homepage links — card padding is the clearance.
+        bottom: 0;
         z-index: 1;
-    }
-
-    // Multi-subject only — only-child row is icon-tall so no mid-nudge.
-    &:has(.subject:not(:only-child)) {
-
-        > a[mat-icon-button],
-        > button[mat-icon-button] {
-            bottom: calc(var(--public-card-footer-clearance) - var(--public-card-icon-mid-nudge));
-        }
-
-        > .youtubemeta {
-            bottom: calc(var(--public-card-footer-clearance) - var(--public-card-icon-mid-nudge));
-        }
     }
 
     > a[mat-icon-button]:nth-of-type(1),
@@ -206,7 +191,7 @@ mat-card .mdc-card__actions:not(.review-actions):has(> a[mat-icon-button], > but
 
     > .youtubemeta {
         position: absolute;
-        bottom: var(--public-card-footer-clearance);
+        bottom: 0;
         left: 85px;
         z-index: 1;
         height: var(--public-card-icon-row);

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -56,9 +56,9 @@ mat-card-actions.review-actions {
 // Subjects use the FULL footer width; only the last subject when siblings exist
 // reserves a bottom-left island for service icons. A lone subject stays full
 // width. Last subject keeps NATURAL line height (uniform gaps with siblings);
-// service icons / youtube-stats are nudged so their mid-line matches that last
-// line — do NOT min-height the last subject (that left a hole above it).
-// Bottom clearance is padding on the card itself.
+// service icons / youtube-stats share a footer clearance band and a mid-nudge
+// so their mid-line matches the last subject — do NOT min-height the last
+// subject (that left a hole above it).
 // Review/outgoing (.review-actions) keep their own two-column layout.
 mat-card:has(> .mdc-card__actions:not(.review-actions)) {
     padding-bottom: 16px;
@@ -73,23 +73,27 @@ mat-card .mdc-card__actions:not(.review-actions) {
     --public-card-icon-row: var(--mdc-icon-button-state-layer-size, 40px);
     // Natural last-subject line box (matches .subject a line-height ≈ 1.25).
     --public-card-subject-line: 20px;
-    // Shift icons down so icon mid == last-subject mid.
+    // Keep icons clear of the card/actions bottom edge (also absorbs scale(1.2)).
+    --public-card-footer-clearance: 14px;
+    // Shift icons relative to that clearance so icon mid == last-subject mid.
     --public-card-icon-mid-nudge: calc((var(--public-card-icon-row) - var(--public-card-subject-line)) / 2);
     min-height: var(--public-card-icon-row);
-    padding-bottom: 0;
+    // Lifts in-flow subjects with the icons; abspos bottom uses the same token.
+    padding-bottom: var(--public-card-footer-clearance);
     --public-card-icon-island: 16.5rem;
 
     // No subjects: breathe between description and the icon row.
     &:not(:has(.subject)) {
         padding-top: 22px;
-        min-height: calc(var(--public-card-icon-row) + 22px);
+        min-height: calc(var(--public-card-icon-row) + 22px + var(--public-card-footer-clearance));
     }
 
     app-episode-links,
     app-episode-podcast-links {
         position: absolute;
         left: 20px;
-        bottom: 0;
+        // Default (no subjects): sit on the clearance inset.
+        bottom: var(--public-card-footer-clearance);
         z-index: 1;
     }
 
@@ -97,7 +101,8 @@ mat-card .mdc-card__actions:not(.review-actions) {
 
         app-episode-links,
         app-episode-podcast-links {
-            bottom: calc(-1 * var(--public-card-icon-mid-nudge));
+            // clearance lifts the band; subtract mid-nudge so icon mid matches text.
+            bottom: calc(var(--public-card-footer-clearance) - var(--public-card-icon-mid-nudge));
         }
     }
 
@@ -154,7 +159,7 @@ mat-card .mdc-card__actions:not(.review-actions):has(> a[mat-icon-button], > but
     > a[mat-icon-button],
     > button[mat-icon-button] {
         position: absolute;
-        bottom: 0;
+        bottom: var(--public-card-footer-clearance);
         z-index: 1;
     }
 
@@ -162,11 +167,11 @@ mat-card .mdc-card__actions:not(.review-actions):has(> a[mat-icon-button], > but
 
         > a[mat-icon-button],
         > button[mat-icon-button] {
-            bottom: calc(-1 * var(--public-card-icon-mid-nudge));
+            bottom: calc(var(--public-card-footer-clearance) - var(--public-card-icon-mid-nudge));
         }
 
         > .youtubemeta {
-            bottom: calc(-1 * var(--public-card-icon-mid-nudge));
+            bottom: calc(var(--public-card-footer-clearance) - var(--public-card-icon-mid-nudge));
         }
     }
 
@@ -192,7 +197,7 @@ mat-card .mdc-card__actions:not(.review-actions):has(> a[mat-icon-button], > but
 
     > .youtubemeta {
         position: absolute;
-        bottom: 0;
+        bottom: var(--public-card-footer-clearance);
         left: 85px;
         z-index: 1;
         height: var(--public-card-icon-row);

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -57,8 +57,8 @@ mat-card-actions.review-actions {
 // reserves a bottom-left island for service icons. A lone subject stays full
 // width (like a leading multi-subject line) so long labels use the middle;
 // actions flex-end + min-height keep it on the icon baseline with no dead band.
-// Icons stay absolutely pinned bottom-left. Review/outgoing (.review-actions)
-// keep their own two-column layout.
+// Icons stay absolutely pinned above a shared bottom inset (not flush to the
+// card edge). Review/outgoing (.review-actions) keep their own two-column layout.
 mat-card .mdc-card__actions:not(.review-actions) {
     display: flex !important;
     flex-direction: column;
@@ -66,6 +66,10 @@ mat-card .mdc-card__actions:not(.review-actions) {
     align-items: stretch;
     position: relative;
     min-height: var(--mdc-icon-button-state-layer-size, 40px);
+    // Space under icons + subject baseline so they clear the card border.
+    // Absolute icons use the same value for `bottom` (abspos ignores padding).
+    --public-card-actions-inset: 10px;
+    padding-bottom: var(--public-card-actions-inset);
     // Max footprint of 4 service buttons with 25px margins (do not shrink icons).
     --public-card-icon-island: 16.5rem;
 
@@ -73,7 +77,7 @@ mat-card .mdc-card__actions:not(.review-actions) {
     app-episode-podcast-links {
         position: absolute;
         left: 20px;
-        bottom: 0;
+        bottom: var(--public-card-actions-inset);
         z-index: 1;
     }
 
@@ -133,7 +137,7 @@ mat-card .mdc-card__actions:not(.review-actions):has(> a[mat-icon-button], > but
     > a[mat-icon-button],
     > button[mat-icon-button] {
         position: absolute;
-        bottom: 0;
+        bottom: var(--public-card-actions-inset);
         z-index: 1;
     }
 
@@ -161,7 +165,7 @@ mat-card .mdc-card__actions:not(.review-actions):has(> a[mat-icon-button], > but
     // icon mid-line with subjects (a short bottom:0 box sat too low).
     > .youtubemeta {
         position: absolute;
-        bottom: 0;
+        bottom: var(--public-card-actions-inset);
         left: 85px;
         z-index: 1;
         height: var(--mdc-icon-button-state-layer-size, 40px);

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -57,8 +57,15 @@ mat-card-actions.review-actions {
 // reserves a bottom-left island for service icons. A lone subject stays full
 // width (like a leading multi-subject line) so long labels use the middle;
 // actions flex-end + min-height keep it on the icon baseline with no dead band.
-// Icons stay absolutely pinned above a shared bottom inset (not flush to the
-// card edge). Review/outgoing (.review-actions) keep their own two-column layout.
+// Icons stay absolutely pinned bottom-left of the actions row (same baseline as
+// subjects). Bottom clearance from the card edge is padding on the card itself
+// — never lift icons with a separate absolute `bottom` inset.
+// Review/outgoing (.review-actions) keep their own two-column layout.
+mat-card:has(> .mdc-card__actions:not(.review-actions)) {
+    // Keeps icons+subjects (shared baseline) clear of the card bottom border.
+    padding-bottom: 12px;
+}
+
 mat-card .mdc-card__actions:not(.review-actions) {
     display: flex !important;
     flex-direction: column;
@@ -66,12 +73,6 @@ mat-card .mdc-card__actions:not(.review-actions) {
     align-items: stretch;
     position: relative;
     min-height: var(--mdc-icon-button-state-layer-size, 40px);
-    // Space under icons + subject baseline so they clear the card border.
-    // Absolute icons use the same value for `bottom` (abspos ignores padding).
-    // 16px (not 10): icon buttons use transform:scale(1.2), which extends the
-    // visual past the layout box toward the card edge.
-    --public-card-actions-inset: 16px;
-    padding-bottom: var(--public-card-actions-inset);
     // Max footprint of 4 service buttons with 25px margins (do not shrink icons).
     --public-card-icon-island: 16.5rem;
 
@@ -79,7 +80,7 @@ mat-card .mdc-card__actions:not(.review-actions) {
     app-episode-podcast-links {
         position: absolute;
         left: 20px;
-        bottom: var(--public-card-actions-inset);
+        bottom: 0;
         z-index: 1;
     }
 
@@ -139,7 +140,7 @@ mat-card .mdc-card__actions:not(.review-actions):has(> a[mat-icon-button], > but
     > a[mat-icon-button],
     > button[mat-icon-button] {
         position: absolute;
-        bottom: var(--public-card-actions-inset);
+        bottom: 0;
         z-index: 1;
     }
 
@@ -167,7 +168,7 @@ mat-card .mdc-card__actions:not(.review-actions):has(> a[mat-icon-button], > but
     // icon mid-line with subjects (a short bottom:0 box sat too low).
     > .youtubemeta {
         position: absolute;
-        bottom: var(--public-card-actions-inset);
+        bottom: 0;
         left: 85px;
         z-index: 1;
         height: var(--mdc-icon-button-state-layer-size, 40px);


### PR DESCRIPTION
## Summary
- Root cause (from #423): lone subjects used `padding-bottom` under absolute icons (vertical dead band). #424 first pass also applied last-child icon-island padding to `:only-child`, which squeezed long labels into a narrow right column with unused middle width.
- Shared `styles.scss` public-card rule (homepage, search, discovery, podcast, episode, subject, bookmarks):
  - Actions: column flex + `justify-content: flex-end` + icon-sized `min-height` so only-child shares the icon baseline (no vertical dead band).
  - `:last-child:not(:only-child)` keeps the horizontal icon island (multi-subject flow-around unchanged).
  - `:only-child` uses full footer width (`padding-left: 0`) like a leading multi-subject line.
  - Discovery `.youtubemeta` centered in icon-button height.
- Version `1.9.948`.

## Test plan
- [ ] Homepage/search: only-child long subject (Latter-Day Saints) — one line / uses middle width; baseline with YouTube/Share; no vertical dead band
- [ ] Same page: multi-subject card — leading subjects full width; last subject beside icons (unchanged #423 look)
- [ ] Discovery: one subject ± youtube-stats — no dead band; stats aligned
- [ ] Review / outgoing: unchanged

Made with [Cursor](https://cursor.com)