### PR TITLE
fix(ui): readable form selects in dark and light themes

### DIFF
--- a/cultpodcasts/src/app/add-episode-dialog/add-episode-dialog.component.html
+++ b/cultpodcasts/src/app/add-episode-dialog/add-episode-dialog.component.html
@@ -148,11 +148,11 @@
                 </mat-form-field>
                 <mat-form-field class="full-width">
                     <mat-label>Language</mat-label>
-                    <select matNativeControl [formControl]="form()!.controls.lang">
+                    <mat-select [formControl]="form()!.controls.lang">
                         @for (language of languages() | keyvalue:null; track language) {
-                        <option [value]="language.key">{{language.value}}</option>
+                        <mat-option [value]="language.key">{{language.value}}</mat-option>
                         }
-                    </select>
+                    </mat-select>
                 </mat-form-field>
             </mat-tab>
             <mat-tab label="Guests">

--- a/cultpodcasts/src/app/add-episode-dialog/add-episode-dialog.component.html
+++ b/cultpodcasts/src/app/add-episode-dialog/add-episode-dialog.component.html
@@ -26,31 +26,13 @@
             <mat-tab label="Flags">
                 <div class="flags">
                     @if (featureSwitchService.IsEnabled(FeatureSwitch.redditPost)) {
-                    <label>
-                        <span>Posted:</span>
-                        <mat-checkbox [formControl]="form()!.controls.posted" />
-                    </label>
+                    <mat-checkbox [formControl]="form()!.controls.posted">Posted</mat-checkbox>
                     }
-                    <label>
-                        <span>Tweeted:</span>
-                        <mat-checkbox [formControl]="form()!.controls.tweeted" />
-                    </label>
-                    <label>
-                        <span>Bluesky Post:</span>
-                        <mat-checkbox [formControl]="form()!.controls.blueskyPosted" />
-                    </label>
-                    <label>
-                        <span>Ignored:</span>
-                        <mat-checkbox [formControl]="form()!.controls.ignored" />
-                    </label>
-                    <label>
-                        <span>Removed:</span>
-                        <mat-checkbox [formControl]="form()!.controls.removed" />
-                    </label>
-                    <label>
-                        <span>Explicit:</span>
-                        <mat-checkbox [formControl]="form()!.controls.explicit" />
-                    </label>
+                    <mat-checkbox [formControl]="form()!.controls.tweeted">Tweeted</mat-checkbox>
+                    <mat-checkbox [formControl]="form()!.controls.blueskyPosted">Bluesky Post</mat-checkbox>
+                    <mat-checkbox [formControl]="form()!.controls.ignored">Ignored</mat-checkbox>
+                    <mat-checkbox [formControl]="form()!.controls.removed">Removed</mat-checkbox>
+                    <mat-checkbox [formControl]="form()!.controls.explicit">Explicit</mat-checkbox>
                 </div>
             </mat-tab>
             <mat-tab label="Urls">

--- a/cultpodcasts/src/app/add-episode-dialog/add-episode-dialog.component.sass
+++ b/cultpodcasts/src/app/add-episode-dialog/add-episode-dialog.component.sass
@@ -6,16 +6,11 @@
         display: block
         margin-top: 8px
         margin-bottom: 4px
-    label
-        display: block
-        margin-bottom: 10px
-        margin-top: 10px
-        span
-            display: block
     .flags
-        label
-            span
-                display: inline
+        display: flex
+        flex-direction: column
+        gap: 8px
+        margin-top: 8px
     .guest-actions
         margin: 8px 0
     .guest-suggestions

--- a/cultpodcasts/src/app/add-podcast-dialog/add-podcast-dialog.component.html
+++ b/cultpodcasts/src/app/add-podcast-dialog/add-podcast-dialog.component.html
@@ -120,27 +120,27 @@
             <mat-tab label="Meta">
                 <mat-form-field class="full-width">
                     <mat-label>Release Authority</mat-label>
-                    <select matNativeControl [formControl]="form()!.controls.releaseAuthority">
+                    <mat-select [formControl]="form()!.controls.releaseAuthority">
                         @for (podcastService of podcastServices; track $index) {
-                        <option [value]="podcastService">{{podcastService}}</option>
+                        <mat-option [value]="podcastService">{{podcastService}}</mat-option>
                         }
-                    </select>
+                    </mat-select>
                 </mat-form-field>
                 <mat-form-field class="full-width">
                     <mat-label>Primary Post Service</mat-label>
