### PR TITLE
fix(flix): start hero on first slide and restore dash interaction

### DIFF
--- a/cultpodcasts/src/app/homepage-api/homepage-api.component.html
+++ b/cultpodcasts/src/app/homepage-api/homepage-api.component.html
@@ -20,7 +20,6 @@
     [slides]="heroSlides()"
     [curatedEpisodeIds]="curatedEpisodeIds()"
     [isCurator]="isCurator()"
-    [timeBucket]="heroTimeBucket()"
     (manageHero)="openManageHero()"
     (manageRails)="openManageRails()"
     (removeFeatured)="removeFeaturedFromHero($event)"

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.html
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.html
@@ -1,6 +1,8 @@
 @if (featured(); as feature) {
 <section class="billboard" aria-roledescription="carousel" aria-label="Featured episodes"
-  (mouseenter)="pauseHero()" (mouseleave)="resumeHero()" (focusin)="pauseHero()" (focusout)="resumeHero()">
+  [class.is-paused]="heroPaused()"
+  (mouseenter)="onHeroPointerEnter()" (mouseleave)="onHeroPointerLeave()"
+  (focusin)="onHeroFocusIn()" (focusout)="onHeroFocusOut($event)">
 
   <div class="billboard__stages" aria-hidden="true">
     <div class="billboard__stage" [class.is-active]="heroFrontLayer() === 'a'"
@@ -85,7 +87,7 @@
     @if (slides().length > 1) {
     <div class="billboard__pager">
       <button type="button" class="billboard__nav billboard__nav--prev" aria-label="Previous featured episode"
-        (click)="prevHero()">
+        (click)="prevHero($event)">
         <mat-icon>chevron_left</mat-icon>
       </button>
       <div class="billboard__dots-viewport"
@@ -100,15 +102,15 @@
             [attr.data-hero-dot]="i"
             [attr.aria-selected]="i === heroIndex()"
             [attr.aria-label]="'Show featured episode ' + (i + 1)"
-            (click)="goHero(i)">
+            (click)="goHero(i, $event)">
             <span class="billboard__dot-fill"
-              [class.is-running]="i === heroIndex() && !heroPaused() && heroImageReady()"></span>
+              [class.is-running]="i === heroIndex() && heroImageReady()"></span>
           </button>
           }
         </div>
       </div>
       <button type="button" class="billboard__nav billboard__nav--next" aria-label="Next featured episode"
-        (click)="nextHero()">
+        (click)="nextHero($event)">
         <mat-icon>chevron_right</mat-icon>
       </button>
     </div>

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
@@ -299,8 +299,7 @@
     &.is-running
         animation: nflx-dot-progress var(--hero-interval) linear forwards
 
-.billboard:hover .billboard__dot-fill.is-running,
-.billboard:focus-within .billboard__dot-fill.is-running
+.billboard.is-paused .billboard__dot-fill.is-running
     animation-play-state: paused
 
 @media (prefers-reduced-motion: reduce)

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
@@ -258,25 +258,32 @@
     width: max-content
     padding: 4px 2px
 
+// The button is a transparent 36×31 hit area; ::before paints the visible 28×3 bar
+// so active / curated chrome never outlines the enlarged target.
 .billboard__dot
     position: relative
     flex-shrink: 0
-    // Visible bar is 28×3; expand the hit target so dashes are clickable.
     box-sizing: content-box
     width: 28px
     height: 3px
     padding: 14px 4px
     border: none
-    border-radius: 2px
-    background: #ffffff47
-    background-clip: content-box
+    background: none
     cursor: pointer
-    overflow: hidden
-    &.is-active
+    &::before
+        content: ''
+        position: absolute
+        left: 4px
+        top: 50%
+        width: 28px
+        height: 3px
+        margin-top: -1.5px
+        border-radius: 2px
+        background: #ffffff47
+    &.is-active::before
         background: #ffffff59
-        background-clip: content-box
-    &.is-curated
-        box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--nflx-accent) 55%, transparent)
+    &.is-curated::before
+        box-shadow: 0 0 0 1px color-mix(in srgb, var(--nflx-accent) 55%, transparent)
 
 .billboard__dot-fill
     position: absolute

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
@@ -18,9 +18,11 @@
 .billboard__vignette
     position: absolute
     inset: 0
+    // Full-bleed layers sit under content/controls; without this they steal
+    // clicks/drags from the hero dashes (transform on stages creates a stacking context).
+    pointer-events: none
 
 .billboard__grain
