### PR TITLE
fix(cards): variable-width footer icon island

### DIFF
--- a/cultpodcasts/docs/public-card-footer-permutations.html
+++ b/cultpodcasts/docs/public-card-footer-permutations.html
@@ -6,7 +6,7 @@
   <title>Public card footer — layout permutations</title>
   <style>
     /*
-      Mirrors cultpodcasts/src/styles.scss public footer contract (v1.9.969+).
+      Mirrors cultpodcasts/src/styles.scss public footer contract (v1.9.970+).
       Open this file in a browser — no Angular build required.
       Cross-check failures against docs/public-card-footer.md checklist.
     */
@@ -74,10 +74,10 @@
 
     /* --- Public footer contract (simplified Material stand-in) --- */
     .actions {
-      display: flex;
-      flex-direction: row;
-      flex-wrap: wrap;
-      justify-content: flex-start;
+      display: grid;
+      grid-template-columns:
+        fit-content(calc(100% - var(--public-card-subject-min)))
+        minmax(var(--public-card-subject-min), 1fr);
       align-items: center;
       position: relative;
       min-height: calc(var(--public-card-desc-gap) + var(--public-card-icon-row));
@@ -88,21 +88,21 @@
       column-gap: 0;
       row-gap: 0;
     }
-    .actions:has(.subject:only-child) {
-      flex-wrap: wrap-reverse;
-    }
 
     .icon-host {
+      grid-column: 1;
       order: 2;
-      flex: 0 0 auto;
+      justify-self: start;
+      align-self: center;
       display: flex;
       flex-direction: row;
       flex-wrap: nowrap;
       align-items: center;
-      align-self: center;
       margin-left: 0;
       height: var(--public-card-icon-row);
       min-height: var(--public-card-icon-row);
+      max-width: 100%;
+      min-width: 0;
     }
 
     .icon-btn {
@@ -162,25 +162,22 @@
       font-size: 0.9rem;
       line-height: 1.25;
     }