-                    <select matNativeControl [formControl]="form()!.controls.primaryPostService">
+                    <mat-select [formControl]="form()!.controls.primaryPostService">
                         @for (podcastService of podcastServices; track $index) {
-                        <option [value]="podcastService">{{podcastService}}</option>
+                        <mat-option [value]="podcastService">{{podcastService}}</mat-option>
                         }
-                    </select>
+                    </mat-select>
                 </mat-form-field>
                 <mat-form-field class="full-width">
                     <mat-label>Language</mat-label>
-                    <select matNativeControl [formControl]="form()!.controls.lang">
+                    <mat-select [formControl]="form()!.controls.lang">
                         @for (language of languages() | keyvalue:null; track language) {
-                        <option [value]="language.key">{{language.value}}</option>
+                        <mat-option [value]="language.key">{{language.value}}</mat-option>
                         }
-                    </select>
+                    </mat-select>
                 </mat-form-field>
                 <mat-form-field class="full-width">
                     <mat-label>Minimum Duration</mat-label>

--- a/cultpodcasts/src/app/add-podcast-dialog/add-podcast-dialog.component.html
+++ b/cultpodcasts/src/app/add-podcast-dialog/add-podcast-dialog.component.html
@@ -40,26 +40,11 @@
             </mat-tab>
             <mat-tab label="Flags">
                 <div class="flags">
-                    <label>
-                        <span>Removed:</span>
-                        <mat-checkbox [formControl]="form()!.controls.removed" />
-                    </label>
-                    <label>
-                        <span>Index All Episodes:</span>
-                        <mat-checkbox [formControl]="form()!.controls.indexAllEpisodes" />
-                    </label>
-                    <label>
-                        <span>Bypass Short Episode Checking:</span>
-                        <mat-checkbox [formControl]="form()!.controls.bypassShortEpisodeChecking" />
-                    </label>
-                    <label>
-                        <span>Skip Enriching From YouTube:</span>
-                        <mat-checkbox [formControl]="form()!.controls.skipEnrichingFromYouTube" />
-                    </label>
-                    <label>
-                        <span>Ignore All Episodes:</span>
-                        <mat-checkbox [formControl]="form()!.controls.ignoreAllEpisodes" />
-                    </label>
+                    <mat-checkbox [formControl]="form()!.controls.removed">Removed</mat-checkbox>
+                    <mat-checkbox [formControl]="form()!.controls.indexAllEpisodes">Index All Episodes</mat-checkbox>
+                    <mat-checkbox [formControl]="form()!.controls.bypassShortEpisodeChecking">Bypass Short Episode Checking</mat-checkbox>
+                    <mat-checkbox [formControl]="form()!.controls.skipEnrichingFromYouTube">Skip Enriching From YouTube</mat-checkbox>
+                    <mat-checkbox [formControl]="form()!.controls.ignoreAllEpisodes">Ignore All Episodes</mat-checkbox>
                 </div>
             </mat-tab>
             <mat-tab label="Subjects" [labelClass]="highlightSubjectsTab() ? 'subjects-tab-highlight' : ''">

--- a/cultpodcasts/src/app/add-podcast-dialog/add-podcast-dialog.component.sass
+++ b/cultpodcasts/src/app/add-podcast-dialog/add-podcast-dialog.component.sass
@@ -11,13 +11,8 @@
         display: block
         margin-top: 8px
         margin-bottom: 4px
-    label
-        display: block
-        margin-bottom: 10px
-        margin-top: 10px
-        span
-            display: block
     .flags
-        label
-            span
-                display: inline
+        display: flex
+        flex-direction: column
+        gap: 8px
+        margin-top: 8px

--- a/cultpodcasts/src/app/add-term/add-term.component.html
+++ b/cultpodcasts/src/app/add-term/add-term.component.html
@@ -11,7 +11,10 @@
     <p id="error">An error occurred</p>
     }
     }
-    <input matInput type="text" [(ngModel)]="term" (keydown.enter)="onSubmit()">
+    <mat-form-field class="full-width">
+        <mat-label>Term</mat-label>
+        <input matInput type="text" [(ngModel)]="term" (keydown.enter)="onSubmit()">
+    </mat-form-field>
     }
 </mat-dialog-content>
 

--- a/cultpodcasts/src/app/add-term/add-term.component.sass
+++ b/cultpodcasts/src/app/add-term/add-term.component.sass
@@ -1,2 +1,5 @@
 #error
     font-size: 1em
+.full-width
+    width: 100%
+    display: block