-    pointer-events: none
     opacity: 0.07
     mix-blend-mode: soft-light
     // Static noise tile — avoids animated SVG feTurbulence paint cost on every frame.
@@ -31,7 +33,6 @@
     background: linear-gradient(85deg, rgba(0, 0, 0, 0.94) 0%, rgba(0, 0, 0, 0.62) 38%, rgba(0, 0, 0, 0.15) 68%, transparent 82%), linear-gradient(to top, var(--nflx-bg, #0b0b0b) 0%, transparent 45%), linear-gradient(to bottom, rgba(0, 0, 0, 0.55) 0%, transparent 22%)
 
 .billboard__vignette
-    pointer-events: none
     background: radial-gradient(ellipse at 70% 40%, transparent 20%, rgba(0, 0, 0, 0.45) 100%)
 
 .billboard__stage
@@ -53,6 +54,7 @@
     z-index: 2
     width: min(640px, 100%)
     padding-top: 96px
+    pointer-events: auto
 
 .billboard__feature
     opacity: 1
@@ -177,6 +179,7 @@
     flex-wrap: wrap
     justify-content: flex-end
     max-width: calc(100% - 8vw)
+    pointer-events: auto
 
 .billboard__manage
     display: inline-flex
@@ -234,6 +237,8 @@
     min-width: 0
     overflow-x: auto
     overflow-y: hidden
+    // Prefer horizontal scrubbing on the dash strip over page scroll.
+    touch-action: pan-x
     scroll-behavior: smooth
     scrollbar-width: none
     -ms-overflow-style: none
@@ -251,30 +256,39 @@
     display: flex
     gap: 6px
     width: max-content
-    padding: 10px 2px
+    padding: 4px 2px
 
 .billboard__dot
     position: relative
     flex-shrink: 0
+    // Visible bar is 28×3; expand the hit target so dashes are clickable.
+    box-sizing: content-box
     width: 28px
     height: 3px
-    padding: 0
+    padding: 14px 4px
     border: none
     border-radius: 2px
     background: #ffffff47
+    background-clip: content-box
     cursor: pointer
     overflow: hidden
     &.is-active
         background: #ffffff59
+        background-clip: content-box
     &.is-curated
-        box-shadow: 0 0 0 1px color-mix(in srgb, var(--nflx-accent) 55%, transparent)
+        box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--nflx-accent) 55%, transparent)
 
 .billboard__dot-fill
     position: absolute
-    inset: 0
+    left: 4px
+    top: 50%
+    height: 3px
+    margin-top: -1.5px
     width: 0
+    // Progress fill spans the visible 28px bar (button content width), not the padded hit box.
+    max-width: 28px
     background: var(--nflx-accent)
-    border-radius: inherit
+    border-radius: 2px
     &.is-running
         animation: nflx-dot-progress var(--hero-interval) linear forwards
 

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.spec.ts
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.spec.ts
@@ -105,6 +105,56 @@ describe('HomepageHeroComponent', () => {
     expect(component['featured']()?.id).toBe('a');
   });
 