-    .subject:not(:only-child) {
+    .subject:not(:last-child) {
+      grid-column: 1 / -1;
       order: 1;
-      flex: 1 0 100%;
       align-self: stretch;
     }
-    .subject:only-child {
+    .subject:last-child {
+      grid-column: 2;
       order: 2;
-      flex: 1 1 var(--public-card-subject-min);
-      min-width: var(--public-card-subject-min);
       padding-bottom: 0;
       align-self: center;
-      height: auto;
+      justify-self: stretch;
+      min-width: 0;
       display: flex;
       flex-direction: row;
       align-items: center;
       justify-content: flex-end;
-    }
-    .subject:last-child:not(:only-child) {
-      padding-bottom: 6px;
     }
 
     /* Mid-line guide (toggle with checkbox) */
@@ -239,8 +236,8 @@
 
   <div class="pass-rules">
     Every card must: flush-left icons · one icon mid-line · island never between subjects ·
-    2+ subjects stacked above icons · only-child mid-aligned with icons ·
-    8px under description · ~10px card bottom · no subject/icon collision · 6px subject gaps.
+    leading subjects full-width above · last/only subject beside island (≥ min-width) ·
+    8px under description · ~10px card bottom · no crush / no subject-icon collision · 6px subject gaps.
   </div>
 
   <h2>A — 0 subjects, YT + Share</h2>
@@ -302,7 +299,7 @@
         <div class="subject">Human Trafficking</div>
         <div class="subject">Hustler's University</div>
       </div>
-      <p class="note">Both subjects full width above; icon island underneath — never between subjects.</p>
+      <p class="note">Leading subjects above; last subject shares the bottom row with icons when ≥ min-width remains.</p>
     </article>
   </div>
 
@@ -320,6 +317,7 @@
         <div class="subject">Human Trafficking</div>
         <div class="subject">Hustler's University</div>
       </div>
+      <p class="note">Subjects 1–2 full width above; last subject shares the bottom row with icons.</p>
     </article>
   </div>
 
@@ -394,7 +392,7 @@
         <div class="subject">Human Trafficking</div>
         <div class="subject">Hustler's University</div>
       </div>
-      <p class="note">Wide island stays <strong>under</strong> both subjects — never between them.</p>
+      <p class="note">Wide island is capped so last subject keeps ≥ min-width on the bottom row — island never between subjects.</p>
     </article>
   </div>
 
@@ -431,7 +429,7 @@
         </div>
         <div class="subject">The Church Of Jesus Christ Of Latter-Day Saints</div>
       </div>
-      <p class="note">Subject keeps at least <code>--public-card-subject-min</code> (100px). If the stats island is too wide, subject stacks <strong>above</strong> the island — never a one-word-per-line column.</p>
+      <p class="note">Subject column ≥ <code>--public-card-subject-min</code> (100px) beside the stats island — not a one-word-per-line crush.</p>
     </article>
   </div>
 

--- a/cultpodcasts/docs/public-card-footer-permutations.html
+++ b/cultpodcasts/docs/public-card-footer-permutations.html
@@ -6,7 +6,7 @@
   <title>Public card footer — layout permutations</title>
   <style>
     /*
-      Mirrors cultpodcasts/src/styles.scss public footer contract (v1.9.967+).
+      Mirrors cultpodcasts/src/styles.scss public footer contract (v1.9.968+).
       Open this file in a browser — no Angular build required.
       Cross-check failures against docs/public-card-footer.md checklist.
     */
@@ -158,12 +158,12 @@
       font-size: 0.9rem;
       line-height: 1.25;
     }
-    .subject:not(:last-child) {
+    .subject:not(:only-child) {
       order: 1;
       flex: 1 0 100%;
       align-self: stretch;
     }
-    .subject:last-child {
+    .subject:only-child {
       order: 2;
       flex: 1 1 0;
       padding-bottom: 0;
@@ -174,6 +174,9 @@
       flex-direction: row;
       align-items: center;
       justify-content: flex-end;
+    }
+    .subject:last-child:not(:only-child) {
+      padding-bottom: 6px;
     }
 
     /* Mid-line guide (toggle with checkbox) */
@@ -231,7 +234,8 @@
   </div>
 
   <div class="pass-rules">
-    Every card must: flush-left icons · one icon mid-line · last/only subject on that mid-line ·
+    Every card must: flush-left icons · one icon mid-line · island never between subjects ·
+    2+ subjects stacked above icons · only-child mid-aligned with icons ·
     8px under description · ~10px card bottom · no subject/icon collision · 6px subject gaps.
   </div>
 
@@ -281,7 +285,7 @@
     </article>
   </div>
 
-  <h2>D — 2+ subjects, YT + Share (short last — uniform gaps)</h2>
+  <h2>D — 2+ subjects, YT + Share (all subjects above icons)</h2>
   <div class="grid">
     <article class="card" data-case="D">
       <div class="card-title">Episode title</div>
@@ -294,7 +298,7 @@
         <div class="subject">Human Trafficking</div>
         <div class="subject">Hustler's University</div>
       </div>
-      <p class="note">Gap above last subject must match gap between siblings — no hole from last-subject min-height.</p>
+      <p class="note">Both subjects full width above; icon island underneath — never between subjects.</p>
     </article>
   </div>
 
@@ -330,7 +334,7 @@
         <div class="subject">Independent Fundamentalist Baptist ABCDEF GHI JKLMN OPQRSTUVWXZY</div>
         <div class="subject">Independent Fundamentalist Baptist ABCDEF GHI JKLMN OPQRSTUVWXZY</div>
       </div>
-      <p class="note">Wrapped last subject: sibling gaps still uniform; may wrap beside icons.</p>
+      <p class="note">Wrapped labels stay in the subject stack above icons; island never inserts between lines.</p>
     </article>
   </div>
 
@@ -350,7 +354,7 @@
         <div class="subject">Independent Fundamentalist Baptist ABCDEF GHI JKLMN OPQRSTUVWXZY</div>
         <div class="subject">Independent Fundamentalist</div>
       </div>
-      <p class="note">Short last must not open an extra gap under the long leading subject.</p>
+      <p class="note">Both subjects above; icons underneath the stack.</p>
     </article>
   </div>
 
@@ -386,6 +390,7 @@
         <div class="subject">Human Trafficking</div>
         <div class="subject">Hustler's University</div>
       </div>
+      <p class="note">Wide island stays <strong>under</strong> both subjects — never between them.</p>
     </article>
   </div>
 

--- a/cultpodcasts/docs/public-card-footer-permutations.html
+++ b/cultpodcasts/docs/public-card-footer-permutations.html
@@ -1,0 +1,402 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Public card footer — layout permutations</title>
+  <style>
+    /*
+      Mirrors cultpodcasts/src/styles.scss public footer contract (v1.9.966+).
+      Open this file in a browser — no Angular build required.
+      Cross-check failures against docs/public-card-footer.md checklist.
+    */
+    :root {
+      --public-card-footer-clearance: 10px;
+      --public-card-icon-row: 40px;
+      --public-card-desc-gap: 8px;
+      --icon-margin-right: 25px;
+      --actions-padding-left: 20px;
+      --mat-theme-text-secondary: #5f6368;
+      --card-border: #c4c7c5;
+      --bg: #f0f1f2;
+    }
+
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: system-ui, Segoe UI, sans-serif;
+      background: var(--bg);
+      color: #1f1f1f;
+      line-height: 1.35;
+      padding: 1.5rem;
+    }
+    h1 { font-size: 1.25rem; margin: 0 0 0.35rem; }
+    .lead { margin: 0 0 1.25rem; color: #444; max-width: 52rem; }
+    h2 { font-size: 1rem; margin: 1.75rem 0 0.5rem; }
+    .grid {
+      display: grid;
+      gap: 1rem;
+      grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+      align-items: start;
+    }
+    .note {
+      font-size: 0.8rem;
+      color: #555;
+      margin: 0.35rem 0 0;
+    }
+    .pass-rules {
+      font-size: 0.75rem;
+      color: #333;
+      background: #fff;
+      border: 1px dashed #999;
+      padding: 0.5rem 0.65rem;
+      margin-bottom: 1rem;
+      max-width: 52rem;
+    }
+    .pass-rules code { font-size: 0.85em; }
+
+    /* --- Card shell --- */
+    .card {
+      background: #fff;
+      border: 1px solid var(--card-border);
+      border-radius: 4px;
+      padding: 12px 0 0;
+      padding-bottom: var(--public-card-footer-clearance);
+      max-width: 420px;
+    }
+    .card-title { font-weight: 600; padding: 0 var(--actions-padding-left); margin: 0 0 6px; }
+    .card-desc {
+      padding: 0 var(--actions-padding-left);
+      margin: 0;
+      font-size: 0.95rem;
+    }
+
+    /* --- Public footer contract (simplified Material stand-in) --- */
+    .actions {
+      display: flex;
+      flex-direction: row;
+      flex-wrap: wrap;
+      justify-content: flex-start;
+      align-items: center;
+      position: relative;
+      min-height: calc(var(--public-card-desc-gap) + var(--public-card-icon-row));
+      padding-top: var(--public-card-desc-gap);
+      padding-bottom: 0;
+      padding-left: var(--actions-padding-left);
+      padding-right: 8px;
+      column-gap: 0;
+      row-gap: 0;
+    }
+
+    .icon-host {
+      order: 2;
+      flex: 0 0 auto;
+      display: flex;
+      flex-direction: row;
+      flex-wrap: nowrap;
+      align-items: center;
+      align-self: center;
+      margin-left: 0;
+      height: var(--public-card-icon-row);
+      min-height: var(--public-card-icon-row);
+    }
+
+    .icon-btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 40px;
+      height: 40px;
+      margin-right: var(--icon-margin-right);
+      margin-top: 0;
+      margin-bottom: 0;
+      border: none;
+      background: transparent;
+      border-radius: 50%;
+      font-size: 1.1rem;
+      line-height: 1;
+      transform: scale(1.2);
+      transform-origin: center center;
+      color: #333;
+      text-decoration: none;
+      flex: 0 0 auto;
+      align-self: center;
+      padding: 0;
+    }
+    .icon-btn .glyph {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 24px;
+      height: 24px;
+      line-height: 1;
+    }
+
+    .youtubemeta {
+      height: var(--public-card-icon-row);
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-self: center;
+      flex: 0 0 auto;
+      font-size: 0.7rem;
+      line-height: 1.2;
+      color: var(--mat-theme-text-secondary);
+      margin-right: var(--icon-margin-right);
+      min-width: 5.5rem;
+    }
+
+    .subject {
+      box-sizing: border-box;
+      text-align: right;
+      padding-left: 0;
+      padding-bottom: 6px;
+      min-width: 0;
+      color: var(--mat-theme-text-secondary);
+      text-decoration: underline dashed 1px;
+      text-underline-offset: 5px;
+      font-size: 0.9rem;
+      line-height: 1.25;
+    }
+    .subject:not(:last-child) {
+      order: 1;
+      flex: 1 0 100%;
+      align-self: stretch;
+    }
+    .subject:last-child {
+      order: 2;
+      flex: 1 1 0;
+      padding-bottom: 0;
+      align-self: center;
+      min-height: var(--public-card-icon-row);
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      justify-content: flex-end;
+    }
+
+    /* Mid-line guide (toggle with checkbox) */
+    body.show-guides .actions {
+      background-image: linear-gradient(
+        to bottom,
+        transparent calc(var(--public-card-desc-gap) + var(--public-card-icon-row) / 2 - 0.5px),
+        rgba(220, 20, 60, 0.55) calc(var(--public-card-desc-gap) + var(--public-card-icon-row) / 2 - 0.5px),
+        rgba(220, 20, 60, 0.55) calc(var(--public-card-desc-gap) + var(--public-card-icon-row) / 2 + 0.5px),
+        transparent calc(var(--public-card-desc-gap) + var(--public-card-icon-row) / 2 + 0.5px)
+      );
+      background-repeat: no-repeat;
+      background-size: 100% 100%;
+    }
+    body.show-guides .card-desc {
+      box-shadow: inset 2px 0 0 rgba(30, 120, 200, 0.7);
+    }
+    body.show-guides .icon-host {
+      box-shadow: inset 2px 0 0 rgba(30, 120, 200, 0.7);
+    }
+
+    .toolbar {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem 1.25rem;
+      align-items: center;
+      margin-bottom: 1rem;
+      font-size: 0.9rem;
+    }
+
+    @media (max-width: 600px) {
+      :root {
+        --actions-padding-left: 10px;
+        --icon-margin-right: 18px;
+      }
+    }
+    @media (max-width: 400px) {
+      :root {
+        --actions-padding-left: 2px;
+        --icon-margin-right: 12px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <h1>Public card footer permutations</h1>
+  <p class="lead">
+    Static stand-in for the shared public footer contract. Checklist:
+    <code>docs/public-card-footer.md</code>. Red guide = icon/subject mid-line;
+    blue edge = description / icon flush-left.
+  </p>
+
+  <div class="toolbar">
+    <label><input type="checkbox" id="guides" checked /> Show alignment guides</label>
+  </div>
+
+  <div class="pass-rules">
+    Every card must: flush-left icons · one icon mid-line · last/only subject on that mid-line ·
+    8px under description · ~10px card bottom · no subject/icon collision · 6px subject gaps.
+  </div>
+
+  <h2>A — 0 subjects, YT + Share</h2>
+  <div class="grid">
+    <article class="card" data-case="A">
+      <div class="card-title">Episode title</div>
+      <p class="card-desc">Description text left edge — icons must match this inset.</p>
+      <div class="actions">
+        <div class="icon-host">
+          <a class="icon-btn" href="#" title="YouTube"><span class="glyph">▶</span></a>
+          <button type="button" class="icon-btn" title="Share"><span class="glyph">⤴</span></button>
+        </div>
+      </div>
+    </article>
+  </div>
+
+  <h2>B — 1 short subject, YT + Share</h2>
+  <div class="grid">
+    <article class="card" data-case="B">
+      <div class="card-title">Episode title</div>
+      <p class="card-desc">Description text left edge — icons must match this inset.</p>
+      <div class="actions">
+        <div class="icon-host">
+          <a class="icon-btn" href="#" title="YouTube"><span class="glyph">▶</span></a>
+          <button type="button" class="icon-btn" title="Share"><span class="glyph">⤴</span></button>
+        </div>
+        <div class="subject">Cults</div>
+      </div>
+    </article>
+  </div>
+
+  <h2>C — 1 long subject, YT + Spotify + Apple + Share</h2>
+  <div class="grid">
+    <article class="card" data-case="C">
+      <div class="card-title">Episode title</div>
+      <p class="card-desc">Description text left edge — icons must match this inset.</p>
+      <div class="actions">
+        <div class="icon-host">
+          <a class="icon-btn" href="#" title="YouTube"><span class="glyph">▶</span></a>
+          <a class="icon-btn" href="#" title="Spotify"><span class="glyph">♫</span></a>
+          <a class="icon-btn" href="#" title="Apple"><span class="glyph"></span></a>
+          <button type="button" class="icon-btn" title="Share"><span class="glyph">⤴</span></button>
+        </div>
+        <div class="subject">The Church Of Jesus Christ Of Latter-Day Saints</div>
+      </div>
+    </article>
+  </div>
+
+  <h2>D — 2+ subjects, YT + Share</h2>
+  <div class="grid">
+    <article class="card" data-case="D">
+      <div class="card-title">Episode title</div>
+      <p class="card-desc">Description text left edge — icons must match this inset.</p>
+      <div class="actions">
+        <div class="icon-host">
+          <a class="icon-btn" href="#" title="YouTube"><span class="glyph">▶</span></a>
+          <button type="button" class="icon-btn" title="Share"><span class="glyph">⤴</span></button>
+        </div>
+        <div class="subject">Human Trafficking</div>
+        <div class="subject">Hustler's University</div>
+      </div>
+    </article>
+  </div>
+
+  <h2>E — 2+ subjects, YT only</h2>
+  <div class="grid">
+    <article class="card" data-case="E">
+      <div class="card-title">Episode title</div>
+      <p class="card-desc">Description text left edge — icons must match this inset.</p>
+      <div class="actions">
+        <div class="icon-host">
+          <a class="icon-btn" href="#" title="YouTube"><span class="glyph">▶</span></a>
+        </div>
+        <div class="subject">Human Trafficking</div>
+        <div class="subject">Hustler's University</div>
+      </div>
+    </article>
+  </div>
+
+  <h2>F — 2+ subjects, many services (YT + Spotify + Apple + BBC + IA + Share)</h2>
+  <div class="grid">
+    <article class="card" data-case="F">
+      <div class="card-title">Episode title</div>
+      <p class="card-desc">Description text left edge — icons must match this inset.</p>
+      <div class="actions">
+        <div class="icon-host">
+          <a class="icon-btn" href="#" title="YouTube"><span class="glyph">▶</span></a>
+          <a class="icon-btn" href="#" title="Spotify"><span class="glyph">♫</span></a>
+          <a class="icon-btn" href="#" title="Apple"><span class="glyph"></span></a>
+          <a class="icon-btn" href="#" title="BBC"><span class="glyph">B</span></a>
+          <a class="icon-btn" href="#" title="Internet Archive"><span class="glyph">A</span></a>
+          <button type="button" class="icon-btn" title="Share"><span class="glyph">⤴</span></button>
+        </div>
+        <div class="subject">Human Trafficking</div>
+        <div class="subject">Hustler's University</div>
+      </div>
+    </article>
+  </div>
+
+  <h2>G — 1 subject, YT + Spotify + Apple</h2>
+  <div class="grid">
+    <article class="card" data-case="G">
+      <div class="card-title">Episode title</div>
+      <p class="card-desc">Description text left edge — icons must match this inset.</p>
+      <div class="actions">
+        <div class="icon-host">
+          <a class="icon-btn" href="#" title="YouTube"><span class="glyph">▶</span></a>
+          <a class="icon-btn" href="#" title="Spotify"><span class="glyph">♫</span></a>
+          <a class="icon-btn" href="#" title="Apple"><span class="glyph"></span></a>
+        </div>
+        <div class="subject">Troubled Teen Industry</div>
+      </div>
+    </article>
+  </div>
+
+  <h2>H — Discovery youtube-stats + subject</h2>
+  <div class="grid">
+    <article class="card" data-case="H">
+      <div class="card-title">Discovery item</div>
+      <p class="card-desc">Description text left edge — icons must match this inset.</p>
+      <div class="actions">
+        <div class="icon-host">
+          <a class="icon-btn" href="#" title="YouTube"><span class="glyph">▶</span></a>
+          <div class="youtubemeta">
+            <span>Views: 12.4k</span>
+            <span>Members: 890</span>
+          </div>
+          <a class="icon-btn" href="#" title="Spotify"><span class="glyph">♫</span></a>
+          <a class="icon-btn" href="#" title="Apple"><span class="glyph"></span></a>
+        </div>
+        <div class="subject">The Church Of Jesus Christ Of Latter-Day Saints</div>
+      </div>
+    </article>
+  </div>
+
+  <h2>I — Discovery youtube-stats + 2 subjects</h2>
+  <div class="grid">
+    <article class="card" data-case="I">
+      <div class="card-title">Discovery item</div>
+      <p class="card-desc">Description text left edge — icons must match this inset.</p>
+      <div class="actions">
+        <div class="icon-host">
+          <a class="icon-btn" href="#" title="YouTube"><span class="glyph">▶</span></a>
+          <div class="youtubemeta">
+            <span>Views: 12.4k</span>
+            <span>Members: 890</span>
+          </div>
+          <button type="button" class="icon-btn" title="Share"><span class="glyph">⤴</span></button>
+        </div>
+        <div class="subject">Human Trafficking</div>
+        <div class="subject">Hustler's University</div>
+      </div>
+    </article>
+  </div>
+
+  <p class="note">
+    Resize the window for cases J/K (≤600px / ≤400px padding + icon gaps).
+    Fixture geometry only — still verify H/I on a live Discovery run with Members data.
+  </p>
+
+  <script>
+    const box = document.getElementById('guides');
+    const sync = () => document.body.classList.toggle('show-guides', box.checked);
+    box.addEventListener('change', sync);
+    sync();
+  </script>
+</body>
+</html>

--- a/cultpodcasts/docs/public-card-footer-permutations.html
+++ b/cultpodcasts/docs/public-card-footer-permutations.html
@@ -6,7 +6,7 @@
   <title>Public card footer — layout permutations</title>
   <style>
     /*
-      Mirrors cultpodcasts/src/styles.scss public footer contract (v1.9.968+).
+      Mirrors cultpodcasts/src/styles.scss public footer contract (v1.9.969+).
       Open this file in a browser — no Angular build required.
       Cross-check failures against docs/public-card-footer.md checklist.
     */
@@ -14,6 +14,7 @@
       --public-card-footer-clearance: 10px;
       --public-card-icon-row: 40px;
       --public-card-desc-gap: 8px;
+      --public-card-subject-min: 100px;
       --icon-margin-right: 25px;
       --actions-padding-left: 20px;
       --mat-theme-text-secondary: #5f6368;
@@ -86,6 +87,9 @@
       padding-right: 8px;
       column-gap: 0;
       row-gap: 0;
+    }
+    .actions:has(.subject:only-child) {
+      flex-wrap: wrap-reverse;
     }
 
     .icon-host {
@@ -165,10 +169,10 @@
     }
     .subject:only-child {
       order: 2;
-      flex: 1 1 0;
+      flex: 1 1 var(--public-card-subject-min);
+      min-width: var(--public-card-subject-min);
       padding-bottom: 0;
       align-self: center;
-      min-height: 0;
       height: auto;
       display: flex;
       flex-direction: row;
@@ -427,6 +431,7 @@
         </div>
         <div class="subject">The Church Of Jesus Christ Of Latter-Day Saints</div>
       </div>
+      <p class="note">Subject keeps at least <code>--public-card-subject-min</code> (100px). If the stats island is too wide, subject stacks <strong>above</strong> the island — never a one-word-per-line column.</p>
     </article>
   </div>
 

--- a/cultpodcasts/docs/public-card-footer-permutations.html
+++ b/cultpodcasts/docs/public-card-footer-permutations.html
@@ -6,9 +6,10 @@
   <title>Public card footer — layout permutations</title>
   <style>
     /*
-      Mirrors cultpodcasts/src/styles.scss public footer contract (v1.9.970+).
+      Mirrors cultpodcasts/src/styles.scss public footer contract (v1.9.971+).
       Open this file in a browser — no Angular build required.
       Cross-check failures against docs/public-card-footer.md checklist.
+      Subject length bands: tiny / short / medium / long / very long (see design doc).
     */
     :root {
       --public-card-footer-clearance: 10px;
@@ -264,8 +265,9 @@
           <a class="icon-btn" href="#" title="YouTube"><span class="glyph">▶</span></a>
           <button type="button" class="icon-btn" title="Share"><span class="glyph">⤴</span></button>
         </div>
-        <div class="subject">Cults</div>
+        <div class="subject">Cult Psychology</div>
       </div>
+      <p class="note">Short band — bottom row coexist.</p>
     </article>
   </div>
 
@@ -283,10 +285,45 @@
         </div>
         <div class="subject">The Church Of Jesus Christ Of Latter-Day Saints</div>
       </div>
+      <p class="note">Long band — may wrap in subject column; column ≥ min-width.</p>
     </article>
   </div>
 
-  <h2>D — 2+ subjects, YT + Share (all subjects above icons)</h2>
+  <h2>C2 — 1 tiny subject, YT + Share</h2>
+  <div class="grid">
+    <article class="card" data-case="C2">
+      <div class="card-title">Episode title</div>
+      <p class="card-desc">Description text left edge — icons must match this inset.</p>
+      <div class="actions">
+        <div class="icon-host">
+          <a class="icon-btn" href="#" title="YouTube"><span class="glyph">▶</span></a>
+          <button type="button" class="icon-btn" title="Share"><span class="glyph">⤴</span></button>
+        </div>
+        <div class="subject">Qanon</div>
+      </div>
+      <p class="note">Tiny band — column still ≥ <code>--public-card-subject-min</code> (not shrink-wrapped to text).</p>
+    </article>
+  </div>
+
+  <h2>C3 — 1 very long subject, YT + Spotify + Apple + Share</h2>
+  <div class="grid">
+    <article class="card" data-case="C3">
+      <div class="card-title">Episode title</div>
+      <p class="card-desc">Description text left edge — icons must match this inset.</p>
+      <div class="actions">
+        <div class="icon-host">
+          <a class="icon-btn" href="#" title="YouTube"><span class="glyph">▶</span></a>
+          <a class="icon-btn" href="#" title="Spotify"><span class="glyph">♫</span></a>
+          <a class="icon-btn" href="#" title="Apple"><span class="glyph"></span></a>
+          <button type="button" class="icon-btn" title="Share"><span class="glyph">⤴</span></button>
+        </div>
+        <div class="subject">Independent Fundamentalist Baptist ABCDEF GHI JKLMN OPQRSTUVWXZY</div>
+      </div>
+      <p class="note">Very long band — wraps in column; never crushed to one word per line.</p>
+    </article>
+  </div>
+
+  <h2>D — 2× medium subjects, YT + Share (last beside icons)</h2>
   <div class="grid">
     <article class="card" data-case="D">
       <div class="card-title">Episode title</div>
@@ -356,7 +393,43 @@
         <div class="subject">Independent Fundamentalist Baptist ABCDEF GHI JKLMN OPQRSTUVWXZY</div>
         <div class="subject">Independent Fundamentalist</div>
       </div>
-      <p class="note">Both subjects above; icons underneath the stack.</p>
+      <p class="note">Very long leading above; short/medium last beside icons on the bottom row.</p>
+    </article>
+  </div>
+
+  <h2>D5 — tiny leading + long last, YT + Share</h2>
+  <div class="grid">
+    <article class="card" data-case="D5">
+      <div class="card-title">Episode title</div>
+      <p class="card-desc">Description text left edge — icons must match this inset.</p>
+      <div class="actions">
+        <div class="icon-host">
+          <a class="icon-btn" href="#" title="YouTube"><span class="glyph">▶</span></a>
+          <button type="button" class="icon-btn" title="Share"><span class="glyph">⤴</span></button>
+        </div>
+        <div class="subject">NXIVM</div>
+        <div class="subject">The Church Of Jesus Christ Of Latter-Day Saints</div>
+      </div>
+      <p class="note">Tiny leading above; long last beside icons (≥ min-width).</p>
+    </article>
+  </div>
+
+  <h2>D6 — short + medium + long, YT + Spotify + Share</h2>
+  <div class="grid">
+    <article class="card" data-case="D6">
+      <div class="card-title">Episode title</div>
+      <p class="card-desc">Description text left edge — icons must match this inset.</p>
+      <div class="actions">
+        <div class="icon-host">
+          <a class="icon-btn" href="#" title="YouTube"><span class="glyph">▶</span></a>
+          <a class="icon-btn" href="#" title="Spotify"><span class="glyph">♫</span></a>
+          <button type="button" class="icon-btn" title="Share"><span class="glyph">⤴</span></button>
+        </div>
+        <div class="subject">Cult Psychology</div>
+        <div class="subject">Troubled Teen Industry</div>
+        <div class="subject">The Church Of Jesus Christ Of Latter-Day Saints</div>
+      </div>
+      <p class="note">Mixed lengths — only the last subject shares the bottom row with icons.</p>
     </article>
   </div>
 
@@ -430,6 +503,26 @@
         <div class="subject">The Church Of Jesus Christ Of Latter-Day Saints</div>
       </div>
       <p class="note">Subject column ≥ <code>--public-card-subject-min</code> (100px) beside the stats island — not a one-word-per-line crush.</p>
+    </article>
+  </div>
+
+  <h2>H2 — Discovery youtube-stats + tiny subject</h2>
+  <div class="grid">
+    <article class="card" data-case="H2">
+      <div class="card-title">Discovery item</div>
+      <p class="card-desc">Description text left edge — icons must match this inset.</p>
+      <div class="actions">
+        <div class="icon-host">
+          <a class="icon-btn" href="#" title="YouTube"><span class="glyph">▶</span></a>
+          <div class="youtubemeta">
+            <span>Views: 12.4k</span>
+            <span>Members: 890</span>
+          </div>
+          <a class="icon-btn" href="#" title="Spotify"><span class="glyph">♫</span></a>
+        </div>
+        <div class="subject">Qanon</div>
+      </div>
+      <p class="note">Tiny label — column still ≥ min-width beside meta island.</p>
     </article>
   </div>
 

--- a/cultpodcasts/docs/public-card-footer-permutations.html
+++ b/cultpodcasts/docs/public-card-footer-permutations.html
@@ -6,7 +6,7 @@
   <title>Public card footer — layout permutations</title>
   <style>
     /*
-      Mirrors cultpodcasts/src/styles.scss public footer contract (v1.9.966+).
+      Mirrors cultpodcasts/src/styles.scss public footer contract (v1.9.967+).
       Open this file in a browser — no Angular build required.
       Cross-check failures against docs/public-card-footer.md checklist.
     */
@@ -168,7 +168,8 @@
       flex: 1 1 0;
       padding-bottom: 0;
       align-self: center;
-      min-height: var(--public-card-icon-row);
+      min-height: 0;
+      height: auto;
       display: flex;
       flex-direction: row;
       align-items: center;
@@ -280,7 +281,7 @@
     </article>
   </div>
 
-  <h2>D — 2+ subjects, YT + Share</h2>
+  <h2>D — 2+ subjects, YT + Share (short last — uniform gaps)</h2>
   <div class="grid">
     <article class="card" data-case="D">
       <div class="card-title">Episode title</div>
@@ -293,6 +294,63 @@
         <div class="subject">Human Trafficking</div>
         <div class="subject">Hustler's University</div>
       </div>
+      <p class="note">Gap above last subject must match gap between siblings — no hole from last-subject min-height.</p>
+    </article>
+  </div>
+
+  <h2>D2 — 3 subjects, short last (duplicate mid labels)</h2>
+  <div class="grid">
+    <article class="card" data-case="D2">
+      <div class="card-title">Episode title</div>
+      <p class="card-desc">Description text left edge — icons must match this inset.</p>
+      <div class="actions">
+        <div class="icon-host">
+          <a class="icon-btn" href="#" title="YouTube"><span class="glyph">▶</span></a>
+          <button type="button" class="icon-btn" title="Share"><span class="glyph">⤴</span></button>
+        </div>
+        <div class="subject">Human Trafficking</div>
+        <div class="subject">Human Trafficking</div>
+        <div class="subject">Hustler's University</div>
+      </div>
+    </article>
+  </div>
+
+  <h2>D3 — long wrapped last subject</h2>
+  <div class="grid">
+    <article class="card" data-case="D3">
+      <div class="card-title">Episode title</div>
+      <p class="card-desc">Description text left edge — icons must match this inset.</p>
+      <div class="actions">
+        <div class="icon-host">
+          <a class="icon-btn" href="#" title="YouTube"><span class="glyph">▶</span></a>
+          <a class="icon-btn" href="#" title="Spotify"><span class="glyph">♫</span></a>
+          <a class="icon-btn" href="#" title="Apple"><span class="glyph"></span></a>
+          <button type="button" class="icon-btn" title="Share"><span class="glyph">⤴</span></button>
+        </div>
+        <div class="subject">Independent Fundamentalist Baptist ABCDEF GHI JKLMN OPQRSTUVWXZY</div>
+        <div class="subject">Independent Fundamentalist Baptist ABCDEF GHI JKLMN OPQRSTUVWXZY</div>
+      </div>
+      <p class="note">Wrapped last subject: sibling gaps still uniform; may wrap beside icons.</p>
+    </article>
+  </div>
+
+  <h2>D4 — long leading + short last (one line)</h2>
+  <div class="grid">
+    <article class="card" data-case="D4">
+      <div class="card-title">Episode title</div>
+      <p class="card-desc">Description text left edge — icons must match this inset.</p>
+      <div class="actions">
+        <div class="icon-host">
+          <a class="icon-btn" href="#" title="YouTube"><span class="glyph">▶</span></a>
+          <a class="icon-btn" href="#" title="YouTube 2"><span class="glyph">▶</span></a>
+          <a class="icon-btn" href="#" title="Spotify"><span class="glyph">♫</span></a>
+          <a class="icon-btn" href="#" title="Apple"><span class="glyph"></span></a>
+          <button type="button" class="icon-btn" title="Share"><span class="glyph">⤴</span></button>
+        </div>
+        <div class="subject">Independent Fundamentalist Baptist ABCDEF GHI JKLMN OPQRSTUVWXZY</div>
+        <div class="subject">Independent Fundamentalist</div>
+      </div>
+      <p class="note">Short last must not open an extra gap under the long leading subject.</p>
     </article>
   </div>
 

--- a/cultpodcasts/docs/public-card-footer.html
+++ b/cultpodcasts/docs/public-card-footer.html
@@ -6,7 +6,7 @@
   <title>Public card footer — layout guide</title>
   <style>
     /*
-      Mirrors cultpodcasts/src/styles.scss public footer contract (v1.9.973+).
+      Mirrors cultpodcasts/src/styles.scss public footer contract (v1.9.974+).
       Open this file in a browser — no Angular build required.
       Cross-check failures against docs/public-card-footer.md checklist.
       Subject length bands: tiny / short / medium / long / very long (see design doc).
@@ -15,8 +15,8 @@
       --public-card-footer-clearance: 10px;
       --public-card-icon-row: 40px;
       --public-card-desc-gap: 8px;
-      --public-card-subject-min: 100px;
       --public-card-subject-line: 1.25em;
+      --public-card-subject-mid-offset: calc((var(--public-card-icon-row) - var(--public-card-subject-line)) / 2);
       --icon-margin-right: 25px;
       --actions-padding-left: 20px;
       --mat-theme-text-secondary: #5f6368;
@@ -173,17 +173,27 @@
     }
     .subject:last-child {
       order: 2;
-      flex: 1 1 var(--public-card-subject-min);
+      flex: 1 1 min-content;
       width: auto;
       max-width: 100%;
-      min-width: min(100%, var(--public-card-subject-min));
+      min-width: min-content;
       padding-bottom: 0;
       align-self: flex-end;
-      margin-bottom: calc((var(--public-card-icon-row) - var(--public-card-subject-line)) / 2);
+      margin-bottom: var(--public-card-subject-mid-offset);
       display: flex;
       flex-direction: row;
       align-items: flex-end;
       justify-content: flex-end;
+    }
+    /* Uniform leading→last gap: cancel icon-row empty space above last subject.
+       padding-top cancels the pull when the last subject stacks above the island. */
+    .actions:has(.subject:not(:last-child)) .subject:last-child {
+      margin-top: calc(-1 * var(--public-card-subject-mid-offset));
+      padding-top: var(--public-card-subject-mid-offset);
+      box-sizing: border-box;
+    }
+    .actions:has(.subject:not(:last-child)) .icon-host {
+      margin-top: calc(-1 * var(--public-card-subject-mid-offset));
     }
 
     /* Red guide = icon-host vertical mid (tracks wrap / tall subjects). */
@@ -244,9 +254,10 @@
 
   <div class="pass-rules">
     Every card must: flush-left icons · one icon mid-line · island never between subjects ·
-    leading subjects full-width above · last/only subject beside island when room (≥ min-width),
-    else all subjects above island · no crush / no subject-icon overlap · 8px under description ·
-    ~10px card bottom · 6px subject gaps · when coexisting, last-line mid ↔ icon mid.
+    leading subjects full-width above · last/only subject beside island when island + subject
+    min-content fit, else all subjects above island · no crush / no subject-icon overlap ·
+    8px under description · ~10px card bottom · uniform 6px subject gaps · when coexisting,
+    last-line mid ↔ icon mid.
   </div>
 
   <h2>A — 0 subjects, YT + Share</h2>
@@ -309,7 +320,7 @@
         </div>
         <div class="subject">Qanon</div>
       </div>
-      <p class="note">Tiny band — column still ≥ <code>--public-card-subject-min</code> (not shrink-wrapped to text).</p>
+      <p class="note">Tiny band — sits beside island at content width (min-content), not a fixed 100px column.</p>
     </article>
   </div>
 
@@ -344,7 +355,7 @@
         <div class="subject">Human Trafficking</div>
         <div class="subject">Hustler's University</div>
       </div>
-      <p class="note">Leading subjects above; last subject shares the bottom row with icons when ≥ min-width remains.</p>
+      <p class="note">Leading subjects above; last subject shares the bottom row with icons when content width fits; uniform 6px gaps.</p>
     </article>
   </div>
 
@@ -362,7 +373,7 @@
         <div class="subject">Human Trafficking</div>
         <div class="subject">Hustler's University</div>
       </div>
-      <p class="note">Subjects 1–2 full width above; last subject shares the bottom row with icons.</p>
+      <p class="note">Subjects 1–2 full width above; last beside icons; gaps 1→2 and 2→3 equal (~6px).</p>
     </article>
   </div>
 
@@ -401,7 +412,7 @@
         <div class="subject">Independent Fundamentalist Baptist ABCDEF GHI JKLMN OPQRSTUVWXZY</div>
         <div class="subject">Independent Fundamentalist</div>
       </div>
-      <p class="note">Very long leading above; short/medium last beside icons on the bottom row when room allows.</p>
+      <p class="note">Very long leading above; short/medium last beside icons when its min-content fits.</p>
     </article>
   </div>
 
@@ -418,7 +429,7 @@
         <div class="subject">NXIVM</div>
         <div class="subject">The Church Of Jesus Christ Of Latter-Day Saints</div>
       </div>
-      <p class="note">Tiny leading above; long last beside icons (≥ min-width) when room allows.</p>
+      <p class="note">Tiny leading above; long last beside icons when min-content fits (may wrap).</p>
     </article>
   </div>
 
@@ -437,7 +448,7 @@
         <div class="subject">Troubled Teen Industry</div>
         <div class="subject">The Church Of Jesus Christ Of Latter-Day Saints</div>
       </div>
-      <p class="note">Mixed lengths — only the last subject shares the bottom row with icons when room allows.</p>
+      <p class="note">Mixed lengths — only the last subject shares the bottom row with icons when its content width fits.</p>
     </article>
   </div>
 
@@ -473,7 +484,7 @@
         <div class="subject">Human Trafficking</div>
         <div class="subject">Hustler's University</div>
       </div>
-      <p class="note">Wide island — when island + min-width cannot coexist, <strong>all subjects stack above</strong> the island (no overlap, island never between).</p>
+      <p class="note">Wide island — when island + subject min-content cannot coexist, <strong>all subjects stack above</strong> the island (no overlap, island never between).</p>
     </article>
   </div>
 
@@ -510,7 +521,7 @@
         </div>
         <div class="subject">The Church Of Jesus Christ Of Latter-Day Saints</div>
       </div>
-      <p class="note">Stats island — coexist only if subject keeps ≥ min-width; otherwise subject stacks full-width above, island alone below (no one-word crush / overlap).</p>
+      <p class="note">Stats island — coexist when subject min-content fits beside island; otherwise stack above (no one-word crush / overlap).</p>
     </article>
   </div>
 
@@ -530,7 +541,7 @@
         </div>
         <div class="subject">Qanon</div>
       </div>
-      <p class="note">Tiny label — column still ≥ min-width beside meta island when room allows; else stack above.</p>
+      <p class="note">Tiny label — must sit <strong>beside</strong> meta island (content width, not a 100px floor); stack only if min-content cannot fit.</p>
     </article>
   </div>
 

--- a/cultpodcasts/docs/public-card-footer.html
+++ b/cultpodcasts/docs/public-card-footer.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Public card footer — layout permutations</title>
+  <title>Public card footer — layout guide</title>
   <style>
     /*
       Mirrors cultpodcasts/src/styles.scss public footer contract (v1.9.971+).
@@ -224,9 +224,9 @@
   </style>
 </head>
 <body>
-  <h1>Public card footer permutations</h1>
+  <h1>Public card footer</h1>
   <p class="lead">
-    Static stand-in for the shared public footer contract. Checklist:
+    Static layout guide for the public episode-card footer contract in
     <code>docs/public-card-footer.md</code>. Red guide = icon/subject mid-line;
     blue edge = description / icon flush-left.
   </p>

--- a/cultpodcasts/docs/public-card-footer.html
+++ b/cultpodcasts/docs/public-card-footer.html
@@ -6,7 +6,7 @@
   <title>Public card footer — layout guide</title>
   <style>
     /*
-      Mirrors cultpodcasts/src/styles.scss public footer contract (v1.9.971+).
+      Mirrors cultpodcasts/src/styles.scss public footer contract (v1.9.973+).
       Open this file in a browser — no Angular build required.
       Cross-check failures against docs/public-card-footer.md checklist.
       Subject length bands: tiny / short / medium / long / very long (see design doc).
@@ -16,6 +16,7 @@
       --public-card-icon-row: 40px;
       --public-card-desc-gap: 8px;
       --public-card-subject-min: 100px;
+      --public-card-subject-line: 1.25em;
       --icon-margin-right: 25px;
       --actions-padding-left: 20px;
       --mat-theme-text-secondary: #5f6368;
@@ -75,11 +76,11 @@
 
     /* --- Public footer contract (simplified Material stand-in) --- */
     .actions {
-      display: grid;
-      grid-template-columns:
-        fit-content(calc(100% - var(--public-card-subject-min)))
-        minmax(var(--public-card-subject-min), 1fr);
-      align-items: center;
+      display: flex;
+      flex-wrap: wrap;
+      flex-direction: row-reverse;
+      align-items: flex-end;
+      justify-content: flex-start;
       position: relative;
       min-height: calc(var(--public-card-desc-gap) + var(--public-card-icon-row));
       padding-top: var(--public-card-desc-gap);
@@ -91,15 +92,16 @@
     }
 
     .icon-host {
-      grid-column: 1;
-      order: 2;
-      justify-self: start;
-      align-self: center;
+      order: 3;
+      flex: 0 0 auto;
+      align-self: flex-end;
       display: flex;
       flex-direction: row;
       flex-wrap: nowrap;
       align-items: center;
       margin-left: 0;
+      margin-right: auto;
+      position: relative;
       height: var(--public-card-icon-row);
       min-height: var(--public-card-icon-row);
       max-width: 100%;
@@ -164,34 +166,38 @@
       line-height: 1.25;
     }
     .subject:not(:last-child) {
-      grid-column: 1 / -1;
+      flex: 0 0 100%;
+      width: 100%;
       order: 1;
       align-self: stretch;
     }
     .subject:last-child {
-      grid-column: 2;
       order: 2;
+      flex: 1 1 var(--public-card-subject-min);
+      width: auto;
+      max-width: 100%;
+      min-width: min(100%, var(--public-card-subject-min));
       padding-bottom: 0;
-      align-self: center;
-      justify-self: stretch;
-      min-width: 0;
+      align-self: flex-end;
+      margin-bottom: calc((var(--public-card-icon-row) - var(--public-card-subject-line)) / 2);
       display: flex;
       flex-direction: row;
-      align-items: center;
+      align-items: flex-end;
       justify-content: flex-end;
     }
 
-    /* Mid-line guide (toggle with checkbox) */
-    body.show-guides .actions {
-      background-image: linear-gradient(
-        to bottom,
-        transparent calc(var(--public-card-desc-gap) + var(--public-card-icon-row) / 2 - 0.5px),
-        rgba(220, 20, 60, 0.55) calc(var(--public-card-desc-gap) + var(--public-card-icon-row) / 2 - 0.5px),
-        rgba(220, 20, 60, 0.55) calc(var(--public-card-desc-gap) + var(--public-card-icon-row) / 2 + 0.5px),
-        transparent calc(var(--public-card-desc-gap) + var(--public-card-icon-row) / 2 + 0.5px)
-      );
-      background-repeat: no-repeat;
-      background-size: 100% 100%;
+    /* Red guide = icon-host vertical mid (tracks wrap / tall subjects). */
+    body.show-guides .icon-host::after {
+      content: "";
+      position: absolute;
+      left: 0;
+      right: 0;
+      top: 50%;
+      height: 1px;
+      margin-top: -0.5px;
+      background: rgba(220, 20, 60, 0.55);
+      pointer-events: none;
+      z-index: 2;
     }
     body.show-guides .card-desc {
       box-shadow: inset 2px 0 0 rgba(30, 120, 200, 0.7);
@@ -227,7 +233,8 @@
   <h1>Public card footer</h1>
   <p class="lead">
     Static layout guide for the public episode-card footer contract in
-    <code>docs/public-card-footer.md</code>. Red guide = icon/subject mid-line;
+    <code>docs/public-card-footer.md</code>. Red guide = icon-host vertical mid
+    (should meet the middle of the last subject’s last line when they coexist);
     blue edge = description / icon flush-left.
   </p>
 
@@ -237,8 +244,9 @@
 
   <div class="pass-rules">
     Every card must: flush-left icons · one icon mid-line · island never between subjects ·
-    leading subjects full-width above · last/only subject beside island (≥ min-width) ·
-    8px under description · ~10px card bottom · no crush / no subject-icon collision · 6px subject gaps.
+    leading subjects full-width above · last/only subject beside island when room (≥ min-width),
+    else all subjects above island · no crush / no subject-icon overlap · 8px under description ·
+    ~10px card bottom · 6px subject gaps · when coexisting, last-line mid ↔ icon mid.
   </div>
 
   <h2>A — 0 subjects, YT + Share</h2>
@@ -267,7 +275,7 @@
         </div>
         <div class="subject">Cult Psychology</div>
       </div>
-      <p class="note">Short band — bottom row coexist.</p>
+      <p class="note">Short band — bottom row coexist; last-line mid ↔ icon mid.</p>
     </article>
   </div>
 
@@ -285,7 +293,7 @@
         </div>
         <div class="subject">The Church Of Jesus Christ Of Latter-Day Saints</div>
       </div>
-      <p class="note">Long band — may wrap in subject column; column ≥ min-width.</p>
+      <p class="note">Long band — may wrap; when beside island, red guide = last-line mid ↔ icon mid (not top of first line).</p>
     </article>
   </div>
 
@@ -319,7 +327,7 @@
         </div>
         <div class="subject">Independent Fundamentalist Baptist ABCDEF GHI JKLMN OPQRSTUVWXZY</div>
       </div>
-      <p class="note">Very long band — wraps in column; never crushed to one word per line.</p>
+      <p class="note">Very long band — wraps in column when coexisting; stacks above island if room runs out.</p>
     </article>
   </div>
 
@@ -393,7 +401,7 @@
         <div class="subject">Independent Fundamentalist Baptist ABCDEF GHI JKLMN OPQRSTUVWXZY</div>
         <div class="subject">Independent Fundamentalist</div>
       </div>
-      <p class="note">Very long leading above; short/medium last beside icons on the bottom row.</p>
+      <p class="note">Very long leading above; short/medium last beside icons on the bottom row when room allows.</p>
     </article>
   </div>
 
@@ -410,7 +418,7 @@
         <div class="subject">NXIVM</div>
         <div class="subject">The Church Of Jesus Christ Of Latter-Day Saints</div>
       </div>
-      <p class="note">Tiny leading above; long last beside icons (≥ min-width).</p>
+      <p class="note">Tiny leading above; long last beside icons (≥ min-width) when room allows.</p>
     </article>
   </div>
 
@@ -429,7 +437,7 @@
         <div class="subject">Troubled Teen Industry</div>
         <div class="subject">The Church Of Jesus Christ Of Latter-Day Saints</div>
       </div>
-      <p class="note">Mixed lengths — only the last subject shares the bottom row with icons.</p>
+      <p class="note">Mixed lengths — only the last subject shares the bottom row with icons when room allows.</p>
     </article>
   </div>
 
@@ -465,7 +473,7 @@
         <div class="subject">Human Trafficking</div>
         <div class="subject">Hustler's University</div>
       </div>
-      <p class="note">Wide island is capped so last subject keeps ≥ min-width on the bottom row — island never between subjects.</p>
+      <p class="note">Wide island — when island + min-width cannot coexist, <strong>all subjects stack above</strong> the island (no overlap, island never between).</p>
     </article>
   </div>
 
@@ -502,7 +510,7 @@
         </div>
         <div class="subject">The Church Of Jesus Christ Of Latter-Day Saints</div>
       </div>
-      <p class="note">Subject column ≥ <code>--public-card-subject-min</code> (100px) beside the stats island — not a one-word-per-line crush.</p>
+      <p class="note">Stats island — coexist only if subject keeps ≥ min-width; otherwise subject stacks full-width above, island alone below (no one-word crush / overlap).</p>
     </article>
   </div>
 
@@ -522,7 +530,7 @@
         </div>
         <div class="subject">Qanon</div>
       </div>
-      <p class="note">Tiny label — column still ≥ min-width beside meta island.</p>
+      <p class="note">Tiny label — column still ≥ min-width beside meta island when room allows; else stack above.</p>
     </article>
   </div>
 
@@ -549,6 +557,7 @@
   <p class="note">
     Resize the window for cases J/K (≤600px / ≤400px padding + icon gaps).
     Fixture geometry only — still verify H/I on a live Discovery run with Members data.
+    Vert alignment: when last/only subject shares the bottom row, icon mid meets the middle of that subject’s last line.
   </p>
 
   <script>

--- a/cultpodcasts/docs/public-card-footer.md
+++ b/cultpodcasts/docs/public-card-footer.md
@@ -2,7 +2,7 @@
 
 Shared layout for subjects, podcast-service icon buttons, and Discovery youtube-stats on public result cards.
 
-**Source of truth:** `src/styles.scss` (`mat-card .mdc-card__actions:not(.review-actions)`), from **v1.9.971+**.
+**Source of truth:** `src/styles.scss` (`mat-card .mdc-card__actions:not(.review-actions)`), from **v1.9.973+**.
 
 **Local eyeball aid:** open [`public-card-footer.html`](./public-card-footer.html) in a browser (static fixture — no Angular build).
 
@@ -14,26 +14,23 @@ One shared rule covers homepage, search, podcast list, podcast episode, subject,
 
 ## Layout model
 
-CSS **grid** on the actions row (not flex-wrap). `mat-card-footer.subjects` and `app-subjects` use **`display: contents`** so each `.subject` and the icon host are grid items.
-
-```css
-grid-template-columns:
-  fit-content(calc(100% - var(--public-card-subject-min)))
-  minmax(var(--public-card-subject-min), 1fr);
-```
+CSS **flex** on the actions row (`flex-wrap` + `flex-direction: row-reverse`). `mat-card-footer.subjects` and `app-subjects` use **`display: contents`** so each `.subject` and the icon host are flex items.
 
 | Role | Behaviour |
 |------|-----------|
-| Icon host | `grid-column: 1`, `order: 2` — left cell of the **bottom** row. Flush left. Height `icon-row`. Width grows with buttons/stats but is **capped** so the subject column keeps its minimum. |
-| Leading subjects | `grid-column: 1 / -1`, `order: 1` — full-width rows **above** the bottom row. |
-| Last / only subject | `grid-column: 2`, `order: 2` — **shares the bottom row** with the icon island; mid-aligned; not crushed below `--public-card-subject-min`. |
-| Zero subjects | Icon host alone in column 1. |
+| Icon host | `order: 3`, `flex: 0 0 auto`, `margin-right: auto` — left of last subject when coexisting; alone flush-left when wrapped below. |
+| Leading subjects | `flex: 0 0 100%`, `order: 1` — full-width rows **above** the bottom row. |
+| Last / only subject | `order: 2`, `flex: 1 1 var(--public-card-subject-min)`, `min-width: min(100%, var(--public-card-subject-min))` — **beside** the island when island + min-width fit; otherwise full line **above** a wrapped island. |
+| Zero subjects | Icon host alone, flush left. |
+
+`row-reverse` is what keeps **island left / subject right** on one row, while still wrapping the **island below** the subject when they cannot coexist (subject is packed first in the reversed order).
 
 ### Hard rules
 
-1. **Coexist when there is room** — last/only subject and the button island share the bottom row.
-2. **Never split subjects** — island must not appear between subject lines (leading labels stay above the bottom row).
-3. **Never crush** — subject column minimum is `--public-card-subject-min` (default **100px**, configurable). The island track is `fit-content(100% - min)` so labels keep that floor.
+1. **Coexist when there is room** — last/only subject and the button island share the bottom row when island width + `--public-card-subject-min` fit.
+2. **Stack when crushed** — if coexistence would drop the subject below `--public-card-subject-min` or overlap icons (wide island, youtube-stats, narrow card), **all subjects** (including last/only) sit **above** the island; island alone on the bottom row.
+3. **Never split subjects** — island must not appear between subject lines (leading labels stay above; last subject never lands below the island while another subject is above).
+4. **Never overlap** — subject text must not paint over the icon/stats island.
 
 ### Configurable subject min-width
 
@@ -47,10 +44,10 @@ grid-template-columns:
 
 **Contract:**
 
-- The **subject column** (last/only subject beside the island) must never be narrower than this value.
-- The **island column** is `fit-content(calc(100% - var(--public-card-subject-min)))` so the island cannot steal that floor.
+- When coexisting, the last/only subject box is never narrower than this value.
+- When the island’s intrinsic width leaves less than this for the subject, flex wrap stacks subjects above the island instead of crushing.
 - Override the custom property to tune (e.g. `120px` on a denser layout) — do not hard-code a different px in one-off rules.
-- Measure in DevTools: last/only `.subject` content box width ≥ computed `--public-card-subject-min`.
+- Measure in DevTools: either last/only `.subject` content box width ≥ computed `--public-card-subject-min` **beside** the island, or the subject is on a full-width row **above** the island.
 
 ### Subject length bands (use these in checks)
 
@@ -62,7 +59,7 @@ grid-template-columns:
 | **Long** | real long proper name | `The Church Of Jesus Christ Of Latter-Day Saints` |
 | **Very long** | stress / wrap | `Independent Fundamentalist Baptist ABCDEF GHI JKLMN OPQRSTUVWXZY` |
 
-Length applies to **leading** rows (full card width) and to the **last/only** cell (beside island, ≥ min-width). Wrapping inside the last cell is OK; crushing below min-width is not.
+Length applies to **leading** rows (full card width) and to the **last/only** cell (beside island when coexisting, ≥ min-width). Wrapping inside the last cell is OK; crushing below min-width is not — stack instead.
 
 ## Spacing tokens
 
@@ -71,26 +68,29 @@ Length applies to **leading** rows (full card width) and to the **last/only** ce
 | `--public-card-desc-gap` | `8px` | Description → footer |
 | `--public-card-footer-clearance` | `10px` | Icon/meta → card bottom |
 | `--public-card-icon-row` | `40px` | Icon host / `.youtubemeta` height |
-| `--public-card-subject-min` | `100px` | Min width of subject column beside island |
+| `--public-card-subject-min` | `100px` | Min width of subject beside island (else stack) |
+| `--public-card-subject-line` | `1.25em` | Subject line-height used for last-line mid optical offset |
 | Icon `margin-right` | `25px` / `18px` / `12px` | Between service buttons — **do not squeeze** |
 | Subject gaps | `6px` | Uniform between leading subjects |
 
 ## Vertical alignment
 
 1. All service buttons share one mid-line inside the icon host.
-2. Last/only subject mid-aligns with that mid-line (`align-items: center` on the grid).
-3. `.youtubemeta` mid-aligns inside the host.
-4. Card `padding-bottom` ≈ 10px under the icon row.
+2. When last/only subject **coexists** on the bottom row with the island: icon-host vertical mid aligns with the **middle of the last line** of that subject (`align-self: flex-end` on both + `margin-bottom: calc((icon-row - subject-line) / 2)` on the subject) — not the top of the first line, and not the center of the whole wrapped subject block.
+3. Single-line subjects optically mid-align with the icon row via the same formula.
+4. Leading subjects (above the bottom row) are unchanged.
+5. `.youtubemeta` mid-aligns inside the host.
+6. Card `padding-bottom` ≈ 10px under the icon row.
 
 ## What NOT to do
 
 - Flex-wrap that places the island **between** subject lines.
-- Putting **every** multi subject full-width above the island (loses bottom-row coexistence).
-- Fixed island widths / `nth-of-type` left offsets.
-- Extra left margin on the icon host.
+- Forcing last subject beside a too-wide island (crush / overlap) — stack instead.
+- Putting **every** multi subject full-width above the island even when coexistence fits (loses bottom-row coexistence).
+- Fixed island widths / `nth-of-type` left offsets / hardcoded button-count breakpoints.
+- Extra left margin on the icon host (use `margin-right: auto` only so a wrapped island stays flush left).
 - Squeezing the 25px icon `margin-right`.
 - `min-height: icon-row` on subjects (uneven gaps).
-- Crushing the subject column below `--public-card-subject-min`.
 
 ---
 
@@ -106,10 +106,12 @@ Use the [static fixture](./public-card-footer.html) first, then preview.
 | All service icons one mid-line | ☐ |
 | Island **never** between subject lines | ☐ |
 | Leading subjects full width above bottom row | ☐ |
-| Last/only subject **beside** island on bottom row | ☐ |
-| Subject column ≥ `--public-card-subject-min` (**100px** default) for last/only | ☐ |
-| Tiny last/only subject does **not** shrink the column below min-width | ☐ |
-| Long / very long last/only may wrap inside the column — never crushed to ~1 word/line | ☐ |
+| Last/only subject **beside** island when room (≥ min-width) | ☐ |
+| When island too wide: **all subjects above**, island alone below — no overlap | ☐ |
+| Subject column ≥ `--public-card-subject-min` when coexisting | ☐ |
+| Tiny last/only subject does **not** shrink below min-width when coexisting | ☐ |
+| Long / very long last/only may wrap when coexisting — or stack above if crushed | ☐ |
+| Coexisting multi-line last subject: icon mid ↔ **last-line** mid | ☐ |
 | ~8px under description · ~10px card bottom | ☐ |
 | Uniform ~6px gaps between leading subjects | ☐ |
 
@@ -118,22 +120,22 @@ Use the [static fixture](./public-card-footer.html) first, then preview.
 | # | Subjects | Buttons | Expect |
 |---|----------|---------|--------|
 | A | 0 | YT + Share | Island only |
-| B | 1 **short** | YT + Share | Bottom row coexist; column ≥ min-width |
-| C | 1 **long** | YT + Spotify + Apple + Share | Bottom row; ≥ min-width; may wrap in column |
-| C2 | 1 **tiny** | YT + Share | Bottom row; column still ≥ min-width (not shrink-wrapped to glyph width) |
-| C3 | 1 **very long** | YT + Spotify + Apple + Share | Bottom row; wraps in column; never one-word-per-line crush |
-| D | 2× **medium** | YT + Share | Leading above; **last beside icons** |
+| B | 1 **short** | YT + Share | Bottom row coexist; last-line mid ↔ icon mid |
+| C | 1 **long** | YT + Spotify + Apple + Share | Coexist if room (wrap OK); else stack above; last-line mid when beside |
+| C2 | 1 **tiny** | YT + Share | Bottom row; column still ≥ min-width |
+| C3 | 1 **very long** | YT + Spotify + Apple + Share | Coexist/wrap or stack; never one-word crush beside island |
+| D | 2× **medium** | YT + Share | Leading above; **last beside icons** when room |
 | D2 | 3× **medium** (dup mid) | YT + Share | First two above; **last beside icons**; uniform gaps |
-| D3 | 2× **very long** | many | Leading above (full width wrap OK); last beside (wraps in column) |
-| D4 | **very long** leading + **short** last | many | Leading above; short last beside |
-| D5 | **tiny** leading + **long** last | YT + Share | Leading above; long last beside ≥ min-width |
-| D6 | **short** + **medium** + **long** | YT + Spotify + Share | Mixed lengths; only last on bottom row with icons |
+| D3 | 2× **very long** | many | Leading above; last beside or stack if crushed |
+| D4 | **very long** leading + **short** last | many | Leading above; short last beside when room |
+| D5 | **tiny** leading + **long** last | YT + Share | Leading above; long last beside ≥ min-width when room |
+| D6 | **short** + **medium** + **long** | YT + Spotify + Share | Mixed lengths; only last on bottom row when room |
 | E | 2× **medium** | YT only | Same coexist; narrow island |
-| F | 2× **medium** | YT…BBC…IA…Share | Wide island **capped**; last beside, not between |
-| G | 1 **medium** | YT + Spotify + Apple | Bottom row coexist |
-| H | 1 **long** + youtube-stats | YT + meta + … | Bottom row; subject ≥ min-width (not one-word column) |
-| H2 | 1 **tiny** + youtube-stats | YT + meta | Bottom row; column still ≥ min-width |
-| I | 2× **medium** + youtube-stats | YT + meta + Share | Leading above; last beside host |
+| F | 2× **medium** | YT…BBC…IA…Share | **Wide island → subjects above, island below**; no overlap |
+| G | 1 **medium** | YT + Spotify + Apple | Bottom row coexist when room |
+| H | 1 **long** + youtube-stats | YT + meta + … | Stack above if stats island too wide; else coexist ≥ min-width |
+| H2 | 1 **tiny** + youtube-stats | YT + meta | Coexist ≥ min-width or stack |
+| I | 2× **medium** + youtube-stats | YT + meta + Share | Leading above; last beside or stack |
 
 **Live check owed:** H/H2/I with real Discovery Members/Views.
 
@@ -141,10 +143,11 @@ Use the [static fixture](./public-card-footer.html) first, then preview.
 
 ## DevTools
 
-1. 2+ subjects: every non-last `.subject` bottom ≤ icon host top; last `.subject` shares the icon host mid-line.
-2. Last/only subject width ≥ `--public-card-subject-min`.
-3. Description left vs first icon left — same inset.
-4. Card bottom − icon bottom ≈ 10px.
+1. 2+ subjects: every non-last `.subject` bottom ≤ icon host top; last `.subject` either shares the icon host mid-line (last-line mid) or sits fully above the island.
+2. When coexisting: last/only subject width ≥ `--public-card-subject-min`; no overlap with island.
+3. When stacked: last subject bottom ≤ icon host top; island alone on bottom row, flush left.
+4. Description left vs first icon left — same inset.
+5. Card bottom − icon bottom ≈ 10px.
 
 ## Where to edit
 

--- a/cultpodcasts/docs/public-card-footer.md
+++ b/cultpodcasts/docs/public-card-footer.md
@@ -4,7 +4,7 @@ Shared layout for subjects, podcast-service icon buttons, and Discovery youtube-
 
 **Source of truth:** `src/styles.scss` (`mat-card .mdc-card__actions:not(.review-actions)`), from **v1.9.971+**.
 
-**Local eyeball aid:** open [`public-card-footer-permutations.html`](./public-card-footer-permutations.html) in a browser (static fixture — no Angular build).
+**Local eyeball aid:** open [`public-card-footer.html`](./public-card-footer.html) in a browser (static fixture — no Angular build).
 
 Review/outgoing cards (`.review-actions`) are **out of scope**.
 
@@ -96,7 +96,7 @@ Length applies to **leading** rows (full card width) and to the **last/only** ce
 
 ## Permutation matrix / verification checklist
 
-Use the [static fixture](./public-card-footer-permutations.html) first, then preview.
+Use the [static fixture](./public-card-footer.html) first, then preview.
 
 ### Must be true
 
@@ -152,4 +152,4 @@ Use the [static fixture](./public-card-footer-permutations.html) first, then pre
 |---------|------|
 | Public footer contract | `src/styles.scss` |
 | Subject stack (editable X) | `src/app/subjects/subjects.component.sass` |
-| This checklist + fixture | `docs/public-card-footer.md`, `docs/public-card-footer-permutations.html` |
+| This checklist + fixture | `docs/public-card-footer.md`, `docs/public-card-footer.html` |

--- a/cultpodcasts/docs/public-card-footer.md
+++ b/cultpodcasts/docs/public-card-footer.md
@@ -2,7 +2,7 @@
 
 Shared layout for subjects, podcast-service icon buttons, and Discovery youtube-stats on public result cards.
 
-**Source of truth:** `src/styles.scss` (`mat-card .mdc-card__actions:not(.review-actions)`), from **v1.9.973+**.
+**Source of truth:** `src/styles.scss` (`mat-card .mdc-card__actions:not(.review-actions)`), from **v1.9.974+**.
 
 **Local eyeball aid:** open [`public-card-footer.html`](./public-card-footer.html) in a browser (static fixture — no Angular build).
 
@@ -20,34 +20,32 @@ CSS **flex** on the actions row (`flex-wrap` + `flex-direction: row-reverse`). `
 |------|-----------|
 | Icon host | `order: 3`, `flex: 0 0 auto`, `margin-right: auto` — left of last subject when coexisting; alone flush-left when wrapped below. |
 | Leading subjects | `flex: 0 0 100%`, `order: 1` — full-width rows **above** the bottom row. |
-| Last / only subject | `order: 2`, `flex: 1 1 var(--public-card-subject-min)`, `min-width: min(100%, var(--public-card-subject-min))` — **beside** the island when island + min-width fit; otherwise full line **above** a wrapped island. |
+| Last / only subject | `order: 2`, `flex: 1 1 min-content`, `min-width: min-content` — **beside** the island when island + subject **min-content** fit; otherwise full line **above** a wrapped island. |
 | Zero subjects | Icon host alone, flush left. |
 
 `row-reverse` is what keeps **island left / subject right** on one row, while still wrapping the **island below** the subject when they cannot coexist (subject is packed first in the reversed order).
 
 ### Hard rules
 
-1. **Coexist when there is room** — last/only subject and the button island share the bottom row when island width + `--public-card-subject-min` fit.
-2. **Stack when crushed** — if coexistence would drop the subject below `--public-card-subject-min` or overlap icons (wide island, youtube-stats, narrow card), **all subjects** (including last/only) sit **above** the island; island alone on the bottom row.
+1. **Coexist when there is room** — last/only subject and the button island share the bottom row when island width + the subject’s **intrinsic min-content width** (longest unbreakable run / label need) fit.
+2. **Stack when crushed** — if coexistence would force the subject narrower than its min-content (one-word crush) or overlap icons (wide island, youtube-stats, narrow card), **all subjects** (including last/only) sit **above** the island; island alone on the bottom row.
 3. **Never split subjects** — island must not appear between subject lines (leading labels stay above; last subject never lands below the island while another subject is above).
 4. **Never overlap** — subject text must not paint over the icon/stats island.
 
-### Configurable subject min-width
+### Coexist threshold (content width, not a fixed column)
 
-| Token | Default | Where set |
-|-------|---------|-----------|
-| `--public-card-subject-min` | **`100px`** | `mat-card .mdc-card__actions:not(.review-actions)` in `styles.scss` |
+There is **no** fixed `--public-card-subject-min` / 100px subject column. Tiny labels (e.g. `Qanon`) must sit beside the island whenever their content width fits — do not reserve a wide empty column that forces an unnecessary stack.
 
-```css
---public-card-subject-min: 100px; /* override on card / actions / theme if needed */
-```
+| Token | Role |
+|-------|------|
+| `min-width: min-content` / `flex-basis: min-content` on last/only `.subject` | Flex wrap stacks the island below only when the label’s min-content cannot fit beside the island. |
+| `--public-card-subject-mid-offset` | Optical last-line mid ↔ icon mid (not a coexist threshold). |
 
 **Contract:**
 
-- When coexisting, the last/only subject box is never narrower than this value.
-- When the island’s intrinsic width leaves less than this for the subject, flex wrap stacks subjects above the island instead of crushing.
-- Override the custom property to tune (e.g. `120px` on a denser layout) — do not hard-code a different px in one-off rules.
-- Measure in DevTools: either last/only `.subject` content box width ≥ computed `--public-card-subject-min` **beside** the island, or the subject is on a full-width row **above** the island.
+- Coexist vs stack = `island intrinsic width + subject min-content` vs container (plus any flex gap).
+- Long subjects may **wrap** in the remaining space when coexisting; they stack when remaining space is below min-content.
+- Measure in DevTools: either last/only `.subject` sits **beside** the island at ≥ its min-content width, or it is on a full-width row **above** the island.
 
 ### Subject length bands (use these in checks)
 
@@ -59,7 +57,7 @@ CSS **flex** on the actions row (`flex-wrap` + `flex-direction: row-reverse`). `
 | **Long** | real long proper name | `The Church Of Jesus Christ Of Latter-Day Saints` |
 | **Very long** | stress / wrap | `Independent Fundamentalist Baptist ABCDEF GHI JKLMN OPQRSTUVWXZY` |
 
-Length applies to **leading** rows (full card width) and to the **last/only** cell (beside island when coexisting, ≥ min-width). Wrapping inside the last cell is OK; crushing below min-width is not — stack instead.
+Length applies to **leading** rows (full card width) and to the **last/only** cell (beside island when coexisting at content need). Wrapping inside the last cell is OK; crushing below min-content is not — stack instead.
 
 ## Spacing tokens
 
@@ -68,17 +66,17 @@ Length applies to **leading** rows (full card width) and to the **last/only** ce
 | `--public-card-desc-gap` | `8px` | Description → footer |
 | `--public-card-footer-clearance` | `10px` | Icon/meta → card bottom |
 | `--public-card-icon-row` | `40px` | Icon host / `.youtubemeta` height |
-| `--public-card-subject-min` | `100px` | Min width of subject beside island (else stack) |
 | `--public-card-subject-line` | `1.25em` | Subject line-height used for last-line mid optical offset |
+| `--public-card-subject-mid-offset` | `(icon-row − subject-line) / 2` | Last-line mid ↔ icon mid; also cancels leading→last gap inflation |
 | Icon `margin-right` | `25px` / `18px` / `12px` | Between service buttons — **do not squeeze** |
-| Subject gaps | `6px` | Uniform between leading subjects |
+| Subject gaps | `6px` | Uniform between **all** consecutive subjects (leading↔leading and leading↔last) |
 
 ## Vertical alignment
 
 1. All service buttons share one mid-line inside the icon host.
-2. When last/only subject **coexists** on the bottom row with the island: icon-host vertical mid aligns with the **middle of the last line** of that subject (`align-self: flex-end` on both + `margin-bottom: calc((icon-row - subject-line) / 2)` on the subject) — not the top of the first line, and not the center of the whole wrapped subject block.
+2. When last/only subject **coexists** on the bottom row with the island: icon-host vertical mid aligns with the **middle of the last line** of that subject (`align-self: flex-end` on both + `margin-bottom: var(--public-card-subject-mid-offset)` on the subject) — not the top of the first line, and not the center of the whole wrapped subject block.
 3. Single-line subjects optically mid-align with the icon row via the same formula.
-4. Leading subjects (above the bottom row) are unchanged.
+4. When leading subjects sit above that bottom row, the whole bottom row is pulled up by the same mid-offset (`margin-top: −mid-offset` on last subject + icon host) so leading→last text gap matches the 6px leading→leading gap (flex-end mid-align would otherwise leave empty space above the last subject inside the taller icon line). The last subject also gets matching `padding-top` so that when it stacks full-width above the island, labels do not overlap.
 5. `.youtubemeta` mid-aligns inside the host.
 6. Card `padding-bottom` ≈ 10px under the icon row.
 
@@ -87,6 +85,7 @@ Length applies to **leading** rows (full card width) and to the **last/only** ce
 - Flex-wrap that places the island **between** subject lines.
 - Forcing last subject beside a too-wide island (crush / overlap) — stack instead.
 - Putting **every** multi subject full-width above the island even when coexistence fits (loses bottom-row coexistence).
+- A fixed 100px (or similar) subject column min that stacks tiny labels when their content width would fit.
 - Fixed island widths / `nth-of-type` left offsets / hardcoded button-count breakpoints.
 - Extra left margin on the icon host (use `margin-right: auto` only so a wrapped island stays flush left).
 - Squeezing the 25px icon `margin-right`.
@@ -106,14 +105,13 @@ Use the [static fixture](./public-card-footer.html) first, then preview.
 | All service icons one mid-line | ☐ |
 | Island **never** between subject lines | ☐ |
 | Leading subjects full width above bottom row | ☐ |
-| Last/only subject **beside** island when room (≥ min-width) | ☐ |
+| Last/only subject **beside** island when island + subject min-content fit | ☐ |
 | When island too wide: **all subjects above**, island alone below — no overlap | ☐ |
-| Subject column ≥ `--public-card-subject-min` when coexisting | ☐ |
-| Tiny last/only subject does **not** shrink below min-width when coexisting | ☐ |
+| Tiny last/only (e.g. Qanon) sits beside when content width fits — not forced to stack by a 100px floor | ☐ |
 | Long / very long last/only may wrap when coexisting — or stack above if crushed | ☐ |
 | Coexisting multi-line last subject: icon mid ↔ **last-line** mid | ☐ |
 | ~8px under description · ~10px card bottom | ☐ |
-| Uniform ~6px gaps between leading subjects | ☐ |
+| Uniform ~6px gaps between **all** consecutive subjects | ☐ |
 
 ### Subjects × services
 
@@ -122,19 +120,19 @@ Use the [static fixture](./public-card-footer.html) first, then preview.
 | A | 0 | YT + Share | Island only |
 | B | 1 **short** | YT + Share | Bottom row coexist; last-line mid ↔ icon mid |
 | C | 1 **long** | YT + Spotify + Apple + Share | Coexist if room (wrap OK); else stack above; last-line mid when beside |
-| C2 | 1 **tiny** | YT + Share | Bottom row; column still ≥ min-width |
+| C2 | 1 **tiny** | YT + Share | Bottom row at content width |
 | C3 | 1 **very long** | YT + Spotify + Apple + Share | Coexist/wrap or stack; never one-word crush beside island |
-| D | 2× **medium** | YT + Share | Leading above; **last beside icons** when room |
+| D | 2× **medium** | YT + Share | Leading above; **last beside icons** when content fits; uniform gaps |
 | D2 | 3× **medium** (dup mid) | YT + Share | First two above; **last beside icons**; uniform gaps |
 | D3 | 2× **very long** | many | Leading above; last beside or stack if crushed |
-| D4 | **very long** leading + **short** last | many | Leading above; short last beside when room |
-| D5 | **tiny** leading + **long** last | YT + Share | Leading above; long last beside ≥ min-width when room |
-| D6 | **short** + **medium** + **long** | YT + Spotify + Share | Mixed lengths; only last on bottom row when room |
+| D4 | **very long** leading + **short** last | many | Leading above; short last beside when content fits |
+| D5 | **tiny** leading + **long** last | YT + Share | Leading above; long last beside when min-content fits |
+| D6 | **short** + **medium** + **long** | YT + Spotify + Share | Mixed lengths; only last on bottom row when content fits |
 | E | 2× **medium** | YT only | Same coexist; narrow island |
 | F | 2× **medium** | YT…BBC…IA…Share | **Wide island → subjects above, island below**; no overlap |
-| G | 1 **medium** | YT + Spotify + Apple | Bottom row coexist when room |
-| H | 1 **long** + youtube-stats | YT + meta + … | Stack above if stats island too wide; else coexist ≥ min-width |
-| H2 | 1 **tiny** + youtube-stats | YT + meta | Coexist ≥ min-width or stack |
+| G | 1 **medium** | YT + Spotify + Apple | Bottom row coexist when content fits |
+| H | 1 **long** + youtube-stats | YT + meta + … | Stack above if stats island + min-content too wide; else coexist |
+| H2 | 1 **tiny** + youtube-stats | YT + meta | **Qanon beside** meta island (content width); stack only if min-content cannot fit |
 | I | 2× **medium** + youtube-stats | YT + meta + Share | Leading above; last beside or stack |
 
 **Live check owed:** H/H2/I with real Discovery Members/Views.
@@ -144,10 +142,11 @@ Use the [static fixture](./public-card-footer.html) first, then preview.
 ## DevTools
 
 1. 2+ subjects: every non-last `.subject` bottom ≤ icon host top; last `.subject` either shares the icon host mid-line (last-line mid) or sits fully above the island.
-2. When coexisting: last/only subject width ≥ `--public-card-subject-min`; no overlap with island.
+2. When coexisting: last/only subject width ≥ its min-content; no overlap with island.
 3. When stacked: last subject bottom ≤ icon host top; island alone on bottom row, flush left.
 4. Description left vs first icon left — same inset.
 5. Card bottom − icon bottom ≈ 10px.
+6. Multi-subject: gaps between consecutive subject labels are visually equal (~6px).
 
 ## Where to edit
 

--- a/cultpodcasts/docs/public-card-footer.md
+++ b/cultpodcasts/docs/public-card-footer.md
@@ -2,7 +2,7 @@
 
 Shared layout for subjects, podcast-service icon buttons, and Discovery youtube-stats on public result cards.
 
-**Source of truth:** `src/styles.scss` (`mat-card .mdc-card__actions:not(.review-actions)`), from **v1.9.967+**.
+**Source of truth:** `src/styles.scss` (`mat-card .mdc-card__actions:not(.review-actions)`), from **v1.9.968+**.
 
 **Local eyeball aid:** open [`public-card-footer-permutations.html`](./public-card-footer-permutations.html) in a browser (static fixture — no Angular build).
 
@@ -18,12 +18,16 @@ Flex **row-wrap** on the actions row. `mat-card-footer.subjects` and `app-subjec
 
 | Role | Behaviour |
 |------|-----------|
-| Icon host | `app-episode-links`, `app-episode-podcast-links`, or `.discovery-service-links` — one content-sized flex item (`order: 2`). **Flush left** with description (actions `padding-left` only — **no** host `margin-left`). Fixed **`height: icon-row`**; all buttons mid-align inside it. |
-| Leading subjects | `order: 1`, `flex: 1 0 100%` — full-width rows above the icon island. |
-| Last / only subject | `order: 2`, `flex: 1 1 0`, **natural height** — parent `align-items: center` mid-aligns it with the icon host. **Never** `min-height`/`height: icon-row` on the subject (short last lines leave a hole above the label). |
+| Icon host | `app-episode-links`, `app-episode-podcast-links`, or `.discovery-service-links` — content-sized (`order: 2`). **Flush left** with description. Fixed **`height: icon-row`**; all buttons mid-align inside it. |
+| **2+ subjects** | **Every** subject (including last) is `order: 1`, `flex: 1 0 100%` — full-width rows **above** the icon island. Island is **always underneath the whole subject list**. |
+| **Only-child** | `order: 2`, `flex: 1 1 0` — shares the icon row; natural height; mid-aligned with icons. |
 | Zero subjects | Actions still reserve `desc-gap + icon-row` min-height. |
 
-Island width = **actual icon host width** (variable button count). Never a fixed `padding-left` / rem guess.
+Island width = **actual icon host width** (variable button count: YT, Spotify, Apple, BBC, Internet Archive, Share, …). Never a fixed `padding-left` / rem guess.
+
+### Hard rule: never split subjects
+
+The icon island must **never** appear between subject lines (e.g. subject₁ → icons → subject₂). That was a flex-wrap failure when the island was wide and last subject shared `order` with the icons. With 2+ subjects, stack all labels first; icons come after.
 
 ## Spacing tokens
 
@@ -31,28 +35,29 @@ Island width = **actual icon host width** (variable button count). Never a fixed
 |--------------|-------|------|
 | `--public-card-desc-gap` | `8px` | Description → footer |
 | `--public-card-footer-clearance` | `10px` | Icon/meta → card bottom |
-| `--public-card-icon-row` | `40px` (MDC state layer) | Icon host + last/only subject + `.youtubemeta` height |
+| `--public-card-icon-row` | `40px` (MDC state layer) | Icon host + only-child / `.youtubemeta` height |
 | Actions `padding-left` | `20px` / `10px` / `2px` | Shared left inset for description **and** icons |
 | Icon `margin-right` | `25px` / `18px` / `12px` | Gap between service buttons — **do not squeeze** |
-| Subject gaps | `6px` | Uniform between subjects — no stretch hole above last |
+| Subject gaps | `6px` | Uniform between subjects |
 
 ## Vertical alignment (non-negotiable)
 
-1. **All service buttons** (YT, Spotify, Apple, BBC, IA, Share, …) share **one mid-line** inside the icon host.
-2. **Last/only subject** mid-aligns with that icon mid-line via the actions row’s `align-items: center` (subject stays **natural height**).
-3. **`.youtubemeta`** (Discovery) mid-aligns with the same icon mid-line.
-4. Clearance under the icon row comes from card `padding-bottom` (~10px), not from nudging individual icons.
-5. Gaps between subject lines stay **uniform** (~6px from leading `padding-bottom`) — short vs wrapped last subjects must not change that.
+1. **All service buttons** share **one mid-line** inside the icon host.
+2. **Only-child** mid-aligns with that icon mid-line (natural height; parent `align-items: center`).
+3. **2+ subjects:** icons sit on a row **below** the subject stack (left-aligned); subjects are not mid-aligned beside a wide island.
+4. **`.youtubemeta`** mid-aligns with the icon mid-line inside the host.
+5. Clearance under the icon row = card `padding-bottom` (~10px).
+6. Gaps between subject lines stay **uniform** (~6px).
 
 ## What NOT to do
 
+- Let the icon island wrap **between** subject lines.
 - Fixed island widths (`16.5rem`, `nth-of-type` left offsets).
 - Extra left margin on the icon host (double-indents vs description).
 - Absolute-positioning each button with guessed `left` values.
 - Squeezing the 25px icon `margin-right`.
-- `min-height` / `height: icon-row` on **last/only** subjects (uneven gap above short last labels; wrapped last labels hide the bug).
-- `min-height` on **leading** subjects to fake align (opens uneven gaps).
-- Relying on `align-items: end` from `mat-card .mdc-card__actions` for public footers.
+- `min-height` / `height: icon-row` on subjects (uneven gaps).
+- Putting last-of-many on `order: 2` with the icon host (wide islands re-split the list on wrap).
 - Page-specific forks / touching `.review-actions` for this contract.
 
 ---
@@ -65,56 +70,55 @@ Check **every** cell before shipping footer CSS changes. Use the [static fixture
 
 | Rule | Pass |
 |------|------|
-| Icons flush left with description left edge (no extra indent) | ☐ |
-| All service icons share one horizontal mid-line (YT not lower than Share) | ☐ |
-| Last/only subject mid-aligned with that icon mid-line | ☐ |
+| Icons flush left with description left edge | ☐ |
+| All service icons share one horizontal mid-line | ☐ |
+| Icon island **never** between subject lines | ☐ |
 | ~8px gap description → footer | ☐ |
 | ~10px clearance icons → card bottom | ☐ |
 | No subject text overlapping icons | ☐ |
-| Uniform ~6px gaps between subject lines (2+ subjects) — same whether last is short or wraps | ☐ |
-| Leading subjects (if any) use full card width | ☐ |
-| Short last subject does **not** sit in a taller box than siblings (no hole above it) | ☐ |
+| Uniform ~6px gaps between subject lines (2+) | ☐ |
+| Leading / multi subjects use full card width | ☐ |
+| Only-child mid-aligned with icons on the same row | ☐ |
 
 ### Subjects × services
 
 | # | Subjects | Service buttons | Expect |
 |---|----------|-----------------|--------|
-| A | **0** | YT + Share | Icon row only; flush left; mid-line shared; 8px top / 10px bottom |
-| B | **1** short | YT + Share | Subject right of icons, mid-aligned; no collision |
-| C | **1** long (“The Church Of Jesus Christ Of Latter-Day Saints”) | YT + Spotify + Apple + Share | Subject clears full icon cluster; may wrap within remaining width; no overlap |
-| D | **2+** (“Human Trafficking” + “Hustler's University”) | YT + Share | First subject full width; last mid-aligned with icons; **uniform 6px gap** (no hole above short last) |
-| D2 | **2+** short last + duplicate mid lines | YT + Share | Gaps between all subject lines equal; last not stretched |
-| D3 | **2+** with **long wrapped last** subject | YT + Spotify + Apple + Share | Last may wrap beside icons; gaps above last still match sibling gaps |
-| D4 | **2+** long **leading** + short last (one line) | many buttons | Leading full width; short last mid-aligned; **no extra gap** under leading before last row |
-| E | **2+** | YT only | Same as D; island narrows to one button + margins |
-| F | **2+** | YT + Spotify + Apple + BBC + IA + Share | Island grows; last subject still clears all icons; icons stay one mid-line |
+| A | **0** | YT + Share | Icon row only; flush left; 8px top / 10px bottom |
+| B | **1** short | YT + Share | Subject right of icons, mid-aligned |
+| C | **1** long (Latter-Day Saints) | YT + Spotify + Apple + Share | Clears full cluster; may wrap in remaining width |
+| D | **2+** short | YT + Share | **All subjects stacked full width; icons underneath** |
+| D2 | **3** short | YT + Share | Uniform gaps; icons under entire stack |
+| D3 | **2+** long labels | many buttons | Subjects stacked full width (may wrap within row); icons underneath — **not** between |
+| D4 | long leading + short last | many buttons | Both above; icons underneath |
+| E | **2+** | YT only | Same stack-then-icons |
+| F | **2+** | YT + Spotify + Apple + BBC + IA + Share | Same — wide island still **under** subjects, never between |
 | G | **1** | YT + Spotify + Apple | Mid-align + flush left |
 
 ### Discovery youtube-stats
 
 | # | Subjects | Buttons + meta | Expect |
 |---|----------|----------------|--------|
-| H | 0 or 1+ | YT + **`.youtubemeta`** (Views / Members) + Spotify… | Meta mid-aligned with icons; same bottom clearance; subjects clear host including meta width |
-| I | 2+ | YT + meta + Share | Same as H; leading subjects full width |
+| H | 0 or 1 | YT + **`.youtubemeta`** + … | Meta mid-aligned in host; only-child / none rules as above |
+| I | 2+ | YT + meta + Share | Subjects stacked; host (with meta) underneath |
 
-**Live check owed:** H/I against a Discovery run that actually populates Members/Views (fixture covers geometry only).
+**Live check owed:** H/I against Discovery with real Members/Views.
 
 ### Narrow widths
 
 | # | Viewport | Expect |
 |---|----------|--------|
-| J | ≤600px | `padding-left` 10px; icon `margin-right` 18px; rules A–I still hold |
-| K | ≤400px | `padding-left` 2px; icon `margin-right` 12px; long subject still no collision |
+| J | ≤600px | Rules A–I still hold |
+| K | ≤400px | Long subjects still no collision / no split |
 
 ---
 
 ## DevTools measurement (live card)
 
-1. Select the icon host (`app-episode-links` / `.discovery-service-links`) and the last `.subject`.
-2. Compare **getBoundingClientRect().top/bottom** midpoints — should match within ~1px.
-3. Compare each `mat-icon-button` midpoint inside the host — should match each other.
-4. Description left vs first icon left — same content inset (actions padding).
-5. Card bottom − icon bottom ≈ 10px.
+1. With 2+ subjects: every `.subject` top edge is **above** the icon host top — no subject below the host.
+2. Only-child: subject and icon host midpoints match within ~1px.
+3. Description left vs first icon left — same content inset.
+4. Card bottom − icon bottom ≈ 10px.
 
 ---
 

--- a/cultpodcasts/docs/public-card-footer.md
+++ b/cultpodcasts/docs/public-card-footer.md
@@ -1,0 +1,124 @@
+# Public episode card footer — design contract
+
+Shared layout for subjects, podcast-service icon buttons, and Discovery youtube-stats on public result cards.
+
+**Source of truth:** `src/styles.scss` (`mat-card .mdc-card__actions:not(.review-actions)`), from **v1.9.966+**.
+
+**Local eyeball aid:** open [`public-card-footer-permutations.html`](./public-card-footer-permutations.html) in a browser (static fixture — no Angular build).
+
+Review/outgoing cards (`.review-actions`) are **out of scope**.
+
+## Surfaces
+
+One shared rule covers homepage, search, podcast list, podcast episode, subject, bookmarks, and Discovery. Do **not** add page-specific footer forks.
+
+## Layout model
+
+Flex **row-wrap** on the actions row. `mat-card-footer.subjects` and `app-subjects` use **`display: contents`** so each `.subject` and the icon host share one flex formatting context.
+
+| Role | Behaviour |
+|------|-----------|
+| Icon host | `app-episode-links`, `app-episode-podcast-links`, or `.discovery-service-links` — one content-sized flex item (`order: 2`). **Flush left** with description (actions `padding-left` only — **no** host `margin-left`). Fixed **`height: icon-row`**; all buttons mid-align inside it. |
+| Leading subjects | `order: 1`, `flex: 1 0 100%` — full-width rows above the icon island. |
+| Last / only subject | `order: 2`, `flex: 1 1 0`, **same `height` as icon-row**, flex-centers the label → shared mid-line with icons. |
+| Zero subjects | Actions still reserve `desc-gap + icon-row` min-height. |
+
+Island width = **actual icon host width** (variable button count). Never a fixed `padding-left` / rem guess.
+
+## Spacing tokens
+
+| Token / rule | Value | Role |
+|--------------|-------|------|
+| `--public-card-desc-gap` | `8px` | Description → footer |
+| `--public-card-footer-clearance` | `10px` | Icon/meta → card bottom |
+| `--public-card-icon-row` | `40px` (MDC state layer) | Icon host + last/only subject + `.youtubemeta` height |
+| Actions `padding-left` | `20px` / `10px` / `2px` | Shared left inset for description **and** icons |
+| Icon `margin-right` | `25px` / `18px` / `12px` | Gap between service buttons — **do not squeeze** |
+| Subject gaps | `6px` | Uniform between subjects — no stretch hole above last |
+
+## Vertical alignment (non-negotiable)
+
+1. **All service buttons** (YT, Spotify, Apple, BBC, IA, Share, …) share **one mid-line** inside the icon host.
+2. **Last/only subject** mid-aligns with that icon mid-line (same row height + `align-items: center`).
+3. **`.youtubemeta`** (Discovery) mid-aligns with the same icon mid-line.
+4. Clearance under the icon row comes from card `padding-bottom` (~10px), not from nudging individual icons.
+
+## What NOT to do
+
+- Fixed island widths (`16.5rem`, `nth-of-type` left offsets).
+- Extra left margin on the icon host (double-indents vs description).
+- Absolute-positioning each button with guessed `left` values.
+- Squeezing the 25px icon `margin-right`.
+- `min-height` on **leading** subjects to fake align (opens uneven gaps).
+- Relying on `align-items: end` from `mat-card .mdc-card__actions` for public footers.
+- Page-specific forks / touching `.review-actions` for this contract.
+
+---
+
+## Permutation matrix / verification checklist
+
+Check **every** cell before shipping footer CSS changes. Use the [static fixture](./public-card-footer-permutations.html) first, then a live card on preview.
+
+### Must be true on every permutation
+
+| Rule | Pass |
+|------|------|
+| Icons flush left with description left edge (no extra indent) | ☐ |
+| All service icons share one horizontal mid-line (YT not lower than Share) | ☐ |
+| Last/only subject mid-aligned with that icon mid-line | ☐ |
+| ~8px gap description → footer | ☐ |
+| ~10px clearance icons → card bottom | ☐ |
+| No subject text overlapping icons | ☐ |
+| Uniform ~6px gaps between subject lines (2+ subjects) | ☐ |
+| Leading subjects (if any) use full card width | ☐ |
+
+### Subjects × services
+
+| # | Subjects | Service buttons | Expect |
+|---|----------|-----------------|--------|
+| A | **0** | YT + Share | Icon row only; flush left; mid-line shared; 8px top / 10px bottom |
+| B | **1** short | YT + Share | Subject right of icons, mid-aligned; no collision |
+| C | **1** long (“The Church Of Jesus Christ Of Latter-Day Saints”) | YT + Spotify + Apple + Share | Subject clears full icon cluster; may wrap within remaining width; no overlap |
+| D | **2+** (“Human Trafficking” + “Hustler's University”) | YT + Share | First subject full width; last mid-aligned with icons; 6px gap |
+| E | **2+** | YT only | Same as D; island narrows to one button + margins |
+| F | **2+** | YT + Spotify + Apple + BBC + IA + Share | Island grows; last subject still clears all icons; icons stay one mid-line |
+| G | **1** | YT + Spotify + Apple | Mid-align + flush left |
+
+### Discovery youtube-stats
+
+| # | Subjects | Buttons + meta | Expect |
+|---|----------|----------------|--------|
+| H | 0 or 1+ | YT + **`.youtubemeta`** (Views / Members) + Spotify… | Meta mid-aligned with icons; same bottom clearance; subjects clear host including meta width |
+| I | 2+ | YT + meta + Share | Same as H; leading subjects full width |
+
+**Live check owed:** H/I against a Discovery run that actually populates Members/Views (fixture covers geometry only).
+
+### Narrow widths
+
+| # | Viewport | Expect |
+|---|----------|--------|
+| J | ≤600px | `padding-left` 10px; icon `margin-right` 18px; rules A–I still hold |
+| K | ≤400px | `padding-left` 2px; icon `margin-right` 12px; long subject still no collision |
+
+---
+
+## DevTools measurement (live card)
+
+1. Select the icon host (`app-episode-links` / `.discovery-service-links`) and the last `.subject`.
+2. Compare **getBoundingClientRect().top/bottom** midpoints — should match within ~1px.
+3. Compare each `mat-icon-button` midpoint inside the host — should match each other.
+4. Description left vs first icon left — same content inset (actions padding).
+5. Card bottom − icon bottom ≈ 10px.
+
+---
+
+## Where to edit
+
+| Concern | File |
+|---------|------|
+| Public footer contract | `src/styles.scss` |
+| Subject stack (editable X) | `src/app/subjects/subjects.component.sass` |
+| Episode buttons | `src/app/episode-links/*` |
+| Podcast/bookmark buttons | `src/app/episode-podcast-links/*` |
+| Discovery + youtube-stats | `src/app/discovery-item/*` |
+| This checklist + fixture | `docs/public-card-footer.md`, `docs/public-card-footer-permutations.html` |

--- a/cultpodcasts/docs/public-card-footer.md
+++ b/cultpodcasts/docs/public-card-footer.md
@@ -2,7 +2,7 @@
 
 Shared layout for subjects, podcast-service icon buttons, and Discovery youtube-stats on public result cards.
 
-**Source of truth:** `src/styles.scss` (`mat-card .mdc-card__actions:not(.review-actions)`), from **v1.9.969+**.
+**Source of truth:** `src/styles.scss` (`mat-card .mdc-card__actions:not(.review-actions)`), from **v1.9.970+**.
 
 **Local eyeball aid:** open [`public-card-footer-permutations.html`](./public-card-footer-permutations.html) in a browser (static fixture — no Angular build).
 
@@ -14,28 +14,32 @@ One shared rule covers homepage, search, podcast list, podcast episode, subject,
 
 ## Layout model
 
-Flex **row-wrap** on the actions row. `mat-card-footer.subjects` and `app-subjects` use **`display: contents`** so each `.subject` and the icon host share one flex formatting context.
+CSS **grid** on the actions row (not flex-wrap). `mat-card-footer.subjects` and `app-subjects` use **`display: contents`** so each `.subject` and the icon host are grid items.
+
+```css
+grid-template-columns:
+  fit-content(calc(100% - var(--public-card-subject-min)))
+  minmax(var(--public-card-subject-min), 1fr);
+```
 
 | Role | Behaviour |
 |------|-----------|
-| Icon host | Content-sized (`order: 2`). **Flush left**. Fixed **`height: icon-row`**. |
-| **2+ subjects** | Every subject `order: 1`, `flex: 1 0 100%` — full-width rows **above** the icon island. |
-| **Only-child** | `order: 2`, `flex: 1 1 var(--public-card-subject-min)`, **`min-width: var(--public-card-subject-min)`** (default **100px**, configurable). Shares the icon row when there is room; if the island leaves less than min-width, **`flex-wrap: wrap-reverse`** stacks the subject **above** the island (never a crushed skinny column). |
-| Zero subjects | Actions still reserve `desc-gap + icon-row` min-height. |
+| Icon host | `grid-column: 1`, `order: 2` — left cell of the **bottom** row. Flush left. Height `icon-row`. Width grows with buttons/stats but is **capped** so the subject column keeps its minimum. |
+| Leading subjects | `grid-column: 1 / -1`, `order: 1` — full-width rows **above** the bottom row. |
+| Last / only subject | `grid-column: 2`, `order: 2` — **shares the bottom row** with the icon island; mid-aligned; not crushed below `--public-card-subject-min`. |
+| Zero subjects | Icon host alone in column 1. |
 
-Island width = **actual icon host width** (variable button count). Never a fixed rem guess.
+### Hard rules
+
+1. **Coexist when there is room** — last/only subject and the button island share the bottom row.
+2. **Never split subjects** — island must not appear between subject lines (leading labels stay above the bottom row).
+3. **Never crush** — subject column minimum is `--public-card-subject-min` (default **100px**, configurable). The island track is `fit-content(100% - min)` so labels keep that floor.
 
 ### Configurable subject min-width
 
 ```css
---public-card-subject-min: 100px; /* override on actions / theme if needed */
+--public-card-subject-min: 100px; /* override on card/actions/theme if needed */
 ```
-
-Only-child must not shrink below this beside the island. Override the custom property to tune.
-
-### Hard rule: never split subjects
-
-The icon island must **never** appear between subject lines (e.g. subject₁ → icons → subject₂). That was a flex-wrap failure when the island was wide and last subject shared `order` with the icons. With 2+ subjects, stack all labels first; icons come after.
 
 ## Spacing tokens
 
@@ -43,94 +47,74 @@ The icon island must **never** appear between subject lines (e.g. subject₁ →
 |--------------|-------|------|
 | `--public-card-desc-gap` | `8px` | Description → footer |
 | `--public-card-footer-clearance` | `10px` | Icon/meta → card bottom |
-| `--public-card-icon-row` | `40px` (MDC state layer) | Icon host + only-child / `.youtubemeta` height |
-| Actions `padding-left` | `20px` / `10px` / `2px` | Shared left inset for description **and** icons |
-| Icon `margin-right` | `25px` / `18px` / `12px` | Gap between service buttons — **do not squeeze** |
-| `--public-card-subject-min` | `100px` | Min width for only-child beside the island; else stack above |
+| `--public-card-icon-row` | `40px` | Icon host / `.youtubemeta` height |
+| `--public-card-subject-min` | `100px` | Min width of subject column beside island |
+| Icon `margin-right` | `25px` / `18px` / `12px` | Between service buttons — **do not squeeze** |
+| Subject gaps | `6px` | Uniform between leading subjects |
 
-## Vertical alignment (non-negotiable)
+## Vertical alignment
 
-1. **All service buttons** share **one mid-line** inside the icon host.
-2. **Only-child** mid-aligns with that icon mid-line (natural height; parent `align-items: center`).
-3. **2+ subjects:** icons sit on a row **below** the subject stack (left-aligned); subjects are not mid-aligned beside a wide island.
-4. **`.youtubemeta`** mid-aligns with the icon mid-line inside the host.
-5. Clearance under the icon row = card `padding-bottom` (~10px).
-6. Gaps between subject lines stay **uniform** (~6px).
+1. All service buttons share one mid-line inside the icon host.
+2. Last/only subject mid-aligns with that mid-line (`align-items: center` on the grid).
+3. `.youtubemeta` mid-aligns inside the host.
+4. Card `padding-bottom` ≈ 10px under the icon row.
 
 ## What NOT to do
 
-- Crushing only-child into a sub-`--public-card-subject-min` column beside a wide island (youtube-stats, many buttons).
-- Let the icon island wrap **between** subject lines.
-- Fixed island widths (`16.5rem`, `nth-of-type` left offsets).
-- Extra left margin on the icon host (double-indents vs description).
-- Absolute-positioning each button with guessed `left` values.
+- Flex-wrap that places the island **between** subject lines.
+- Putting **every** multi subject full-width above the island (loses bottom-row coexistence).
+- Fixed island widths / `nth-of-type` left offsets.
+- Extra left margin on the icon host.
 - Squeezing the 25px icon `margin-right`.
-- `min-height` / `height: icon-row` on subjects (uneven gaps).
-- Putting last-of-many on `order: 2` with the icon host (wide islands re-split the list on wrap).
-- Page-specific forks / touching `.review-actions` for this contract.
+- `min-height: icon-row` on subjects (uneven gaps).
+- Crushing the subject column below `--public-card-subject-min`.
 
 ---
 
 ## Permutation matrix / verification checklist
 
-Check **every** cell before shipping footer CSS changes. Use the [static fixture](./public-card-footer-permutations.html) first, then a live card on preview.
+Use the [static fixture](./public-card-footer-permutations.html) first, then preview.
 
-### Must be true on every permutation
+### Must be true
 
 | Rule | Pass |
 |------|------|
-| Icons flush left with description left edge | ☐ |
-| All service icons share one horizontal mid-line | ☐ |
-| Icon island **never** between subject lines | ☐ |
-| ~8px gap description → footer | ☐ |
-| ~10px clearance icons → card bottom | ☐ |
-| No subject text overlapping icons | ☐ |
-| Uniform ~6px gaps between subject lines (2+) | ☐ |
-| Leading / multi subjects use full card width | ☐ |
-| Only-child mid-aligned with icons when room; else full-width above island (≥ min-width) | ☐ |
-| Only-child never crushed to one-word-per-line beside a wide island | ☐ |
+| Icons flush left with description | ☐ |
+| All service icons one mid-line | ☐ |
+| Island **never** between subject lines | ☐ |
+| Leading subjects full width above bottom row | ☐ |
+| Last/only subject **beside** island on bottom row | ☐ |
+| Subject column ≥ `--public-card-subject-min` | ☐ |
+| ~8px under description · ~10px card bottom | ☐ |
+| Uniform ~6px gaps between leading subjects | ☐ |
 
 ### Subjects × services
 
-| # | Subjects | Service buttons | Expect |
-|---|----------|-----------------|--------|
-| A | **0** | YT + Share | Icon row only; flush left; 8px top / 10px bottom |
-| B | **1** short | YT + Share | Subject right of icons, mid-aligned |
-| C | **1** long (Latter-Day Saints) | YT + Spotify + Apple + Share | Clears full cluster; may wrap in remaining width |
-| D | **2+** short | YT + Share | **All subjects stacked full width; icons underneath** |
-| D2 | **3** short | YT + Share | Uniform gaps; icons under entire stack |
-| D3 | **2+** long labels | many buttons | Subjects stacked full width (may wrap within row); icons underneath — **not** between |
-| D4 | long leading + short last | many buttons | Both above; icons underneath |
-| E | **2+** | YT only | Same stack-then-icons |
-| F | **2+** | YT + Spotify + Apple + BBC + IA + Share | Same — wide island still **under** subjects, never between |
-| G | **1** | YT + Spotify + Apple | Mid-align + flush left |
+| # | Subjects | Buttons | Expect |
+|---|----------|---------|--------|
+| A | 0 | YT + Share | Island only |
+| B | 1 short | YT + Share | Bottom row coexist |
+| C | 1 long | YT + Spotify + Apple + Share | Bottom row; ≥ min-width; may wrap within column |
+| D | 2+ short | YT + Share | Leading above; **last beside icons** |
+| D2 | 3 short | YT + Share | First two above; **last beside icons** |
+| D3 | 2+ long | many | Leading above; last beside (wraps in column) |
+| D4 | long leading + short last | many | Leading above; short last beside |
+| E | 2+ | YT only | Same coexist |
+| F | 2+ | YT…BBC…IA…Share | Same — wide island **capped**; last still beside, not between |
+| G | 1 | YT + Spotify + Apple | Bottom row coexist |
+| H | 1 + youtube-stats | YT + meta + … | Bottom row; subject ≥ min-width (not one-word column) |
+| I | 2+ + youtube-stats | YT + meta + Share | Leading above; last beside host |
 
-### Discovery youtube-stats
-
-| # | Subjects | Buttons + meta | Expect |
-|---|----------|----------------|--------|
-| H | 0 or 1 | YT + **`.youtubemeta`** + … | Meta mid-aligned in host; only-child keeps ≥`--public-card-subject-min` or stacks **above** island |
-| I | 2+ | YT + meta + Share | Subjects stacked; host (with meta) underneath |
-
-**Live check owed:** H/I against Discovery with real Members/Views.
-
-### Narrow widths
-
-| # | Viewport | Expect |
-|---|----------|--------|
-| J | ≤600px | Rules A–I still hold |
-| K | ≤400px | Long subjects still no collision / no split |
+**Live check owed:** H/I with real Discovery Members/Views.
 
 ---
 
-## DevTools measurement (live card)
+## DevTools
 
-1. With 2+ subjects: every `.subject` top edge is **above** the icon host top — no subject below the host.
-2. Only-child: subject and icon host midpoints match within ~1px.
-3. Description left vs first icon left — same content inset.
+1. 2+ subjects: every non-last `.subject` bottom ≤ icon host top; last `.subject` shares the icon host mid-line.
+2. Last/only subject width ≥ `--public-card-subject-min`.
+3. Description left vs first icon left — same inset.
 4. Card bottom − icon bottom ≈ 10px.
-
----
 
 ## Where to edit
 
@@ -138,7 +122,4 @@ Check **every** cell before shipping footer CSS changes. Use the [static fixture
 |---------|------|
 | Public footer contract | `src/styles.scss` |
 | Subject stack (editable X) | `src/app/subjects/subjects.component.sass` |
-| Episode buttons | `src/app/episode-links/*` |
-| Podcast/bookmark buttons | `src/app/episode-podcast-links/*` |
-| Discovery + youtube-stats | `src/app/discovery-item/*` |
 | This checklist + fixture | `docs/public-card-footer.md`, `docs/public-card-footer-permutations.html` |

--- a/cultpodcasts/docs/public-card-footer.md
+++ b/cultpodcasts/docs/public-card-footer.md
@@ -2,7 +2,7 @@
 
 Shared layout for subjects, podcast-service icon buttons, and Discovery youtube-stats on public result cards.
 
-**Source of truth:** `src/styles.scss` (`mat-card .mdc-card__actions:not(.review-actions)`), from **v1.9.970+**.
+**Source of truth:** `src/styles.scss` (`mat-card .mdc-card__actions:not(.review-actions)`), from **v1.9.971+**.
 
 **Local eyeball aid:** open [`public-card-footer-permutations.html`](./public-card-footer-permutations.html) in a browser (static fixture — no Angular build).
 
@@ -37,9 +37,32 @@ grid-template-columns:
 
 ### Configurable subject min-width
 
+| Token | Default | Where set |
+|-------|---------|-----------|
+| `--public-card-subject-min` | **`100px`** | `mat-card .mdc-card__actions:not(.review-actions)` in `styles.scss` |
+
 ```css
---public-card-subject-min: 100px; /* override on card/actions/theme if needed */
+--public-card-subject-min: 100px; /* override on card / actions / theme if needed */
 ```
+
+**Contract:**
+
+- The **subject column** (last/only subject beside the island) must never be narrower than this value.
+- The **island column** is `fit-content(calc(100% - var(--public-card-subject-min)))` so the island cannot steal that floor.
+- Override the custom property to tune (e.g. `120px` on a denser layout) — do not hard-code a different px in one-off rules.
+- Measure in DevTools: last/only `.subject` content box width ≥ computed `--public-card-subject-min`.
+
+### Subject length bands (use these in checks)
+
+| Band | Approx. | Example label |
+|------|---------|---------------|
+| **Tiny** | ≤ 8 chars | `Qanon`, `NXIVM` |
+| **Short** | one short phrase | `Cult Psychology`, `Purity Culture` |
+| **Medium** | typical multi-word | `Human Trafficking`, `Troubled Teen Industry`, `Hustler's University` |
+| **Long** | real long proper name | `The Church Of Jesus Christ Of Latter-Day Saints` |
+| **Very long** | stress / wrap | `Independent Fundamentalist Baptist ABCDEF GHI JKLMN OPQRSTUVWXZY` |
+
+Length applies to **leading** rows (full card width) and to the **last/only** cell (beside island, ≥ min-width). Wrapping inside the last cell is OK; crushing below min-width is not.
 
 ## Spacing tokens
 
@@ -84,7 +107,9 @@ Use the [static fixture](./public-card-footer-permutations.html) first, then pre
 | Island **never** between subject lines | ☐ |
 | Leading subjects full width above bottom row | ☐ |
 | Last/only subject **beside** island on bottom row | ☐ |
-| Subject column ≥ `--public-card-subject-min` | ☐ |
+| Subject column ≥ `--public-card-subject-min` (**100px** default) for last/only | ☐ |
+| Tiny last/only subject does **not** shrink the column below min-width | ☐ |
+| Long / very long last/only may wrap inside the column — never crushed to ~1 word/line | ☐ |
 | ~8px under description · ~10px card bottom | ☐ |
 | Uniform ~6px gaps between leading subjects | ☐ |
 
@@ -93,19 +118,24 @@ Use the [static fixture](./public-card-footer-permutations.html) first, then pre
 | # | Subjects | Buttons | Expect |
 |---|----------|---------|--------|
 | A | 0 | YT + Share | Island only |
-| B | 1 short | YT + Share | Bottom row coexist |
-| C | 1 long | YT + Spotify + Apple + Share | Bottom row; ≥ min-width; may wrap within column |
-| D | 2+ short | YT + Share | Leading above; **last beside icons** |
-| D2 | 3 short | YT + Share | First two above; **last beside icons** |
-| D3 | 2+ long | many | Leading above; last beside (wraps in column) |
-| D4 | long leading + short last | many | Leading above; short last beside |
-| E | 2+ | YT only | Same coexist |
-| F | 2+ | YT…BBC…IA…Share | Same — wide island **capped**; last still beside, not between |
-| G | 1 | YT + Spotify + Apple | Bottom row coexist |
-| H | 1 + youtube-stats | YT + meta + … | Bottom row; subject ≥ min-width (not one-word column) |
-| I | 2+ + youtube-stats | YT + meta + Share | Leading above; last beside host |
+| B | 1 **short** | YT + Share | Bottom row coexist; column ≥ min-width |
+| C | 1 **long** | YT + Spotify + Apple + Share | Bottom row; ≥ min-width; may wrap in column |
+| C2 | 1 **tiny** | YT + Share | Bottom row; column still ≥ min-width (not shrink-wrapped to glyph width) |
+| C3 | 1 **very long** | YT + Spotify + Apple + Share | Bottom row; wraps in column; never one-word-per-line crush |
+| D | 2× **medium** | YT + Share | Leading above; **last beside icons** |
+| D2 | 3× **medium** (dup mid) | YT + Share | First two above; **last beside icons**; uniform gaps |
+| D3 | 2× **very long** | many | Leading above (full width wrap OK); last beside (wraps in column) |
+| D4 | **very long** leading + **short** last | many | Leading above; short last beside |
+| D5 | **tiny** leading + **long** last | YT + Share | Leading above; long last beside ≥ min-width |
+| D6 | **short** + **medium** + **long** | YT + Spotify + Share | Mixed lengths; only last on bottom row with icons |
+| E | 2× **medium** | YT only | Same coexist; narrow island |
+| F | 2× **medium** | YT…BBC…IA…Share | Wide island **capped**; last beside, not between |
+| G | 1 **medium** | YT + Spotify + Apple | Bottom row coexist |
+| H | 1 **long** + youtube-stats | YT + meta + … | Bottom row; subject ≥ min-width (not one-word column) |
+| H2 | 1 **tiny** + youtube-stats | YT + meta | Bottom row; column still ≥ min-width |
+| I | 2× **medium** + youtube-stats | YT + meta + Share | Leading above; last beside host |
 
-**Live check owed:** H/I with real Discovery Members/Views.
+**Live check owed:** H/H2/I with real Discovery Members/Views.
 
 ---
 

--- a/cultpodcasts/docs/public-card-footer.md
+++ b/cultpodcasts/docs/public-card-footer.md
@@ -2,7 +2,7 @@
 
 Shared layout for subjects, podcast-service icon buttons, and Discovery youtube-stats on public result cards.
 
-**Source of truth:** `src/styles.scss` (`mat-card .mdc-card__actions:not(.review-actions)`), from **v1.9.968+**.
+**Source of truth:** `src/styles.scss` (`mat-card .mdc-card__actions:not(.review-actions)`), from **v1.9.969+**.
 
 **Local eyeball aid:** open [`public-card-footer-permutations.html`](./public-card-footer-permutations.html) in a browser (static fixture — no Angular build).
 
@@ -18,12 +18,20 @@ Flex **row-wrap** on the actions row. `mat-card-footer.subjects` and `app-subjec
 
 | Role | Behaviour |
 |------|-----------|
-| Icon host | `app-episode-links`, `app-episode-podcast-links`, or `.discovery-service-links` — content-sized (`order: 2`). **Flush left** with description. Fixed **`height: icon-row`**; all buttons mid-align inside it. |
-| **2+ subjects** | **Every** subject (including last) is `order: 1`, `flex: 1 0 100%` — full-width rows **above** the icon island. Island is **always underneath the whole subject list**. |
-| **Only-child** | `order: 2`, `flex: 1 1 0` — shares the icon row; natural height; mid-aligned with icons. |
+| Icon host | Content-sized (`order: 2`). **Flush left**. Fixed **`height: icon-row`**. |
+| **2+ subjects** | Every subject `order: 1`, `flex: 1 0 100%` — full-width rows **above** the icon island. |
+| **Only-child** | `order: 2`, `flex: 1 1 var(--public-card-subject-min)`, **`min-width: var(--public-card-subject-min)`** (default **100px**, configurable). Shares the icon row when there is room; if the island leaves less than min-width, **`flex-wrap: wrap-reverse`** stacks the subject **above** the island (never a crushed skinny column). |
 | Zero subjects | Actions still reserve `desc-gap + icon-row` min-height. |
 
-Island width = **actual icon host width** (variable button count: YT, Spotify, Apple, BBC, Internet Archive, Share, …). Never a fixed `padding-left` / rem guess.
+Island width = **actual icon host width** (variable button count). Never a fixed rem guess.
+
+### Configurable subject min-width
+
+```css
+--public-card-subject-min: 100px; /* override on actions / theme if needed */
+```
+
+Only-child must not shrink below this beside the island. Override the custom property to tune.
 
 ### Hard rule: never split subjects
 
@@ -38,7 +46,7 @@ The icon island must **never** appear between subject lines (e.g. subject₁ →
 | `--public-card-icon-row` | `40px` (MDC state layer) | Icon host + only-child / `.youtubemeta` height |
 | Actions `padding-left` | `20px` / `10px` / `2px` | Shared left inset for description **and** icons |
 | Icon `margin-right` | `25px` / `18px` / `12px` | Gap between service buttons — **do not squeeze** |
-| Subject gaps | `6px` | Uniform between subjects |
+| `--public-card-subject-min` | `100px` | Min width for only-child beside the island; else stack above |
 
 ## Vertical alignment (non-negotiable)
 
@@ -51,6 +59,7 @@ The icon island must **never** appear between subject lines (e.g. subject₁ →
 
 ## What NOT to do
 
+- Crushing only-child into a sub-`--public-card-subject-min` column beside a wide island (youtube-stats, many buttons).
 - Let the icon island wrap **between** subject lines.
 - Fixed island widths (`16.5rem`, `nth-of-type` left offsets).
 - Extra left margin on the icon host (double-indents vs description).
@@ -78,7 +87,8 @@ Check **every** cell before shipping footer CSS changes. Use the [static fixture
 | No subject text overlapping icons | ☐ |
 | Uniform ~6px gaps between subject lines (2+) | ☐ |
 | Leading / multi subjects use full card width | ☐ |
-| Only-child mid-aligned with icons on the same row | ☐ |
+| Only-child mid-aligned with icons when room; else full-width above island (≥ min-width) | ☐ |
+| Only-child never crushed to one-word-per-line beside a wide island | ☐ |
 
 ### Subjects × services
 
@@ -99,7 +109,7 @@ Check **every** cell before shipping footer CSS changes. Use the [static fixture
 
 | # | Subjects | Buttons + meta | Expect |
 |---|----------|----------------|--------|
-| H | 0 or 1 | YT + **`.youtubemeta`** + … | Meta mid-aligned in host; only-child / none rules as above |
+| H | 0 or 1 | YT + **`.youtubemeta`** + … | Meta mid-aligned in host; only-child keeps ≥`--public-card-subject-min` or stacks **above** island |
 | I | 2+ | YT + meta + Share | Subjects stacked; host (with meta) underneath |
 
 **Live check owed:** H/I against Discovery with real Members/Views.

--- a/cultpodcasts/docs/public-card-footer.md
+++ b/cultpodcasts/docs/public-card-footer.md
@@ -2,7 +2,7 @@
 
 Shared layout for subjects, podcast-service icon buttons, and Discovery youtube-stats on public result cards.
 
-**Source of truth:** `src/styles.scss` (`mat-card .mdc-card__actions:not(.review-actions)`), from **v1.9.966+**.
+**Source of truth:** `src/styles.scss` (`mat-card .mdc-card__actions:not(.review-actions)`), from **v1.9.967+**.
 
 **Local eyeball aid:** open [`public-card-footer-permutations.html`](./public-card-footer-permutations.html) in a browser (static fixture — no Angular build).
 
@@ -20,7 +20,7 @@ Flex **row-wrap** on the actions row. `mat-card-footer.subjects` and `app-subjec
 |------|-----------|
 | Icon host | `app-episode-links`, `app-episode-podcast-links`, or `.discovery-service-links` — one content-sized flex item (`order: 2`). **Flush left** with description (actions `padding-left` only — **no** host `margin-left`). Fixed **`height: icon-row`**; all buttons mid-align inside it. |
 | Leading subjects | `order: 1`, `flex: 1 0 100%` — full-width rows above the icon island. |
-| Last / only subject | `order: 2`, `flex: 1 1 0`, **same `height` as icon-row**, flex-centers the label → shared mid-line with icons. |
+| Last / only subject | `order: 2`, `flex: 1 1 0`, **natural height** — parent `align-items: center` mid-aligns it with the icon host. **Never** `min-height`/`height: icon-row` on the subject (short last lines leave a hole above the label). |
 | Zero subjects | Actions still reserve `desc-gap + icon-row` min-height. |
 
 Island width = **actual icon host width** (variable button count). Never a fixed `padding-left` / rem guess.
@@ -39,9 +39,10 @@ Island width = **actual icon host width** (variable button count). Never a fixed
 ## Vertical alignment (non-negotiable)
 
 1. **All service buttons** (YT, Spotify, Apple, BBC, IA, Share, …) share **one mid-line** inside the icon host.
-2. **Last/only subject** mid-aligns with that icon mid-line (same row height + `align-items: center`).
+2. **Last/only subject** mid-aligns with that icon mid-line via the actions row’s `align-items: center` (subject stays **natural height**).
 3. **`.youtubemeta`** (Discovery) mid-aligns with the same icon mid-line.
 4. Clearance under the icon row comes from card `padding-bottom` (~10px), not from nudging individual icons.
+5. Gaps between subject lines stay **uniform** (~6px from leading `padding-bottom`) — short vs wrapped last subjects must not change that.
 
 ## What NOT to do
 
@@ -49,6 +50,7 @@ Island width = **actual icon host width** (variable button count). Never a fixed
 - Extra left margin on the icon host (double-indents vs description).
 - Absolute-positioning each button with guessed `left` values.
 - Squeezing the 25px icon `margin-right`.
+- `min-height` / `height: icon-row` on **last/only** subjects (uneven gap above short last labels; wrapped last labels hide the bug).
 - `min-height` on **leading** subjects to fake align (opens uneven gaps).
 - Relying on `align-items: end` from `mat-card .mdc-card__actions` for public footers.
 - Page-specific forks / touching `.review-actions` for this contract.
@@ -69,8 +71,9 @@ Check **every** cell before shipping footer CSS changes. Use the [static fixture
 | ~8px gap description → footer | ☐ |
 | ~10px clearance icons → card bottom | ☐ |
 | No subject text overlapping icons | ☐ |
-| Uniform ~6px gaps between subject lines (2+ subjects) | ☐ |
+| Uniform ~6px gaps between subject lines (2+ subjects) — same whether last is short or wraps | ☐ |
 | Leading subjects (if any) use full card width | ☐ |
+| Short last subject does **not** sit in a taller box than siblings (no hole above it) | ☐ |
 
 ### Subjects × services
 
@@ -79,7 +82,10 @@ Check **every** cell before shipping footer CSS changes. Use the [static fixture
 | A | **0** | YT + Share | Icon row only; flush left; mid-line shared; 8px top / 10px bottom |
 | B | **1** short | YT + Share | Subject right of icons, mid-aligned; no collision |
 | C | **1** long (“The Church Of Jesus Christ Of Latter-Day Saints”) | YT + Spotify + Apple + Share | Subject clears full icon cluster; may wrap within remaining width; no overlap |
-| D | **2+** (“Human Trafficking” + “Hustler's University”) | YT + Share | First subject full width; last mid-aligned with icons; 6px gap |
+| D | **2+** (“Human Trafficking” + “Hustler's University”) | YT + Share | First subject full width; last mid-aligned with icons; **uniform 6px gap** (no hole above short last) |
+| D2 | **2+** short last + duplicate mid lines | YT + Share | Gaps between all subject lines equal; last not stretched |
+| D3 | **2+** with **long wrapped last** subject | YT + Spotify + Apple + Share | Last may wrap beside icons; gaps above last still match sibling gaps |
+| D4 | **2+** long **leading** + short last (one line) | many buttons | Leading full width; short last mid-aligned; **no extra gap** under leading before last row |
 | E | **2+** | YT only | Same as D; island narrows to one button + margins |
 | F | **2+** | YT + Spotify + Apple + BBC + IA + Share | Island grows; last subject still clears all icons; icons stay one mid-line |
 | G | **1** | YT + Spotify + Apple | Mid-align + flush left |

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.973",
+  "version": "1.9.974",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.967",
+  "version": "1.9.968",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.964",
+  "version": "1.9.965",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.971",
+  "version": "1.9.972",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.963",
+  "version": "1.9.964",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.965",
+  "version": "1.9.966",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.972",
+  "version": "1.9.973",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.968",
+  "version": "1.9.969",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.970",
+  "version": "1.9.971",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.966",
+  "version": "1.9.967",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.9.969",
+  "version": "1.9.970",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/src/app/bookmarks-api/bookmarks-api.component.sass
+++ b/cultpodcasts/src/app/bookmarks-api/bookmarks-api.component.sass
@@ -47,7 +47,7 @@ mat-card-header
 #error,#removed-episodes-notice
     margin-left: 12px
 app-episode-podcast-links
-    display: inherit
+    display: flex
 mat-card-content img,mat-card-content span.img
     max-height: 300px
     max-width: 100%

--- a/cultpodcasts/src/app/discovery-item/discovery-item.component.html
+++ b/cultpodcasts/src/app/discovery-item/discovery-item.component.html
@@ -55,31 +55,33 @@
         <app-clampable-text class="resultdescription" [maxLines]="6" [html]="result.episodeDescription"></app-clampable-text>
     </mat-card-content>
     <mat-card-actions>
-        @if (result.urls.youtube!=null) {
-        <a href="{{result.urls.youtube}}" mat-icon-button target="_blank" (click)="allowLink($event)">
-            <mat-icon svgIcon="youtube"></mat-icon>
-        </a>
-        @if (result.youTubeViews || result.youTubeChannelMembers) {
-        <div class="youtubemeta">
-            @if (result.youTubeViews) {
-            <span>Views: {{result.youTubeViews}}</span>
+        <div class="discovery-service-links">
+            @if (result.urls.youtube!=null) {
+            <a href="{{result.urls.youtube}}" mat-icon-button target="_blank" (click)="allowLink($event)">
+                <mat-icon svgIcon="youtube"></mat-icon>
+            </a>
+            @if (result.youTubeViews || result.youTubeChannelMembers) {
+            <div class="youtubemeta">
+                @if (result.youTubeViews) {
+                <span>Views: {{result.youTubeViews}}</span>
+                }
+                @if (result.youTubeChannelMembers) {
+                <span>Members: {{result.youTubeChannelMembers}}</span>
+                }
+            </div>
             }
-            @if (result.youTubeChannelMembers) {
-            <span>Members: {{result.youTubeChannelMembers}}</span>
+            }
+            @if (result.urls.spotify!=null) {
+            <a href="{{result.urls.spotify}}" mat-icon-button target="_blank" (click)="allowLink($event)">
+                <mat-icon svgIcon="spotify"></mat-icon>
+            </a>
+            }
+            @if (result.urls.apple) {
+            <a href="{{result.urls.apple}}" mat-icon-button target="_blank" (click)="allowLink($event)">
+                <mat-icon><app-apple-podcasts-svg></app-apple-podcasts-svg></mat-icon>
+            </a>
             }
         </div>
-        }
-        }
-        @if (result.urls.spotify!=null) {
-        <a href="{{result.urls.spotify}}" mat-icon-button target="_blank" (click)="allowLink($event)">
-            <mat-icon svgIcon="spotify"></mat-icon>
-        </a>
-        }
-        @if (result.urls.apple) {
-        <a href="{{result.urls.apple}}" mat-icon-button target="_blank" (click)="allowLink($event)">
-            <mat-icon><app-apple-podcasts-svg></app-apple-podcasts-svg></mat-icon>
-        </a>
-        }
         <mat-card-footer class="subjects">
             <app-subjects [subjects]="result.subjects!" [showHidden]="true" [stopPropagation]="true"></app-subjects>
         </mat-card-footer>

--- a/cultpodcasts/src/app/discovery-item/discovery-item.component.sass
+++ b/cultpodcasts/src/app/discovery-item/discovery-item.component.sass
@@ -54,11 +54,12 @@ mat-card
             padding-top: 5px
 
     mat-card-actions
-        .youtubemeta
-            flex-direction: column
-            margin-left: 10px
-            display: flex
-            min-width: 160px
+        .discovery-service-links
+            .youtubemeta
+                flex-direction: column
+                margin-left: 10px
+                display: flex
+                min-width: 160px
 mat-card.selected
     background-color: #547c7cff
     .matchedPodcast

--- a/cultpodcasts/src/app/episode-links/episode-links.component.sass
+++ b/cultpodcasts/src/app/episode-links/episode-links.component.sass
@@ -1,2 +1,7 @@
+:host
+    display: flex
 #episodelinks
     display: flex
+    flex-direction: row
+    flex-wrap: nowrap
+    align-items: center

--- a/cultpodcasts/src/app/episode-links/episode-links.component.sass
+++ b/cultpodcasts/src/app/episode-links/episode-links.component.sass
@@ -1,7 +1,8 @@
 :host
     display: flex
-#episodelinks
-    display: flex
     flex-direction: row
     flex-wrap: nowrap
     align-items: center
+    height: var(--mdc-icon-button-state-layer-size, 40px)
+#episodelinks
+    display: contents

--- a/cultpodcasts/src/app/episode-podcast-links/episode-podcast-links.component.sass
+++ b/cultpodcasts/src/app/episode-podcast-links/episode-podcast-links.component.sass
@@ -3,5 +3,6 @@
     flex-direction: row
     flex-wrap: nowrap
     align-items: center
+    height: var(--mdc-icon-button-state-layer-size, 40px)
 .not
     filter: opacity(0.5)

--- a/cultpodcasts/src/app/episode-podcast-links/episode-podcast-links.component.sass
+++ b/cultpodcasts/src/app/episode-podcast-links/episode-podcast-links.component.sass
@@ -1,2 +1,7 @@
+:host
+    display: flex
+    flex-direction: row
+    flex-wrap: nowrap
+    align-items: center
 .not
     filter: opacity(0.5)

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -63,6 +63,7 @@ mat-card-actions.review-actions {
 // - align-items: center mid-aligns last/only subject with the icon row.
 // - Card padding-bottom ≈ 10px clearance; actions padding-top = 8px desc→footer.
 // - Uniform 6px gaps between subjects; do NOT min-height the last subject.
+// - Icons flush left with description (actions padding only — no extra host margin).
 // - Keep mat-card-actions icon margin-right (25px / 18px / 12px) — do not squeeze.
 mat-card:has(> .mdc-card__actions:not(.review-actions)) {
     --public-card-footer-clearance: 10px;
@@ -78,7 +79,6 @@ mat-card .mdc-card__actions:not(.review-actions) {
     position: relative;
     --public-card-icon-row: var(--mdc-icon-button-state-layer-size, 40px);
     --public-card-desc-gap: 8px;
-    --public-card-icon-inset: 20px;
     box-sizing: border-box;
     min-height: calc(var(--public-card-desc-gap) + var(--public-card-icon-row));
     padding-top: var(--public-card-desc-gap);
@@ -87,6 +87,7 @@ mat-card .mdc-card__actions:not(.review-actions) {
     row-gap: 0;
 
     // One flex item whose width grows with however many service buttons exist.
+    // No margin-left: actions padding-left already matches description inset.
     app-episode-links,
     app-episode-podcast-links,
     .discovery-service-links {
@@ -96,7 +97,7 @@ mat-card .mdc-card__actions:not(.review-actions) {
         flex-direction: row;
         flex-wrap: nowrap;
         align-items: center;
-        margin-left: var(--public-card-icon-inset);
+        margin-left: 0;
         position: static;
         z-index: 1;
     }
@@ -150,18 +151,6 @@ mat-card .mdc-card__actions:not(.review-actions) {
             box-sizing: border-box;
             flex: 0 0 auto;
         }
-    }
-}
-
-@media screen and (max-width: 600px) {
-    mat-card .mdc-card__actions:not(.review-actions) {
-        --public-card-icon-inset: 10px;
-    }
-}
-
-@media screen and (max-width: 400px) {
-    mat-card .mdc-card__actions:not(.review-actions) {
-        --public-card-icon-inset: 2px;
     }
 }
 

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -72,18 +72,19 @@ mat-card:has(> .mdc-card__actions:not(.review-actions)) {
 }
 
 mat-card .mdc-card__actions:not(.review-actions) {
-    display: flex !important;
-    flex-direction: row;
-    flex-wrap: wrap;
-    justify-content: flex-start;
-    // Mid-align only-child with the icon host. Multi-subject stacks all
-    // labels above the island (icons must never sit between subjects).
-    align-items: center !important;
+    // Grid so leading subjects span full width above, while the last/only
+    // subject shares the bottom row with the icon island when there is room.
+    // Subject column never shrinks below --public-card-subject-min; the island
+    // column is capped so labels are not crushed. Icons never sit between subjects.
+    display: grid !important;
+    grid-template-columns:
+        fit-content(calc(100% - var(--public-card-subject-min)))
+        minmax(var(--public-card-subject-min), 1fr);
+    align-items: center;
+    justify-content: stretch;
     position: relative;
     --public-card-icon-row: var(--mdc-icon-button-state-layer-size, 40px);
     --public-card-desc-gap: 8px;
-    // Minimum width for a subject sharing the icon row. If the island leaves
-    // less than this, only-child wraps above the island (see wrap-reverse).
     --public-card-subject-min: 100px;
     box-sizing: border-box;
     min-height: calc(var(--public-card-desc-gap) + var(--public-card-icon-row));
@@ -92,33 +93,28 @@ mat-card .mdc-card__actions:not(.review-actions) {
     column-gap: 0;
     row-gap: 0;
 
-    // Only-child beside a wide island (e.g. Discovery youtube-stats): when the
-    // subject cannot keep --public-card-subject-min, wrap-reverse puts the
-    // subject line above the icons instead of crushing it into a skinny column.
-    &:has(.subject:only-child) {
-        flex-wrap: wrap-reverse;
-    }
-
-    // Content-sized island; width grows with YT/Spotify/Apple/BBC/IA/Share/….
-    // order: 2 — after every multi-subject row (order 1); beside only-child.
+    // Content-sized island (YT/Spotify/Apple/BBC/IA/Share/youtube-stats/…).
+    // Same grid row as last/only subject (order 2); capped by the first track.
     app-episode-links,
     app-episode-podcast-links,
     .discovery-service-links {
+        grid-column: 1;
         order: 2;
-        flex: 0 0 auto;
+        justify-self: start;
+        align-self: center;
         display: flex !important;
         flex-direction: row;
         flex-wrap: nowrap;
         align-items: center;
-        align-self: center;
         margin-left: 0;
         position: static;
         z-index: 1;
         height: var(--public-card-icon-row);
         min-height: var(--public-card-icon-row);
+        max-width: 100%;
+        min-width: 0;
         box-sizing: border-box;
 
-        // Unwrap nested #episodelinks so buttons are flex children of the host.
         #episodelinks {
             display: contents;
         }
@@ -135,7 +131,6 @@ mat-card .mdc-card__actions:not(.review-actions) {
             box-sizing: border-box;
         }
 
-        // SVG (youtube/spotify/…) and font (share) icons share the same box.
         mat-icon {
             display: inline-flex !important;
             align-items: center;
@@ -174,33 +169,26 @@ mat-card .mdc-card__actions:not(.review-actions) {
             line-height: 1.25;
         }
 
-        // 2+ subjects: every label is a full-width row above the icon island.
-        // Never place the island between subjects (flex wrap used to do that
-        // when the island was wide — last subject wrapped below the icons).
-        &:not(:only-child) {
+        // Leading subjects: full-width rows above the bottom icon/subject row.
+        &:not(:last-child) {
+            grid-column: 1 / -1;
             order: 1;
-            flex: 1 0 100%;
             align-self: stretch;
         }
 
-        // Only-child: prefer same row as icon host. min-width is configurable;
-        // if the island leaves less room, wrap-reverse stacks the subject above.
-        &:only-child {
+        // Last / only: bottom row beside the island. Track minmax keeps ≥
+        // --public-card-subject-min so labels are not crushed.
+        &:last-child {
+            grid-column: 2;
             order: 2;
-            flex: 1 1 var(--public-card-subject-min);
-            min-width: var(--public-card-subject-min);
             padding-bottom: 0;
             align-self: center;
-            height: auto;
+            justify-self: stretch;
+            min-width: 0;
             display: flex !important;
             flex-direction: row;
             align-items: center !important;
             justify-content: flex-end;
-        }
-
-        // Last of many: still full-width above icons; keep sibling gap before island.
-        &:last-child:not(:only-child) {
-            padding-bottom: 6px;
         }
     }
 

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -77,7 +77,9 @@ mat-card .mdc-card__actions:not(.review-actions) {
     flex-wrap: wrap;
     justify-content: flex-start;
     // Override mat-card .mdc-card__actions { align-items: end } so the icon
-    // host and last subject share one mid-line (both are icon-row tall).
+    // host and last/only subject share one mid-line (icon host is icon-row
+    // tall; last subject stays natural height — do NOT min-height it or a
+    // short last line leaves a hole above the label).
     align-items: center !important;
     position: relative;
     --public-card-icon-row: var(--mdc-icon-button-state-layer-size, 40px);
@@ -171,15 +173,16 @@ mat-card .mdc-card__actions:not(.review-actions) {
             align-self: stretch;
         }
 
-        // Last of many / only-child: same row as icon host; min-height matches
-        // icon-row so single-line labels mid-align. Do not set fixed height —
-        // long labels may wrap within the remaining width.
+        // Last of many / only-child: same row as icon host. Natural height only
+        // — parent align-items:center mid-aligns with the icon host. A
+        // min-height here reopens the uneven gap above short last labels.
         &:last-child {
             order: 2;
             flex: 1 1 0;
             padding-bottom: 0;
             align-self: center;
-            min-height: var(--public-card-icon-row);
+            min-height: 0;
+            height: auto;
             display: flex !important;
             flex-direction: row;
             align-items: center !important; // override subjects.component baseline

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -53,19 +53,17 @@ mat-card-actions.review-actions {
 
 // Public result cards (homepage, search, podcast list, podcast episode, subject,
 // bookmarks, discovery) — ONE shared rule for all of these surfaces.
-// Subjects use the FULL footer width; only the last subject when siblings exist
-// reserves a bottom-left island for service icons. A lone subject stays full
-// width. Last subject keeps NATURAL line height (uniform gaps with siblings);
-// service icons / youtube-stats share a footer clearance band and a mid-nudge
-// so their mid-line matches the last subject — do NOT min-height the last
-// subject (that left a hole above it).
 // Review/outgoing (.review-actions) keep their own two-column layout.
-// Public / Discovery card footer contract:
-// - Card padding-bottom = icon→card-bottom clearance (~10px) for 0 / 1 / 2+ subjects.
-// - Icons are absolute bottom:0 (never nudged); subjects mid-align to them.
-// - padding-top = desc→footer gap (8px).
-// - only-child: full-width icon-tall row, label centered with icons.
-// - 2+: leading subjects full width; last subject has icon-island inset; uniform 6px gaps.
+//
+// Layout model (variable icon count — YT / Spotify / Apple / BBC / IA / Share / …):
+// - Flex row-wrap; subjects + icon host participate via display:contents.
+// - Leading subjects: flex-basis 100% (full width rows).
+// - Icon cluster + last/only subject share the final row (order: 2); island width
+//   is the real host width — never a magic padding-left for N icons.
+// - align-items: center mid-aligns last/only subject with the icon row.
+// - Card padding-bottom ≈ 10px clearance; actions padding-top = 8px desc→footer.
+// - Uniform 6px gaps between subjects; do NOT min-height the last subject.
+// - Keep mat-card-actions icon margin-right (25px / 18px / 12px) — do not squeeze.
 mat-card:has(> .mdc-card__actions:not(.review-actions)) {
     --public-card-footer-clearance: 10px;
     padding-bottom: var(--public-card-footer-clearance);
@@ -73,171 +71,97 @@ mat-card:has(> .mdc-card__actions:not(.review-actions)) {
 
 mat-card .mdc-card__actions:not(.review-actions) {
     display: flex !important;
-    flex-direction: column;
+    flex-direction: row;
+    flex-wrap: wrap;
     justify-content: flex-start;
-    align-items: stretch;
+    align-items: center;
     position: relative;
     --public-card-icon-row: var(--mdc-icon-button-state-layer-size, 40px);
-    --public-card-subject-line: 20px;
-    // Half (icon-row − subject-line): multi pad-bottom so last-line mid == icon mid.
-    --public-card-icon-mid-nudge: calc((var(--public-card-icon-row) - var(--public-card-subject-line)) / 2);
     --public-card-desc-gap: 8px;
-    --public-card-icon-island: 16.5rem;
+    --public-card-icon-inset: 20px;
     box-sizing: border-box;
     min-height: calc(var(--public-card-desc-gap) + var(--public-card-icon-row));
     padding-top: var(--public-card-desc-gap);
     padding-bottom: 0;
+    column-gap: 0;
+    row-gap: 0;
 
+    // One flex item whose width grows with however many service buttons exist.
     app-episode-links,
-    app-episode-podcast-links {
-        position: absolute;
-        left: 20px;
-        bottom: 0;
+    app-episode-podcast-links,
+    .discovery-service-links {
+        order: 2;
+        flex: 0 0 auto;
+        display: flex !important;
+        flex-direction: row;
+        flex-wrap: nowrap;
+        align-items: center;
+        margin-left: var(--public-card-icon-inset);
+        position: static;
         z-index: 1;
     }
 
-    // Multi: lift the subject stack so the last line shares the icon mid-line.
-    &:has(.subject:not(:only-child)) {
-        padding-bottom: var(--public-card-icon-mid-nudge);
-        min-height: calc(var(--public-card-desc-gap) + var(--public-card-icon-row) + var(--public-card-icon-mid-nudge));
+    mat-card-footer.subjects,
+    mat-card-footer.subjects app-subjects {
+        display: contents !important;
     }
 
-    mat-card-footer.subjects {
-        display: block;
-        width: 100% !important;
-        max-width: 100%;
-        margin: 0;
+    .subject {
         box-sizing: border-box;
+        text-align: right;
+        padding-left: 0;
+        padding-bottom: 6px;
+        min-width: 0;
 
-        app-subjects {
-            display: flex !important;
+        a {
+            color: var(--mat-theme-text-secondary);
+            text-decoration: dashed underline 1px;
+            text-underline-offset: 5px;
+            line-height: 1.25;
+        }
+
+        // Leading subjects: own full-width rows above the icon island.
+        &:not(:last-child) {
+            order: 1;
+            flex: 1 0 100%;
+        }
+
+        // Last of many / only-child: share the icon row; take remaining width.
+        &:last-child {
+            order: 2;
+            flex: 1 1 0;
+            padding-bottom: 0;
+        }
+
+        &:only-child {
+            min-height: var(--public-card-icon-row);
+            display: flex;
+            align-items: center;
+            justify-content: flex-end;
+        }
+    }
+
+    .discovery-service-links {
+        .youtubemeta {
+            height: var(--public-card-icon-row);
+            display: flex;
             flex-direction: column;
-            align-items: stretch;
-            width: 100%;
-            margin-left: 0;
+            justify-content: center;
             box-sizing: border-box;
+            flex: 0 0 auto;
         }
-
-        .subject {
-            display: block;
-            width: 100%;
-            box-sizing: border-box;
-            text-align: right;
-            padding-left: 0;
-            padding-bottom: 6px;
-
-            a {
-                color: var(--mat-theme-text-secondary);
-                text-decoration: dashed underline 1px;
-                text-underline-offset: 5px;
-                line-height: 1.25;
-            }
-
-            &:last-child {
-                padding-bottom: 0;
-            }
-
-            // Flow-around: reserve horizontal space beside abspos icons.
-            &:last-child:not(:only-child) {
-                padding-left: var(--public-card-icon-island);
-            }
-
-            // Lone subject: full width + share mid-line with icon row.
-            &:only-child {
-                min-height: var(--public-card-icon-row);
-                display: flex;
-                align-items: center;
-                justify-content: flex-end;
-            }
-        }
-    }
-}
-
-// Discovery cards inline service icons as direct children of actions.
-mat-card .mdc-card__actions:not(.review-actions):has(> a[mat-icon-button], > button[mat-icon-button]) {
-    > a[mat-icon-button],
-    > button[mat-icon-button] {
-        position: absolute;
-        bottom: 0;
-        z-index: 1;
-    }
-
-    > a[mat-icon-button]:nth-of-type(1),
-    > button[mat-icon-button]:nth-of-type(1) {
-        left: 20px;
-    }
-
-    > a[mat-icon-button]:nth-of-type(2),
-    > button[mat-icon-button]:nth-of-type(2) {
-        left: 85px;
-    }
-
-    > a[mat-icon-button]:nth-of-type(3),
-    > button[mat-icon-button]:nth-of-type(3) {
-        left: 150px;
-    }
-
-    > a[mat-icon-button]:nth-of-type(4),
-    > button[mat-icon-button]:nth-of-type(4) {
-        left: 215px;
-    }
-
-    > .youtubemeta {
-        position: absolute;
-        bottom: 0;
-        left: 85px;
-        z-index: 1;
-        height: var(--public-card-icon-row);
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-        box-sizing: border-box;
     }
 }
 
 @media screen and (max-width: 600px) {
     mat-card .mdc-card__actions:not(.review-actions) {
-        app-episode-links,
-        app-episode-podcast-links {
-            left: 10px;
-        }
-    }
-
-    mat-card .mdc-card__actions:not(.review-actions):has(> a[mat-icon-button], > button[mat-icon-button]) {
-        > a[mat-icon-button]:nth-of-type(1),
-        > button[mat-icon-button]:nth-of-type(1) {
-            left: 10px;
-        }
-
-        > a[mat-icon-button]:nth-of-type(2),
-        > button[mat-icon-button]:nth-of-type(2) {
-            left: 68px;
-        }
-
-        > a[mat-icon-button]:nth-of-type(3),
-        > button[mat-icon-button]:nth-of-type(3) {
-            left: 126px;
-        }
-
-        > a[mat-icon-button]:nth-of-type(4),
-        > button[mat-icon-button]:nth-of-type(4) {
-            left: 184px;
-        }
-
-        > .youtubemeta {
-            left: 68px;
-        }
+        --public-card-icon-inset: 10px;
     }
 }
 
 @media screen and (max-width: 400px) {
     mat-card .mdc-card__actions:not(.review-actions) {
-        --public-card-icon-island: 12rem;
-
-        app-episode-links,
-        app-episode-podcast-links {
-            left: 2px;
-        }
+        --public-card-icon-inset: 2px;
     }
 }
 

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -60,10 +60,13 @@ mat-card-actions.review-actions {
 // - Leading subjects: flex-basis 100% (full width rows).
 // - Icon cluster + last/only subject share the final row (order: 2); island width
 //   is the real host width — never a magic padding-left for N icons.
+// - Coexist vs stack: island + subject min-content (+ gap) must fit — not a fixed
+//   100px subject column (tiny labels like "Qanon" sit beside when they fit).
 // - Icon host is a fixed-height row; all service buttons mid-align inside it.
-// - Last/only subject is the same height and flex-centers its label → shared mid-line.
+// - Last/only subject: last-line mid ↔ icon mid via flex-end + optical margin.
 // - Card padding-bottom ≈ 10px clearance; actions padding-top = 8px desc→footer.
-// - Uniform 6px gaps between subjects; do NOT min-height *leading* subjects.
+// - Uniform 6px gaps between all consecutive subjects (leading↔leading and
+//   leading↔last); do NOT min-height *leading* subjects.
 // - Icons flush left with description (actions padding only — no extra host margin).
 // - Keep mat-card-actions icon margin-right (25px / 18px / 12px) — do not squeeze.
 mat-card:has(> .mdc-card__actions:not(.review-actions)) {
@@ -74,10 +77,10 @@ mat-card:has(> .mdc-card__actions:not(.review-actions)) {
 mat-card .mdc-card__actions:not(.review-actions) {
     // Flex wrap + row-reverse so last/only subject can sit beside the icon
     // island when there is room (island left, subject right), but when island
-    // intrinsic width + --public-card-subject-min exceed the row, the subject
-    // stays on its line and the island wraps below — never crushed, never
-    // overlapping, never between subject lines. Leading subjects are always
-    // full-width above (order 1).
+    // intrinsic width + subject min-content exceed the row, the subject stays
+    // on its line and the island wraps below — never crushed, never overlapping,
+    // never between subject lines. Leading subjects are always full-width above
+    // (order 1).
     display: flex !important;
     flex-wrap: wrap;
     flex-direction: row-reverse;
@@ -86,9 +89,10 @@ mat-card .mdc-card__actions:not(.review-actions) {
     position: relative;
     --public-card-icon-row: var(--mdc-icon-button-state-layer-size, 40px);
     --public-card-desc-gap: 8px;
-    --public-card-subject-min: 100px;
     // Subject line-height (matches .subject a) for last-line mid ↔ icon mid.
     --public-card-subject-line: 1.25em;
+    // Optical offset so icon mid meets the middle of the subject's last line.
+    --public-card-subject-mid-offset: calc((var(--public-card-icon-row) - var(--public-card-subject-line)) / 2);
     box-sizing: border-box;
     min-height: calc(var(--public-card-desc-gap) + var(--public-card-icon-row));
     padding-top: var(--public-card-desc-gap);
@@ -98,7 +102,7 @@ mat-card .mdc-card__actions:not(.review-actions) {
 
     // Content-sized island (YT/Spotify/Apple/BBC/IA/Share/youtube-stats/…).
     // order 3 + row-reverse: packs left of last subject when coexisting; wraps
-    // below when the row cannot keep subject ≥ --public-card-subject-min.
+    // below when the row cannot keep the subject's min-content width.
     // margin-right: auto keeps a lone (wrapped) island flush left.
     app-episode-links,
     app-episode-podcast-links,
@@ -182,23 +186,46 @@ mat-card .mdc-card__actions:not(.review-actions) {
             align-self: stretch;
         }
 
-        // Last / only: shares the bottom row with the island when
-        // island + min-width fit; otherwise full line above a wrapped island.
-        // align-self/end + margin-bottom optically match icon mid to the
-        // middle of the last line of the subject (not the whole wrapped block).
+        // Last / only: shares the bottom row with the island when island +
+        // subject min-content fit; otherwise full line above a wrapped island.
+        // min-width/flex-basis = min-content (label needs), not a fixed 100px
+        // column — tiny labels coexist whenever they fit.
+        // align-self/end + mid-offset optically match icon mid to the middle of
+        // the last line of the subject (not the whole wrapped block).
         &:last-child {
             order: 2;
-            flex: 1 1 var(--public-card-subject-min);
+            flex: 1 1 min-content;
             width: auto;
             max-width: 100%;
-            min-width: min(100%, var(--public-card-subject-min));
+            min-width: min-content;
             padding-bottom: 0;
             align-self: flex-end;
-            margin-bottom: calc((var(--public-card-icon-row) - var(--public-card-subject-line)) / 2);
+            margin-bottom: var(--public-card-subject-mid-offset);
             display: flex !important;
             flex-direction: row;
             align-items: flex-end !important;
             justify-content: flex-end;
+        }
+    }
+
+    // When leading subjects sit above the icon row, flex-end mid-align leaves
+    // empty space above the last subject inside the taller icon line — that
+    // inflates leading→last gap vs leading→leading (6px). Pull the whole
+    // bottom row up by the same mid-offset so text gaps stay uniform while
+    // icon mid ↔ last-line mid is preserved. padding-top on the last subject
+    // cancels that pull for the label itself when it stacks full-width above
+    // the island (Cases F/H) so subjects do not overlap.
+    &:has(.subject:not(:last-child)) {
+        .subject:last-child {
+            margin-top: calc(-1 * var(--public-card-subject-mid-offset));
+            padding-top: var(--public-card-subject-mid-offset);
+            box-sizing: border-box;
+        }
+
+        app-episode-links,
+        app-episode-podcast-links,
+        .discovery-service-links {
+            margin-top: calc(-1 * var(--public-card-subject-mid-offset));
         }
     }
 

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -82,12 +82,22 @@ mat-card .mdc-card__actions:not(.review-actions) {
     position: relative;
     --public-card-icon-row: var(--mdc-icon-button-state-layer-size, 40px);
     --public-card-desc-gap: 8px;
+    // Minimum width for a subject sharing the icon row. If the island leaves
+    // less than this, only-child wraps above the island (see wrap-reverse).
+    --public-card-subject-min: 100px;
     box-sizing: border-box;
     min-height: calc(var(--public-card-desc-gap) + var(--public-card-icon-row));
     padding-top: var(--public-card-desc-gap);
     padding-bottom: 0;
     column-gap: 0;
     row-gap: 0;
+
+    // Only-child beside a wide island (e.g. Discovery youtube-stats): when the
+    // subject cannot keep --public-card-subject-min, wrap-reverse puts the
+    // subject line above the icons instead of crushing it into a skinny column.
+    &:has(.subject:only-child) {
+        flex-wrap: wrap-reverse;
+    }
 
     // Content-sized island; width grows with YT/Spotify/Apple/BBC/IA/Share/….
     // order: 2 — after every multi-subject row (order 1); beside only-child.
@@ -173,13 +183,14 @@ mat-card .mdc-card__actions:not(.review-actions) {
             align-self: stretch;
         }
 
-        // Only-child: same row as icon host (natural height, mid-aligned).
+        // Only-child: prefer same row as icon host. min-width is configurable;
+        // if the island leaves less room, wrap-reverse stacks the subject above.
         &:only-child {
             order: 2;
-            flex: 1 1 0;
+            flex: 1 1 var(--public-card-subject-min);
+            min-width: var(--public-card-subject-min);
             padding-bottom: 0;
             align-self: center;
-            min-height: 0;
             height: auto;
             display: flex !important;
             flex-direction: row;

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -60,9 +60,10 @@ mat-card-actions.review-actions {
 // - Leading subjects: flex-basis 100% (full width rows).
 // - Icon cluster + last/only subject share the final row (order: 2); island width
 //   is the real host width — never a magic padding-left for N icons.
-// - align-items: center mid-aligns last/only subject with the icon row.
+// - Icon host is a fixed-height row; all service buttons mid-align inside it.
+// - Last/only subject is the same height and flex-centers its label → shared mid-line.
 // - Card padding-bottom ≈ 10px clearance; actions padding-top = 8px desc→footer.
-// - Uniform 6px gaps between subjects; do NOT min-height the last subject.
+// - Uniform 6px gaps between subjects; do NOT min-height *leading* subjects.
 // - Icons flush left with description (actions padding only — no extra host margin).
 // - Keep mat-card-actions icon margin-right (25px / 18px / 12px) — do not squeeze.
 mat-card:has(> .mdc-card__actions:not(.review-actions)) {
@@ -75,7 +76,9 @@ mat-card .mdc-card__actions:not(.review-actions) {
     flex-direction: row;
     flex-wrap: wrap;
     justify-content: flex-start;
-    align-items: center;
+    // Override mat-card .mdc-card__actions { align-items: end } so the icon
+    // host and last subject share one mid-line (both are icon-row tall).
+    align-items: center !important;
     position: relative;
     --public-card-icon-row: var(--mdc-icon-button-state-layer-size, 40px);
     --public-card-desc-gap: 8px;
@@ -87,7 +90,7 @@ mat-card .mdc-card__actions:not(.review-actions) {
     row-gap: 0;
 
     // One flex item whose width grows with however many service buttons exist.
-    // No margin-left: actions padding-left already matches description inset.
+    // Fixed height + centered children → YT/Share/BBC/IA share one mid-line.
     app-episode-links,
     app-episode-podcast-links,
     .discovery-service-links {
@@ -97,9 +100,49 @@ mat-card .mdc-card__actions:not(.review-actions) {
         flex-direction: row;
         flex-wrap: nowrap;
         align-items: center;
+        align-self: center;
         margin-left: 0;
         position: static;
         z-index: 1;
+        height: var(--public-card-icon-row);
+        min-height: var(--public-card-icon-row);
+        box-sizing: border-box;
+
+        // Unwrap nested #episodelinks so buttons are flex children of the host.
+        #episodelinks {
+            display: contents;
+        }
+
+        a[mat-icon-button],
+        button[mat-icon-button] {
+            display: inline-flex !important;
+            align-items: center;
+            justify-content: center;
+            align-self: center;
+            margin-top: 0;
+            margin-bottom: 0;
+            vertical-align: middle;
+            box-sizing: border-box;
+        }
+
+        // SVG (youtube/spotify/…) and font (share) icons share the same box.
+        mat-icon {
+            display: inline-flex !important;
+            align-items: center;
+            justify-content: center;
+            margin: 0 !important;
+            line-height: 1 !important;
+            width: var(--mdc-icon-button-icon-size, 24px);
+            height: var(--mdc-icon-button-icon-size, 24px);
+            font-size: var(--mdc-icon-button-icon-size, 24px);
+            overflow: visible;
+        }
+
+        mat-icon svg {
+            display: block;
+            width: 100%;
+            height: 100%;
+        }
     }
 
     mat-card-footer.subjects,
@@ -125,19 +168,21 @@ mat-card .mdc-card__actions:not(.review-actions) {
         &:not(:last-child) {
             order: 1;
             flex: 1 0 100%;
+            align-self: stretch;
         }
 
-        // Last of many / only-child: share the icon row; take remaining width.
+        // Last of many / only-child: same row as icon host; min-height matches
+        // icon-row so single-line labels mid-align. Do not set fixed height —
+        // long labels may wrap within the remaining width.
         &:last-child {
             order: 2;
             flex: 1 1 0;
             padding-bottom: 0;
-        }
-
-        &:only-child {
+            align-self: center;
             min-height: var(--public-card-icon-row);
-            display: flex;
-            align-items: center;
+            display: flex !important;
+            flex-direction: row;
+            align-items: center !important; // override subjects.component baseline
             justify-content: flex-end;
         }
     }
@@ -148,8 +193,10 @@ mat-card .mdc-card__actions:not(.review-actions) {
             display: flex;
             flex-direction: column;
             justify-content: center;
+            align-self: center;
             box-sizing: border-box;
             flex: 0 0 auto;
+            line-height: 1.2;
         }
     }
 }

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -76,10 +76,8 @@ mat-card .mdc-card__actions:not(.review-actions) {
     flex-direction: row;
     flex-wrap: wrap;
     justify-content: flex-start;
-    // Override mat-card .mdc-card__actions { align-items: end } so the icon
-    // host and last/only subject share one mid-line (icon host is icon-row
-    // tall; last subject stays natural height — do NOT min-height it or a
-    // short last line leaves a hole above the label).
+    // Mid-align only-child with the icon host. Multi-subject stacks all
+    // labels above the island (icons must never sit between subjects).
     align-items: center !important;
     position: relative;
     --public-card-icon-row: var(--mdc-icon-button-state-layer-size, 40px);
@@ -91,8 +89,8 @@ mat-card .mdc-card__actions:not(.review-actions) {
     column-gap: 0;
     row-gap: 0;
 
-    // One flex item whose width grows with however many service buttons exist.
-    // Fixed height + centered children → YT/Share/BBC/IA share one mid-line.
+    // Content-sized island; width grows with YT/Spotify/Apple/BBC/IA/Share/….
+    // order: 2 — after every multi-subject row (order 1); beside only-child.
     app-episode-links,
     app-episode-podcast-links,
     .discovery-service-links {
@@ -166,17 +164,17 @@ mat-card .mdc-card__actions:not(.review-actions) {
             line-height: 1.25;
         }
 
-        // Leading subjects: own full-width rows above the icon island.
-        &:not(:last-child) {
+        // 2+ subjects: every label is a full-width row above the icon island.
+        // Never place the island between subjects (flex wrap used to do that
+        // when the island was wide — last subject wrapped below the icons).
+        &:not(:only-child) {
             order: 1;
             flex: 1 0 100%;
             align-self: stretch;
         }
 
-        // Last of many / only-child: same row as icon host. Natural height only
-        // — parent align-items:center mid-aligns with the icon host. A
-        // min-height here reopens the uneven gap above short last labels.
-        &:last-child {
+        // Only-child: same row as icon host (natural height, mid-aligned).
+        &:only-child {
             order: 2;
             flex: 1 1 0;
             padding-bottom: 0;
@@ -185,8 +183,13 @@ mat-card .mdc-card__actions:not(.review-actions) {
             height: auto;
             display: flex !important;
             flex-direction: row;
-            align-items: center !important; // override subjects.component baseline
+            align-items: center !important;
             justify-content: flex-end;
+        }
+
+        // Last of many: still full-width above icons; keep sibling gap before island.
+        &:last-child:not(:only-child) {
+            padding-bottom: 6px;
         }
     }
 

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -72,20 +72,23 @@ mat-card:has(> .mdc-card__actions:not(.review-actions)) {
 }
 
 mat-card .mdc-card__actions:not(.review-actions) {
-    // Grid so leading subjects span full width above, while the last/only
-    // subject shares the bottom row with the icon island when there is room.
-    // Subject column never shrinks below --public-card-subject-min; the island
-    // column is capped so labels are not crushed. Icons never sit between subjects.
-    display: grid !important;
-    grid-template-columns:
-        fit-content(calc(100% - var(--public-card-subject-min)))
-        minmax(var(--public-card-subject-min), 1fr);
-    align-items: center;
-    justify-content: stretch;
+    // Flex wrap + row-reverse so last/only subject can sit beside the icon
+    // island when there is room (island left, subject right), but when island
+    // intrinsic width + --public-card-subject-min exceed the row, the subject
+    // stays on its line and the island wraps below — never crushed, never
+    // overlapping, never between subject lines. Leading subjects are always
+    // full-width above (order 1).
+    display: flex !important;
+    flex-wrap: wrap;
+    flex-direction: row-reverse;
+    align-items: flex-end;
+    justify-content: flex-start;
     position: relative;
     --public-card-icon-row: var(--mdc-icon-button-state-layer-size, 40px);
     --public-card-desc-gap: 8px;
     --public-card-subject-min: 100px;
+    // Subject line-height (matches .subject a) for last-line mid ↔ icon mid.
+    --public-card-subject-line: 1.25em;
     box-sizing: border-box;
     min-height: calc(var(--public-card-desc-gap) + var(--public-card-icon-row));
     padding-top: var(--public-card-desc-gap);
@@ -94,19 +97,21 @@ mat-card .mdc-card__actions:not(.review-actions) {
     row-gap: 0;
 
     // Content-sized island (YT/Spotify/Apple/BBC/IA/Share/youtube-stats/…).
-    // Same grid row as last/only subject (order 2); capped by the first track.
+    // order 3 + row-reverse: packs left of last subject when coexisting; wraps
+    // below when the row cannot keep subject ≥ --public-card-subject-min.
+    // margin-right: auto keeps a lone (wrapped) island flush left.
     app-episode-links,
     app-episode-podcast-links,
     .discovery-service-links {
-        grid-column: 1;
-        order: 2;
-        justify-self: start;
-        align-self: center;
+        order: 3;
+        flex: 0 0 auto;
+        align-self: flex-end;
         display: flex !important;
         flex-direction: row;
         flex-wrap: nowrap;
         align-items: center;
         margin-left: 0;
+        margin-right: auto;
         position: static;
         z-index: 1;
         height: var(--public-card-icon-row);
@@ -171,23 +176,28 @@ mat-card .mdc-card__actions:not(.review-actions) {
 
         // Leading subjects: full-width rows above the bottom icon/subject row.
         &:not(:last-child) {
-            grid-column: 1 / -1;
+            flex: 0 0 100%;
+            width: 100%;
             order: 1;
             align-self: stretch;
         }
 
-        // Last / only: bottom row beside the island. Track minmax keeps ≥
-        // --public-card-subject-min so labels are not crushed.
+        // Last / only: shares the bottom row with the island when
+        // island + min-width fit; otherwise full line above a wrapped island.
+        // align-self/end + margin-bottom optically match icon mid to the
+        // middle of the last line of the subject (not the whole wrapped block).
         &:last-child {
-            grid-column: 2;
             order: 2;
+            flex: 1 1 var(--public-card-subject-min);
+            width: auto;
+            max-width: 100%;
+            min-width: min(100%, var(--public-card-subject-min));
             padding-bottom: 0;
-            align-self: center;
-            justify-self: stretch;
-            min-width: 0;
+            align-self: flex-end;
+            margin-bottom: calc((var(--public-card-icon-row) - var(--public-card-subject-line)) / 2);
             display: flex !important;
             flex-direction: row;
-            align-items: center !important;
+            align-items: flex-end !important;
             justify-content: flex-end;
         }
     }


### PR DESCRIPTION
## Summary
- Replace absolute icons + fixed `--public-card-icon-island` (16.5rem) with a flex row-wrap footer so the icon host (`app-episode-links` / podcast-links / Discovery wrapper) sizes to the real button cluster (YT/Spotify/Apple/BBC/IA/Share, …).
- Last/only subject shares that row and takes remaining width — no magic `padding-left`, so Share no longer collides with long subject labels.
- Wrap Discovery service buttons + `.youtubemeta` in `.discovery-service-links`; bump to 1.9.964.

## Test plan
- [ ] Homepage/search card with YT+Spotify+Apple+Share and a long last/only subject — no overlap
- [ ] Card with BBC and/or Internet Archive in addition to the usual trio + Share
- [ ] Multi-subject cards: leading subjects full width; uniform 6px gaps; last mid-aligned with icons
- [ ] Only-child subject mid-aligned; ~8px under description; ~10px card bottom clearance
- [ ] Bookmarks (`app-episode-podcast-links`) and Discovery footer still align
- [ ] After next Discovery with Members/Views: confirm `.youtubemeta` mid-align and clearance (still unverified live)