--- a/cultpodcasts/src/app/add-term/add-term.component.ts
+++ b/cultpodcasts/src/app/add-term/add-term.component.ts
@@ -3,6 +3,8 @@ import { Component, ChangeDetectionStrategy, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { AuthServiceWrapper } from '../auth-service-wrapper.class';
 import { firstValueFrom } from 'rxjs';
@@ -14,6 +16,8 @@ import { environment } from './../../environments/environment';
     MatDialogModule,
     MatProgressSpinnerModule,
     MatButtonModule,
+    MatFormFieldModule,
+    MatInputModule,
     FormsModule
   ],
   templateUrl: './add-term.component.html',

--- a/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.html
+++ b/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.html
@@ -130,11 +130,11 @@
                 </mat-form-field>
                 <mat-form-field class="full-width">
                     <mat-label>Language</mat-label>
-                    <select matNativeControl [formControl]="form()!.controls.lang">
+                    <mat-select [formControl]="form()!.controls.lang">
                         @for (language of languages() | keyvalue:null; track language) {
-                        <option [value]="language.key">{{language.value}}</option>
+                        <mat-option [value]="language.key">{{language.value}}</mat-option>
                         }
-                    </select>
+                    </mat-select>
                 </mat-form-field>
             </mat-tab>
             <mat-tab label="Images">

--- a/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.html
+++ b/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.html
@@ -26,31 +26,13 @@
             <mat-tab label="Flags">
                 <div class="flags">
                     @if (featureSwitchService.IsEnabled(FeatureSwitch.redditPost)) {
-                    <label>
-                        <span>Posted:</span>
-                        <mat-checkbox [formControl]="form()!.controls.posted" />
-                    </label>
+                    <mat-checkbox [formControl]="form()!.controls.posted">Posted</mat-checkbox>
                     }
-                    <label>
-                        <span>Tweeted:</span>
-                        <mat-checkbox [formControl]="form()!.controls.tweeted" />
-                    </label>
-                    <label>
-                        <span>Bluesky Post:</span>
-                        <mat-checkbox [formControl]="form()!.controls.blueskyPosted" />
-                    </label>
-                    <label>
-                        <span>Ignored:</span>
-                        <mat-checkbox [formControl]="form()!.controls.ignored" />
-                    </label>
-                    <label>
-                        <span>Removed:</span>
-                        <mat-checkbox [formControl]="form()!.controls.removed" />
-                    </label>
-                    <label>
-                        <span>Explicit:</span>
-                        <mat-checkbox [formControl]="form()!.controls.explicit" />
-                    </label>
+                    <mat-checkbox [formControl]="form()!.controls.tweeted">Tweeted</mat-checkbox>
+                    <mat-checkbox [formControl]="form()!.controls.blueskyPosted">Bluesky Post</mat-checkbox>
+                    <mat-checkbox [formControl]="form()!.controls.ignored">Ignored</mat-checkbox>
+                    <mat-checkbox [formControl]="form()!.controls.removed">Removed</mat-checkbox>
+                    <mat-checkbox [formControl]="form()!.controls.explicit">Explicit</mat-checkbox>
                 </div>
             </mat-tab>
             <mat-tab label="Urls">

--- a/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.sass
+++ b/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.sass
@@ -6,16 +6,11 @@
         display: block
         margin-top: 8px
         margin-bottom: 4px
-    label
-        display: block
-        margin-bottom: 10px
-        margin-top: 10px
-        span
-            display: block
     .flags
-        label
-            span
-                display: inline
+        display: flex
+        flex-direction: column
+        gap: 8px
+        margin-top: 8px
     .guest-actions
         margin: 8px 0
     .guest-suggestions