+  it('releases chevron focus so the dash timer can run again after navigation', () => {
+    vi.useFakeTimers();
+    component['reduceMotion'] = false;
+    component['heroImageReady'].set(true);
+    component['pointerInside'] = false;
+    component['focusInside'] = false;
+    component['syncHeroPaused']();
+    fixture.detectChanges();
+
+    const next = fixture.nativeElement.querySelector(
+      'button.billboard__nav--next'
+    ) as HTMLButtonElement;
+    next.focus();
+    component.onHeroFocusIn();
+    expect(component['heroPaused']()).toBe(true);
+
+    next.click();
+    vi.advanceTimersByTime(320);
+    // Cached/missing image gate may still be open in tests; the dwell fill only
+    // requires ready + not paused once the slide has settled.
+    component['heroImageReady'].set(true);
+    fixture.detectChanges();
+
+    expect(document.activeElement === next).toBe(false);
+    expect(component['focusInside']).toBe(false);
+    expect(component['heroPaused']()).toBe(false);
+
+    const activeFill = fixture.nativeElement.querySelector(
+      'button.billboard__dot.is-active .billboard__dot-fill'
+    ) as HTMLElement;
+    expect(activeFill.classList.contains('is-running')).toBe(true);
+  });
+
+  it('keeps the dwell paused while the pointer remains over the billboard after a chevron click', () => {
+    component['pointerInside'] = true;
+    component['focusInside'] = false;
+    component['syncHeroPaused']();
+    expect(component['heroPaused']()).toBe(true);
+
+    const next = fixture.nativeElement.querySelector(
+      'button.billboard__nav--next'
+    ) as HTMLButtonElement;
+    next.focus();
+    component.onHeroFocusIn();
+    next.click();
+
+    expect(component['pointerInside']).toBe(true);
+    expect(component['heroPaused']()).toBe(true);
+  });
+
   it('keeps the featured episode when slides refresh with the same id', () => {
     component['heroIndex'].set(2);
     component['lastFeaturedId'] = 'c';

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.spec.ts
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.spec.ts
@@ -69,6 +69,42 @@ describe('HomepageHeroComponent', () => {
     expect(component['featured']()?.id).toBe('c');
   });
 
+  it('advances when the next chevron is clicked without cancelling the content transition', () => {
+    vi.useFakeTimers();
+    component['reduceMotion'] = false;
+    component['heroIndex'].set(0);
+    component['lastFeaturedId'] = 'a';
+    fixture.detectChanges();
+
+    const next = fixture.nativeElement.querySelector(
+      'button.billboard__nav--next'
+    ) as HTMLButtonElement;
+    next.click();
+
+    // Bug regression: restartHeroCycle used to clear heroContentTimer and leave index at 0.
+    expect(component['heroIndex']()).toBe(0);
+    vi.advanceTimersByTime(320);
+    expect(component['heroIndex']()).toBe(1);
+    expect(component['featured']()?.id).toBe('b');
+  });
+
+  it('goes to the previous slide when the prev chevron is clicked', () => {
+    vi.useFakeTimers();
+    component['reduceMotion'] = false;
+    component['heroIndex'].set(1);
+    component['lastFeaturedId'] = 'b';
+    fixture.detectChanges();
+
+    const prev = fixture.nativeElement.querySelector(
+      'button.billboard__nav--prev'
+    ) as HTMLButtonElement;
+    prev.click();
+    vi.advanceTimersByTime(320);
+
+    expect(component['heroIndex']()).toBe(0);
+    expect(component['featured']()?.id).toBe('a');
+  });
+
   it('keeps the featured episode when slides refresh with the same id', () => {
     component['heroIndex'].set(2);
     component['lastFeaturedId'] = 'c';

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.spec.ts
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.spec.ts
@@ -41,7 +41,6 @@ describe('HomepageHeroComponent', () => {
     fixture = TestBed.createComponent(HomepageHeroComponent);
     component = fixture.componentInstance;
     fixture.componentRef.setInput('slides', [ep('a'), ep('b'), ep('c')]);
-    fixture.componentRef.setInput('timeBucket', 1);
     fixture.detectChanges();
   });
 
@@ -50,9 +49,24 @@ describe('HomepageHeroComponent', () => {
     component['stopHeroCycle']();
   });
 
-  it('starts on timeBucket modulo slide count', () => {
-    expect(component['heroIndex']()).toBe(1);
-    expect(component['featured']()?.id).toBe('b');
+  it('starts on the first slide', () => {
+    expect(component['heroIndex']()).toBe(0);
+    expect(component['featured']()?.id).toBe('a');
+  });
+
+  it('jumps to a slide when its hero dash is clicked', () => {
+    component['reduceMotion'] = true;
+    fixture.detectChanges();
+    const dots = fixture.nativeElement.querySelectorAll(
+      'button.billboard__dot'
+    ) as NodeListOf<HTMLButtonElement>;
+    expect(dots.length).toBe(3);
+
+    dots[2].click();
+    fixture.detectChanges();
+
+    expect(component['heroIndex']()).toBe(2);
+    expect(component['featured']()?.id).toBe('c');
   });
 
   it('keeps the featured episode when slides refresh with the same id', () => {
@@ -73,7 +87,7 @@ describe('HomepageHeroComponent', () => {
     fixture.componentRef.setInput('slides', [ep('a'), ep('b'), ep('c')]);
     fixture.detectChanges();
 
-    expect(component['heroIndex']()).toBe(1);
+    expect(component['heroIndex']()).toBe(0);
     expect(component['heroImageReady']()).toBe(true);
   });
 
@@ -81,14 +95,13 @@ describe('HomepageHeroComponent', () => {
     const removed: string[] = [];
     component.removeFeatured.subscribe((id) => removed.push(id));
     fixture.componentRef.setInput('isCurator', true);
-    fixture.componentRef.setInput('curatedEpisodeIds', ['b']);
-    fixture.componentRef.setInput('timeBucket', 1);
+    fixture.componentRef.setInput('curatedEpisodeIds', ['a']);
     fixture.detectChanges();
 
     const button = fixture.nativeElement.querySelector('button.billboard__curate') as HTMLButtonElement | null;
     expect(button).toBeTruthy();
     button?.click();
-    expect(removed).toEqual(['b']);
+    expect(removed).toEqual(['a']);
   });
 
   it('emits manageHero / manageRails from curator controls', () => {

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.spec.ts
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.spec.ts
@@ -136,7 +136,10 @@ describe('HomepageHeroComponent', () => {
       component['heroImageReady'].set(false);
       component['beginHeroImageGate']();
       expect(component['heroImageReady']()).toBe(false);
-      vi.advanceTimersByTime(2500);
+      // A slow-but-working backdrop must still gate the dwell timer.
+      vi.advanceTimersByTime(7500);
+      expect(component['heroImageReady']()).toBe(false);
+      vi.advanceTimersByTime(4500);
       expect(component['heroImageReady']()).toBe(true);
     } finally {
       globalThis.Image = originalImage;

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.ts
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.ts
@@ -114,6 +114,10 @@ export class HomepageHeroComponent {
   private resizeFrame = 0;
   private dotsScrollFrame = 0;
   private dotsScrollTarget: HTMLElement | undefined;
+  /** Pointer is over the billboard (hover pause). */
+  private pointerInside = false;
+  /** Focus is inside the billboard (keyboard pause). */
+  private focusInside = false;
 
   /**
    * Window resize and dots-strip scroll are bound outside Angular's event manager: in a
@@ -259,42 +263,82 @@ export class HomepageHeroComponent {
     this.play.emit(episode);
   }
 
-  pauseHero(): void {
-    this.heroPaused.set(true);
+  onHeroPointerEnter(): void {
+    this.pointerInside = true;
+    this.syncHeroPaused();
   }
 
-  resumeHero(): void {
-    if (this.playerService.episode()) {
+  onHeroPointerLeave(): void {
+    this.pointerInside = false;
+    this.syncHeroPaused();
+  }
+
+  onHeroFocusIn(): void {
+    this.focusInside = true;
+    this.syncHeroPaused();
+  }
+
+  onHeroFocusOut(event: FocusEvent): void {
+    const root = event.currentTarget as HTMLElement | null;
+    const next = event.relatedTarget as Node | null;
+    // focusout bubbles for every child blur; only clear when focus leaves the billboard.
+    if (root && next && root.contains(next)) {
       return;
     }
-    this.heroPaused.set(false);
+    this.focusInside = false;
+    this.syncHeroPaused();
   }
 
-  goHero(index: number): void {
+  goHero(index: number, event?: Event): void {
     const slides = this.slides();
     if (slides.length === 0) {
       return;
     }
     this.transitionTo(index % slides.length);
     this.restartHeroCycle();
+    this.releasePagerFocus(event);
   }
 
-  nextHero(): void {
+  nextHero(event?: Event): void {
     const n = this.slides().length;
     if (n === 0) {
       return;
     }
     this.transitionTo((this.heroIndex() + 1) % n);
     this.restartHeroCycle();
+    this.releasePagerFocus(event);
   }
 
-  prevHero(): void {
+  prevHero(event?: Event): void {
     const n = this.slides().length;
     if (n === 0) {
       return;
     }
     this.transitionTo((this.heroIndex() - 1 + n) % n);
     this.restartHeroCycle();
+    this.releasePagerFocus(event);
+  }
+
+  /**
+   * Mouse clicks leave focus on the chevron/dash, which kept the hero paused forever
+   * via focusin. Blur and clear focus-pause so the dwell timer / dash fill can run
+   * again once the pointer leaves (hover pause still applies while the pointer is inside).
+   */
+  private releasePagerFocus(event?: Event): void {
+    const target = event?.currentTarget;
+    if (target instanceof HTMLElement) {
+      target.blur();
+    }
+    this.focusInside = false;
+    this.syncHeroPaused();
+  }
+
+  private syncHeroPaused(): void {
+    if (this.playerService.episode()) {
+      this.heroPaused.set(true);
+      return;
+    }
+    this.heroPaused.set(this.pointerInside || this.focusInside);
   }
 
   private scrollActiveHeroDotIntoView(

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.ts
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.ts
@@ -34,7 +34,12 @@ import { displayCatalogName } from '../display-catalog-name';
 })
 export class HomepageHeroComponent {
   private static readonly heroIntervalMs = 7500;
-  private static readonly heroImageFallbackMs = 2500;
+  /**
+   * Safety net only: the dwell timer is meant to start once the backdrop has painted.
+   * Keep this long enough that a slow (but working) image still gates the countdown,
+   * so a slide is never swapped out before it has ever been seen.
+   */
+  private static readonly heroImageFallbackMs = 12000;
   private static readonly heroTransitionMs = 1200;
   private static readonly heroContentOutMs = 320;
 

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.ts
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.ts
@@ -208,6 +208,7 @@ export class HomepageHeroComponent {
       window.addEventListener('resize', this.onResizeEvent, { passive: true });
       this.destroyRef.onDestroy(() => {
         this.stopHeroCycle();
+        this.clearHeroContentTransition();
         this.clearHeroImageWait();
         window.removeEventListener('resize', this.onResizeEvent);
         this.dotsScrollTarget?.removeEventListener('scroll', this.onDotsScrollEvent);
@@ -506,6 +507,23 @@ export class HomepageHeroComponent {
       return;
     }
     this.beginHeroImageGate();
+    this.scheduleHeroAdvance();
+  }
+
+  /**
+   * Reset the dwell clock after a manual prev/next/dash jump.
+   * Must not cancel `heroContentTimer` or re-run the image gate — `transitionTo`
+   * owns both, and clearing them here made the chevrons appear dead.
+   */
+  private restartHeroCycle(): void {
+    this.stopHeroCycle();
+    if (!isPlatformBrowser(this.platformId) || this.reduceMotion || this.slides().length < 2) {
+      return;
+    }
+    this.scheduleHeroAdvance();
+  }
+
+  private scheduleHeroAdvance(): void {
     let elapsed = 0;
     const tickMs = 250;
     this.heroTimer = setInterval(() => {
@@ -525,15 +543,14 @@ export class HomepageHeroComponent {
     }, tickMs);
   }
 
-  private restartHeroCycle(): void {
-    this.startHeroCycle();
-  }
-
   private stopHeroCycle(): void {
     if (this.heroTimer) {
       clearInterval(this.heroTimer);
       this.heroTimer = undefined;
     }
+  }
+
+  private clearHeroContentTransition(): void {
     if (this.heroContentTimer) {
       clearTimeout(this.heroContentTimer);
       this.heroContentTimer = undefined;

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.ts
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.ts
@@ -41,8 +41,6 @@ export class HomepageHeroComponent {
   readonly slides = input.required<HomepageEpisode[]>();
   readonly curatedEpisodeIds = input<readonly string[]>([]);
   readonly isCurator = input(false);
-  /** Stable seed for initial slide index (e.g. 3-hour time bucket). */
-  readonly timeBucket = input(0);
 
   readonly manageHero = output<void>();
   readonly manageRails = output<void>();
@@ -157,10 +155,10 @@ export class HomepageHeroComponent {
       element?.addEventListener('scroll', this.onDotsScrollEvent, { passive: true });
     });
 
-    // Full remount (loading shell) starts from timeBucket; quiet slide refreshes keep featured.
+    // Full remount (loading shell) starts on the first curated/featured slide;
+    // quiet slide refreshes keep the currently featured episode when possible.
     effect(() => {
       const slides = this.slides();
-      const bucket = this.timeBucket();
       const n = slides.length;
       if (n === 0) {
         this.hasInitializedIndex = false;
@@ -181,7 +179,7 @@ export class HomepageHeroComponent {
       this.lastSlideSignature = signature;
 
       if (!this.hasInitializedIndex) {
-        this.heroIndex.set(bucket % n);
+        this.heroIndex.set(0);
         this.hasInitializedIndex = true;
       } else {
         const keep = this.lastFeaturedId


### PR DESCRIPTION
## Summary
- Always open the homepage hero on the first curated/featured slide instead of a time-bucket offset.
- Restore hero-dash click and horizontal scroll by ignoring pointer events on full-bleed stage layers and enlarging dash hit targets.

## Test plan
- [ ] Hard-reload homepage — first hero slide is the first curated/featured item
- [ ] Click hero dashes to jump slides
- [ ] Horizontally scrub the dash strip when there are many slides
- [ ] Prev/next chevrons still work; auto-advance still works