--- a/cultpodcasts/src/app/edit-person-dialog/edit-person-dialog.component.html
+++ b/cultpodcasts/src/app/edit-person-dialog/edit-person-dialog.component.html
@@ -7,36 +7,36 @@
     <p id="error">An error occurred</p>
     } @else {
     <form id="edit" [formGroup]="form()!" (ngSubmit)="onSubmit()">
-        <label>
-            <span>Name:</span>
+        <mat-form-field class="full-width">
+            <mat-label>Name</mat-label>
             <input type="text" [formControl]="form()!.controls.name" [readonly]="!create" matInput>
-        </label>
+        </mat-form-field>
         <div class="search-actions">
             <button type="button" mat-button (click)="searchX()" [disabled]="!searchTerm()">Search X</button>
             <button type="button" mat-button (click)="searchBluesky()" [disabled]="!searchTerm()">Search Bluesky</button>
         </div>
-        <label>
-            <span>Sort name:</span>
+        <mat-form-field class="full-width">
+            <mat-label>Sort name</mat-label>
             <input type="text" [formControl]="form()!.controls.sortName" matInput
                 placeholder="Suggested from name — edit to override">
-        </label>
+        </mat-form-field>
         <p class="sorts-as-hint">Sorts as: {{ sortsAsHint }}</p>
         <mat-checkbox [formControl]="useFullNameForSorting">
             Organization / use full name for sorting
         </mat-checkbox>
-        <label>
-            <span>Aliases:</span>
+        <mat-form-field class="full-width">
+            <mat-label>Aliases</mat-label>
             <textarea [formControl]="form()!.controls.aliases" matInput cdkTextareaAutosize
                 placeholder="Comma-separated aliases"></textarea>
-        </label>
-        <label>
-            <span>Twitter / X handle:</span>
+        </mat-form-field>
+        <mat-form-field class="full-width">
+            <mat-label>Twitter / X handle</mat-label>
             <input type="text" [formControl]="form()!.controls.twitterHandle" matInput placeholder="@handle">
-        </label>
-        <label>
-            <span>Bluesky handle:</span>
+        </mat-form-field>
+        <mat-form-field class="full-width">
+            <mat-label>Bluesky handle</mat-label>
             <input type="text" [formControl]="form()!.controls.blueskyHandle" matInput placeholder="handle.bsky.social">
-        </label>
+        </mat-form-field>
     </form>
     }
 </mat-dialog-content>

--- a/cultpodcasts/src/app/edit-person-dialog/edit-person-dialog.component.sass
+++ b/cultpodcasts/src/app/edit-person-dialog/edit-person-dialog.component.sass
@@ -1,14 +1,11 @@
 #error
     font-size: 1em
 #edit
-    label
+    .full-width
+        width: 100%
         display: block
-        margin-bottom: 10px
-        margin-top: 10px
-        span
-            display: block
-        input[type=text], textarea
-            width: 96%
+        margin-top: 8px
+        margin-bottom: 4px
     .search-actions
         margin-bottom: 10px
         button
@@ -17,3 +14,6 @@
         margin: 0 0 10px
         opacity: 0.75
         font-size: 0.9em
+    mat-checkbox
+        display: block
+        margin: 8px 0 12px

--- a/cultpodcasts/src/app/edit-podcast-dialog/edit-podcast-dialog.component.html
+++ b/cultpodcasts/src/app/edit-podcast-dialog/edit-podcast-dialog.component.html
@@ -119,27 +119,27 @@
             <mat-tab label="Meta">
                 <mat-form-field class="full-width">
                     <mat-label>Release Authority</mat-label>
-                    <select matNativeControl [formControl]="form()!.controls.releaseAuthority">
+                    <mat-select [formControl]="form()!.controls.releaseAuthority">
                         @for (podcastService of podcastServices; track $index) {
-                        <option [value]="podcastService">{{podcastService}}</option>
+                        <mat-option [value]="podcastService">{{podcastService}}</mat-option>
                         }
-                    </select>
+                    </mat-select>
                 </mat-form-field>
                 <mat-form-field class="full-width">
                     <mat-label>Primary Post Service</mat-label>
-                    <select matNativeControl [formControl]="form()!.controls.primaryPostService">
+                    <mat-select [formControl]="form()!.controls.primaryPostService">
                         @for (podcastService of podcastServices; track $index) {
-                        <option [value]="podcastService">{{podcastService}}</option>
+                        <mat-option [value]="podcastService">{{podcastService}}</mat-option>
                         }
-                    </select>
+                    </mat-select>
                 </mat-form-field>
                 <mat-form-field class="full-width">
                     <mat-label>Language</mat-label>
-                    <select matNativeControl [formControl]="form()!.controls.lang">
+                    <mat-select [formControl]="form()!.controls.lang">
                         @for (language of languages() | keyvalue:null; track language) {
-                        <option [value]="language.key">{{language.value}}</option>
+                        <mat-option [value]="language.key">{{language.value}}</mat-option>
                         }
-                    </select>
+                    </mat-select>
                 </mat-form-field>
                 <mat-form-field class="full-width">
                     <mat-label>Minimum Duration</mat-label>

--- a/cultpodcasts/src/app/edit-podcast-dialog/edit-podcast-dialog.component.html
+++ b/cultpodcasts/src/app/edit-podcast-dialog/edit-podcast-dialog.component.html
@@ -39,26 +39,11 @@
             </mat-tab>
             <mat-tab label="Flags">
                 <div class="flags">
-                    <label>
-                        <span>Removed:</span>
-                        <mat-checkbox [formControl]="form()!.controls.removed" />
-                    </label>
-                    <label>
-                        <span>Index All Episodes:</span>
-                        <mat-checkbox [formControl]="form()!.controls.indexAllEpisodes" />
-                    </label>
-                    <label>
-                        <span>Bypass Short Episode Checking:</span>
-                        <mat-checkbox [formControl]="form()!.controls.bypassShortEpisodeChecking" />
-                    </label>
-                    <label>
-                        <span>Skip Enriching From YouTube:</span>
-                        <mat-checkbox [formControl]="form()!.controls.skipEnrichingFromYouTube" />
-                    </label>
-                    <label>
-                        <span>Ignore All Episodes:</span>
-                        <mat-checkbox [formControl]="form()!.controls.ignoreAllEpisodes" />
-                    </label>
+                    <mat-checkbox [formControl]="form()!.controls.removed">Removed</mat-checkbox>
+                    <mat-checkbox [formControl]="form()!.controls.indexAllEpisodes">Index All Episodes</mat-checkbox>
+                    <mat-checkbox [formControl]="form()!.controls.bypassShortEpisodeChecking">Bypass Short Episode Checking</mat-checkbox>
+                    <mat-checkbox [formControl]="form()!.controls.skipEnrichingFromYouTube">Skip Enriching From YouTube</mat-checkbox>
+                    <mat-checkbox [formControl]="form()!.controls.ignoreAllEpisodes">Ignore All Episodes</mat-checkbox>
                 </div>
             </mat-tab>
             <mat-tab label="Subjects">

--- a/cultpodcasts/src/app/edit-podcast-dialog/edit-podcast-dialog.component.sass
+++ b/cultpodcasts/src/app/edit-podcast-dialog/edit-podcast-dialog.component.sass
@@ -6,13 +6,8 @@
         display: block
         margin-top: 8px
         margin-bottom: 4px
-    label
-        display: block
-        margin-bottom: 10px
-        margin-top: 10px
-        span
-            display: block
     .flags
-        label
-            span
-                display: inline
+        display: flex
+        flex-direction: column
+        gap: 8px
+        margin-top: 8px

--- a/cultpodcasts/src/app/edit-subject-dialog/edit-subject-dialog.component.html
+++ b/cultpodcasts/src/app/edit-subject-dialog/edit-subject-dialog.component.html
@@ -9,45 +9,45 @@
     <form id="edit" [formGroup]="form()!" (ngSubmit)="onSubmit()">
         <mat-tab-group>
             <mat-tab label="Details">
-                <label>
-                    <span>Name:</span>
+                <mat-form-field class="full-width">
+                    <mat-label>Name</mat-label>
                     <input type="text" [formControl]="form()!.controls.name" [readonly]="!create" matInput>
-                </label>
-                <label>
-                    <span>Aliases:</span>
+                </mat-form-field>
+                <mat-form-field class="full-width">
+                    <mat-label>Aliases</mat-label>
                     <textarea [formControl]="form()!.controls.aliases" matInput cdkTextareaAutosize></textarea>
-                </label>
-                <label>
-                    <span>Associated Subjects:</span>
-                    <textarea type="text" [formControl]="form()!.controls.associatedSubjects" matInput
+                </mat-form-field>
+                <mat-form-field class="full-width">
+                    <mat-label>Associated Subjects</mat-label>
+                    <textarea [formControl]="form()!.controls.associatedSubjects" matInput
                         cdkTextareaAutosize></textarea>
-                </label>
-                <label>
-                    <span>Subject Type:</span>
+                </mat-form-field>
+                <mat-form-field class="full-width">
+                    <mat-label>Subject Type</mat-label>
                     <mat-select [formControl]="form()!.controls.subjectType">
                         @for (subjectType of subjectTypes; track $index) {
                         <mat-option [value]="subjectType">{{subjectType}}</mat-option>
                         }
                     </mat-select>
-                </label>
+                </mat-form-field>
             </mat-tab>
             <mat-tab label="Hash Tags & Terms">
-                <label>
-                    <span>Hash Tags:</span>
+                <mat-form-field class="full-width">
+                    <mat-label>Hash Tags</mat-label>
                     <input type="text" [formControl]="form()!.controls.hashTag" matInput>
-                </label>
-                <label>
-                    <span>Enrichment Hash Tags:</span>
+                </mat-form-field>
+                <mat-form-field class="full-width">
+                    <mat-label>Enrichment Hash Tags</mat-label>
                     <textarea [formControl]="form()!.controls.enrichmentHashTags" matInput cdkTextareaAutosize></textarea>
-                </label>
-                <label>
-                    <span>Known Terms</span>
+                </mat-form-field>
+                <mat-form-field class="full-width">
+                    <mat-label>Known Terms</mat-label>
                     <input type="text" [formControl]="form()!.controls.knownTerms" matInput>
-                </label>
+                </mat-form-field>
             </mat-tab>
             <mat-tab label="Reddit">
-                <label>
-                    <span>Flair Id:</span>
+                <mat-form-field class="full-width">
+                    <mat-label>Flair Id</mat-label>
                     <mat-select [formControl]="form()!.controls.redditFlairTemplateId" id="flair" [style]="styleSelect()"
                         panelClass="flairs">
                         <mat-option [value]="">No Subject</mat-option>
@@ -56,11 +56,11 @@
                             [style]="styleOption(flair.value)">{{flair.key.substring(0,8)}}</mat-option>
                         }
                     </mat-select>
-                </label>
-                <label>
-                    <span>Flair Text:</span>
+                </mat-form-field>
+                <mat-form-field class="full-width">
+                    <mat-label>Flair Text</mat-label>
                     <input type="text" [formControl]="form()!.controls.redditFlareText" matInput>
-                </label>
+                </mat-form-field>
             </mat-tab>
         </mat-tab-group>
     </form>

--- a/cultpodcasts/src/app/edit-subject-dialog/edit-subject-dialog.component.html
+++ b/cultpodcasts/src/app/edit-subject-dialog/edit-subject-dialog.component.html
@@ -24,11 +24,11 @@
                 </label>
                 <label>
                     <span>Subject Type:</span>
-                    <select matNativeControl [formControl]="form()!.controls.subjectType">
+                    <mat-select [formControl]="form()!.controls.subjectType">
                         @for (subjectType of subjectTypes; track $index) {
-                        <option [value]="subjectType">{{subjectType}}</option>
+                        <mat-option [value]="subjectType">{{subjectType}}</mat-option>
                         }
-                    </select>
+                    </mat-select>
                 </label>
             </mat-tab>
             <mat-tab label="Hash Tags & Terms">

--- a/cultpodcasts/src/app/edit-subject-dialog/edit-subject-dialog.component.sass
+++ b/cultpodcasts/src/app/edit-subject-dialog/edit-subject-dialog.component.sass
@@ -9,6 +9,7 @@
             display: block
         input[type=text], textarea, mat-select
             width: 96%
+            color: var(--mat-sys-on-surface)
     .flags
         label
             span

--- a/cultpodcasts/src/app/edit-subject-dialog/edit-subject-dialog.component.sass
+++ b/cultpodcasts/src/app/edit-subject-dialog/edit-subject-dialog.component.sass
@@ -1,19 +1,11 @@
 #error
     font-size: 1em
 #edit
-    label
+    .full-width
+        width: 100%
         display: block
-        margin-bottom: 10px
-        margin-top: 10px
-        span
-            display: block
-        input[type=text], textarea, mat-select
-            width: 96%
-            color: var(--mat-sys-on-surface)
-    .flags
-        label
-            span
-                display: inline
+        margin-top: 8px
+        margin-bottom: 4px
 .flairs
     .mat-mdc-option.mdc-list-item--selected
         .mdc-list-item__primary-text

--- a/cultpodcasts/src/app/post-episode-dialog/post-episode-dialog.component.html
+++ b/cultpodcasts/src/app/post-episode-dialog/post-episode-dialog.component.html
@@ -9,19 +9,10 @@
     <form id="post" [formGroup]="form!" (ngSubmit)="onSubmit()">
         <div class="flags">
             @if (featureSwitchService.IsEnabled(FeatureSwitch.redditPost)) {
-            <label>
-                <span>Post:</span>
-                <mat-checkbox [formControl]="form!.controls.post"/>
-            </label>
+            <mat-checkbox [formControl]="form!.controls.post">Post</mat-checkbox>
             }
-            <label>
-                <span>Tweet:</span>
-                <mat-checkbox [formControl]="form!.controls.tweet"/>
-            </label>
-            <label>
-                <span>Bluesky Post:</span>
-                <mat-checkbox [formControl]="form!.controls.blueskyPost"/>
-            </label>
+            <mat-checkbox [formControl]="form!.controls.tweet">Tweet</mat-checkbox>
+            <mat-checkbox [formControl]="form!.controls.blueskyPost">Bluesky Post</mat-checkbox>
         </div>
     </form>
     }

--- a/cultpodcasts/src/app/post-episode-dialog/post-episode-dialog.component.sass
+++ b/cultpodcasts/src/app/post-episode-dialog/post-episode-dialog.component.sass
@@ -9,6 +9,7 @@
             display: block
         input[type=text], textarea, mat-select
             width: 96%
+            color: var(--mat-sys-on-surface)
     .flags
         label
             span

--- a/cultpodcasts/src/app/post-episode-dialog/post-episode-dialog.component.sass
+++ b/cultpodcasts/src/app/post-episode-dialog/post-episode-dialog.component.sass
@@ -1,16 +1,8 @@
 #error
     font-size: 1em
 #post
-    label
-        display: block
-        margin-bottom: 10px
-        margin-top: 10px
-        span
-            display: block
-        input[type=text], textarea, mat-select
-            width: 96%
-            color: var(--mat-sys-on-surface)
     .flags
-        label
-            span
-                display: inline
+        display: flex
+        flex-direction: column
+        gap: 8px
+        margin-top: 8px

--- a/cultpodcasts/src/app/rename-podcast-dialog/rename-podcast-dialog.component.html
+++ b/cultpodcasts/src/app/rename-podcast-dialog/rename-podcast-dialog.component.html
@@ -12,21 +12,22 @@
         <p>An error occurred</p>
         }
         <p>Rename "{{podcastName}}" to</p>
-        <input matInput type="text" (keydown.enter)="onSubmit()" class="form-control" id="newPodcastName" required
-            [(ngModel)]="newPodcastName" name="newPodcastName" #newPodcastNameField="ngModel"
-            (keyup)="checkControl(newPodcastNameField)" (keyup.enter)="onSubmit()">
-
-        @if (newPodcastNameField.invalid && (newPodcastNameField.dirty || newPodcastNameField.touched)) {
-        <div class="alert">
-            @if (newPodcastNameField.hasError('required')) {
-            <div>New podcast-name is required. </div>
+        <mat-form-field class="full-width">
+            <mat-label>New podcast name</mat-label>
+            <input matInput type="text" (keydown.enter)="onSubmit()" id="newPodcastName" required
+                [(ngModel)]="newPodcastName" name="newPodcastName" #newPodcastNameField="ngModel"
+                (keyup)="checkControl(newPodcastNameField)" (keyup.enter)="onSubmit()">
+            @if (newPodcastNameField.invalid && (newPodcastNameField.dirty || newPodcastNameField.touched)) {
+            <mat-error>
+                @if (newPodcastNameField.hasError('required')) {
+                New podcast-name is required.
+                }
+                @if (newPodcastNameField.hasError('unsafe')) {
+                Invalid podcast name.
+                }
+            </mat-error>
             }
-            @if (newPodcastNameField.hasError('unsafe')) {
-            <div>Invalid podcast name.</div>
-            }
-        </div>
-
-        }
+        </mat-form-field>
         }
     </mat-dialog-content>
 

--- a/cultpodcasts/src/app/rename-podcast-dialog/rename-podcast-dialog.component.sass
+++ b/cultpodcasts/src/app/rename-podcast-dialog/rename-podcast-dialog.component.sass
@@ -1,0 +1,3 @@
+.full-width
+    width: 100%
+    display: block

--- a/cultpodcasts/src/app/rename-podcast-dialog/rename-podcast-dialog.component.ts
+++ b/cultpodcasts/src/app/rename-podcast-dialog/rename-podcast-dialog.component.ts
@@ -3,6 +3,8 @@ import { Component, Inject, ChangeDetectionStrategy, signal } from '@angular/cor
 import { FormsModule, NgModel } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { firstValueFrom } from 'rxjs';
 import { AuthServiceWrapper } from '../auth-service-wrapper.class';
@@ -16,6 +18,8 @@ import { RenamePodcastDialogResponse } from "../rename-podcast-dialog-response.i
     MatDialogModule,
     MatProgressSpinnerModule,
     MatButtonModule,
+    MatFormFieldModule,
+    MatInputModule,
     FormsModule,
   ],
   templateUrl: './rename-podcast-dialog.component.html',

--- a/cultpodcasts/src/app/set-number-of-days/set-number-of-days.component.html
+++ b/cultpodcasts/src/app/set-number-of-days/set-number-of-days.component.html
@@ -1,7 +1,10 @@
 <h2 mat-dialog-title>Set Number Of Days</h2>
 
 <mat-dialog-content>
-    <input matInput [(ngModel)]="days" type="number" min="1" max="14" (keydown.enter)="close(true)">
+    <mat-form-field class="full-width">
+        <mat-label>Days</mat-label>
+        <input matInput [(ngModel)]="days" type="number" min="1" max="14" (keydown.enter)="close(true)">
+    </mat-form-field>
 </mat-dialog-content>
 
 <mat-dialog-actions>

--- a/cultpodcasts/src/app/set-number-of-days/set-number-of-days.component.sass
+++ b/cultpodcasts/src/app/set-number-of-days/set-number-of-days.component.sass
@@ -1,0 +1,3 @@
+.full-width
+    width: 100%
+    display: block

--- a/cultpodcasts/src/app/set-number-of-days/set-number-of-days.component.ts
+++ b/cultpodcasts/src/app/set-number-of-days/set-number-of-days.component.ts
@@ -1,6 +1,8 @@
 import { ChangeDetectionStrategy, Component, Inject } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
 import { FormsModule } from '@angular/forms';
 
 @Component({
@@ -8,6 +10,8 @@ import { FormsModule } from '@angular/forms';
   imports: [
     MatDialogModule,
     MatButtonModule,
+    MatFormFieldModule,
+    MatInputModule,
     FormsModule
   ],
   templateUrl: './set-number-of-days.component.html',

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -482,6 +482,70 @@ mat-card-actions {
     }
 }
 
+// Form controls — keep text/background contrast in both color schemes.
+// Native <select>/<option> popups ignore Material tokens (dark-on-dark in
+// Firefox/Chrome); prefer mat-select. These rules cover any remaining native
+// controls and reinforce Material field/option contrast.
+.mat-mdc-form-field {
+    .mat-mdc-input-element,
+    .mat-mdc-select-value,
+    .mat-mdc-select-placeholder,
+    .mat-mdc-select-min-line {
+        color: var(--mat-sys-on-surface);
+    }
+
+    textarea.mat-mdc-input-element {
+        color: var(--mat-sys-on-surface);
+    }
+}
+
+.mat-mdc-option {
+    color: var(--mat-sys-on-surface);
+
+    &.mdc-list-item--selected:not(.mdc-list-item--disabled) {
+        .mdc-list-item__primary-text {
+            color: var(--mat-sys-on-surface);
+        }
+    }
+}
+
+.mat-mdc-select-panel {
+    background: var(--mat-sys-surface-container);
+}
+
+select,
+option {
+    color-scheme: light dark;
+    color: CanvasText;
+    background-color: Canvas;
+}
+
+@media (prefers-color-scheme: dark) {
+    option {
+        color: #f2f0f4;
+        background-color: #2b2930;
+    }
+
+    option:checked,
+    option:hover {
+        color: #fff;
+        background-color: #49454f;
+    }
+}
+
+@media (prefers-color-scheme: light) {
+    option {
+        color: #1c1b1f;
+        background-color: #fff;
+    }
+
+    option:checked,
+    option:hover {
+        color: #1c1b1f;
+        background-color: #e8e0ec;
+    }
+}
+
 .mat-mdc-menu-panel:has(a[href*="bsky.app/profile/cultpodcasts.bsky.social"]) {
     background-color: var(--mat-sys-surface);
     opacity: 1;


### PR DESCRIPTION
## Summary
- Replace native `matNativeControl` selects with `mat-select` (language/service/subject type) so option lists use Material theme tokens in dark and light mode.
- Wrap remaining bare `matInput` fields in `mat-form-field` (Edit Subject, Edit Person, Add Term, Rename Podcast, Set Days).
- Flag checkboxes use Material label text instead of bare `<label><span>` wrappers.
- Global form contrast rules as a safety net for any leftover native options.

## Test plan
- [ ] Dark + light: Edit Podcast → Meta → Language / Release Authority / Primary Post Service
- [ ] Edit Subject / Edit Person fields look like other Material dialogs
- [ ] Add Term, Rename Podcast, Set Number Of Days
- [ ] Episode/podcast flag checkboxes readable and clickable
- [ ] Existing mat-selects (subjects, guests, flairs) still work