### PR TITLE
fix(flix): episode release dates, podcast links, larger desktop rails

### DIFF
--- a/cultpodcasts/src/app/episode-poster/episode-poster.component.html
+++ b/cultpodcasts/src/app/episode-poster/episode-poster.component.html
@@ -66,10 +66,22 @@
     } @else {
     <span class="episode-poster__episode">{{ episode().episodeTitle }}</span>
     }
-    @if (showShow()) {
-    <span class="episode-poster__show">{{ displayCatalogName(episode().podcastName) }}</span>
-    }
   </a>
+  @if (showShow() || (showRelease() && releaseLabel())) {
+  <p class="episode-poster__byline">
+    @if (showShow()) {
+    <a class="episode-poster__show" [routerLink]="['/podcast', episode().podcastName]">
+      {{ displayCatalogName(episode().podcastName) }}
+    </a>
+    }
+    @if (showRelease() && releaseLabel(); as release) {
+    @if (showShow()) {
+    <span class="episode-poster__byline-dot" aria-hidden="true">&middot;</span>
+    }
+    <span class="episode-poster__release">{{ release }}</span>
+    }
+  </p>
+  }
   @if (subject(); as subject) {
   <app-subject-chip class="episode-poster__subject" [subject]="subject" />
   }

--- a/cultpodcasts/src/app/episode-poster/episode-poster.component.html
+++ b/cultpodcasts/src/app/episode-poster/episode-poster.component.html
@@ -49,11 +49,14 @@
     <mat-icon>{{ queued() ? 'playlist_add_check' : 'playlist_add' }}</mat-icon>
   </button>
   }
-  @if (languageBadge() || duration()) {
+  @if (languageBadge() || duration() || (showRelease() && releaseLabel())) {
   <div class="episode-poster__meta-badges">
     @if (languageBadge(); as lang) {
     <span class="episode-poster__badge episode-poster__badge--lang" [attr.title]="lang.label"
       [attr.aria-label]="lang.label">{{ lang.flag }}</span>
+    }
+    @if (showRelease() && releaseLabel(); as release) {
+    <span class="episode-poster__badge episode-poster__badge--release">{{ release }}</span>
     }
     @if (duration()) {
     <span class="episode-poster__badge episode-poster__badge--duration">{{ duration() }}</span>
@@ -67,19 +70,11 @@
     <span class="episode-poster__episode">{{ episode().episodeTitle }}</span>
     }
   </a>
-  @if (showShow() || (showRelease() && releaseLabel())) {
+  @if (showShow()) {
   <p class="episode-poster__byline">
-    @if (showShow()) {
     <a class="episode-poster__show" [routerLink]="['/podcast', episode().podcastName]">
       {{ displayCatalogName(episode().podcastName) }}
     </a>
-    }
-    @if (showRelease() && releaseLabel(); as release) {
-    @if (showShow()) {
-    <span class="episode-poster__byline-dot" aria-hidden="true">&middot;</span>
-    }
-    <span class="episode-poster__release">{{ release }}</span>
-    }
   </p>
   }
   @if (subject(); as subject) {

--- a/cultpodcasts/src/app/episode-poster/episode-poster.component.sass
+++ b/cultpodcasts/src/app/episode-poster/episode-poster.component.sass
@@ -234,6 +234,10 @@
     line-height: 1.25
     color: #fff
 
+// Result grids have wider cards and no date heading — give titles room to finish.
+:host-context(.browse-grid) .episode-poster__episode
+    -webkit-line-clamp: 4
+
 // Podcast name only — sits outside .episode-poster__titles so it can be its own
 // link (anchors cannot nest). Publication date lives on the action row instead.
 .episode-poster__byline

--- a/cultpodcasts/src/app/episode-poster/episode-poster.component.sass
+++ b/cultpodcasts/src/app/episode-poster/episode-poster.component.sass
@@ -49,6 +49,14 @@
 :host.episode-poster--wide .episode-poster__art
     aspect-ratio: 16 / 9
 
+// Result grids mix square podcast art with 16:9 thumbs in the same row. A shared
+// frame keeps row rhythm even; rails keep native aspect (they size width per type).
+:host-context(.browse-grid)
+    .episode-poster__art
+        aspect-ratio: 4 / 3
+    &.episode-poster--wide .episode-poster__art
+        aspect-ratio: 4 / 3
+
 .episode-poster__placeholder
     width: 100%
     height: 100%

--- a/cultpodcasts/src/app/episode-poster/episode-poster.component.sass
+++ b/cultpodcasts/src/app/episode-poster/episode-poster.component.sass
@@ -49,13 +49,12 @@
 :host.episode-poster--wide .episode-poster__art
     aspect-ratio: 16 / 9
 
-// Result grids mix square podcast art with 16:9 thumbs in the same row. A shared
-// frame keeps row rhythm even; rails keep native aspect (they size width per type).
-:host-context(.browse-grid)
-    .episode-poster__art
-        aspect-ratio: 4 / 3
-    &.episode-poster--wide .episode-poster__art
-        aspect-ratio: 4 / 3
+// Result grids: one shared frame so mixed square/wide sources don't break row rhythm.
+// (&.class under :host-context incorrectly becomes :host-context(.browse-grid.class).)
+:host-context(.browse-grid) .episode-poster__art,
+:host-context(.browse-grid).episode-poster--wide .episode-poster__art,
+:host-context(.browse-grid).episode-poster--square .episode-poster__art
+    aspect-ratio: 4 / 3
 
 .episode-poster__placeholder
     width: 100%

--- a/cultpodcasts/src/app/episode-poster/episode-poster.component.sass
+++ b/cultpodcasts/src/app/episode-poster/episode-poster.component.sass
@@ -120,7 +120,7 @@
     margin-top: 8px
     color: inherit
 
-// Lang then duration, flush right of Watch / queue on the action row.
+// Lang, release date, then duration — flush right of Watch / queue on the action row.
 .episode-poster__meta-badges
     display: inline-flex
     align-items: center
@@ -148,6 +148,12 @@
     font-weight: 400
     letter-spacing: 0
     background: transparent
+
+.episode-poster__badge--release
+    font-weight: 600
+    color: var(--nflx-muted, #b3b3b3)
+    background: transparent
+    padding: 3px 0
 
 .episode-poster__cta
     display: inline-flex
@@ -220,23 +226,19 @@
     line-height: 1.25
     color: #fff
 
-// Show link + publication date. Sits outside .episode-poster__titles so the
-// podcast name can be its own link (anchors cannot nest).
+// Podcast name only — sits outside .episode-poster__titles so it can be its own
+// link (anchors cannot nest). Publication date lives on the action row instead.
 .episode-poster__byline
     order: 1
-    display: flex
-    align-items: baseline
-    gap: 5px
+    display: block
     width: 100%
     min-width: 0
     margin: 2px 0 0
     font-size: 0.8rem
     color: var(--nflx-muted, #b3b3b3)
 
-.episode-poster__byline-dot
-    flex: 0 0 auto
-
 .episode-poster__show
+    display: block
     min-width: 0
     color: inherit
     text-decoration: none
@@ -248,10 +250,6 @@
         color: var(--nflx-text, #fff)
         text-decoration: underline
         outline: none
-
-.episode-poster__release
-    flex: 0 0 auto
-    font-variant-numeric: tabular-nums
 
 // Sits on its own line below the title/show block, which takes the full meta row.
 .episode-poster__subject

--- a/cultpodcasts/src/app/episode-poster/episode-poster.component.sass
+++ b/cultpodcasts/src/app/episode-poster/episode-poster.component.sass
@@ -49,13 +49,6 @@
 :host.episode-poster--wide .episode-poster__art
     aspect-ratio: 16 / 9
 
-// Result grids: one shared frame so mixed square/wide sources don't break row rhythm.
-// (&.class under :host-context incorrectly becomes :host-context(.browse-grid.class).)
-:host-context(.browse-grid) .episode-poster__art,
-:host-context(.browse-grid).episode-poster--wide .episode-poster__art,
-:host-context(.browse-grid).episode-poster--square .episode-poster__art
-    aspect-ratio: 4 / 3
-
 .episode-poster__placeholder
     width: 100%
     height: 100%

--- a/cultpodcasts/src/app/episode-poster/episode-poster.component.sass
+++ b/cultpodcasts/src/app/episode-poster/episode-poster.component.sass
@@ -49,6 +49,16 @@
 :host.episode-poster--wide .episode-poster__art
     aspect-ratio: 16 / 9
 
+// Browse grids: one wide frame for every card. Square podcast art sits centered
+// (pillarboxed) so rows stay even without cropping covers; YouTube thumbs still fill.
+:host-context(.browse-grid) .episode-poster__art,
+:host-context(.browse-grid).episode-poster--wide .episode-poster__art,
+:host-context(.browse-grid).episode-poster--square .episode-poster__art
+    aspect-ratio: 16 / 9
+
+:host-context(.browse-grid).episode-poster--square .episode-poster__art img
+    object-fit: contain
+
 .episode-poster__placeholder
     width: 100%
     height: 100%

--- a/cultpodcasts/src/app/episode-poster/episode-poster.component.sass
+++ b/cultpodcasts/src/app/episode-poster/episode-poster.component.sass
@@ -49,8 +49,8 @@
 :host.episode-poster--wide .episode-poster__art
     aspect-ratio: 16 / 9
 
-// Browse grids: one wide frame for every card. Square podcast art sits centered
-// (pillarboxed) so rows stay even without cropping covers; YouTube thumbs still fill.
+// Browse grids only: one wide frame for every card. Square podcast art sits
+// centered (pillarboxed). Rails keep native square vs 16:9 and match height via width.
 :host-context(.browse-grid) .episode-poster__art,
 :host-context(.browse-grid).episode-poster--wide .episode-poster__art,
 :host-context(.browse-grid).episode-poster--square .episode-poster__art

--- a/cultpodcasts/src/app/episode-poster/episode-poster.component.sass
+++ b/cultpodcasts/src/app/episode-poster/episode-poster.component.sass
@@ -214,12 +214,18 @@
         color: var(--nflx-accent, #e8a23a)
 
 .episode-poster__titles
+    // Own row below the action buttons — flex-basis 100% forces the wrap;
+    // width alone is not enough when align-items/shrink fight the line break.
     order: 1
+    flex: 0 0 100%
     display: block
     text-decoration: none
     color: inherit
     min-width: 0
-    width: 100%
+    max-width: 100%
+    // Don't let an oversized hit box cover the podcast link below.
+    height: fit-content
+    overflow: hidden
     &:hover .episode-poster__episode,
     &:focus-visible .episode-poster__episode
         text-decoration: underline
@@ -243,7 +249,10 @@
 // Podcast name only — sits outside .episode-poster__titles so it can be its own
 // link (anchors cannot nest). Publication date lives on the action row instead.
 .episode-poster__byline
-    order: 1
+    order: 2
+    flex: 0 0 100%
+    position: relative
+    z-index: 1
     display: block
     width: 100%
     min-width: 0
@@ -252,20 +261,22 @@
     color: var(--nflx-muted, #b3b3b3)
 
 .episode-poster__show
-    display: block
+    display: inline-block
+    max-width: 100%
     min-width: 0
     color: inherit
     text-decoration: none
     white-space: nowrap
     overflow: hidden
     text-overflow: ellipsis
+    vertical-align: bottom
     &:hover,
     &:focus-visible
         color: var(--nflx-text, #fff)
         text-decoration: underline
         outline: none
 
-// Sits on its own line below the title/show block, which takes the full meta row.
+// Sits on its own line below the title/show block.
 .episode-poster__subject
-    order: 2
+    order: 3
     margin-top: 2px

--- a/cultpodcasts/src/app/episode-poster/episode-poster.component.sass
+++ b/cultpodcasts/src/app/episode-poster/episode-poster.component.sass
@@ -220,14 +220,38 @@
     line-height: 1.25
     color: #fff
 
-.episode-poster__show
-    display: block
-    margin-top: 2px
+// Show link + publication date. Sits outside .episode-poster__titles so the
+// podcast name can be its own link (anchors cannot nest).
+.episode-poster__byline
+    order: 1
+    display: flex
+    align-items: baseline
+    gap: 5px
+    width: 100%
+    min-width: 0
+    margin: 2px 0 0
     font-size: 0.8rem
     color: var(--nflx-muted, #b3b3b3)
+
+.episode-poster__byline-dot
+    flex: 0 0 auto
+
+.episode-poster__show
+    min-width: 0
+    color: inherit
+    text-decoration: none
     white-space: nowrap
     overflow: hidden
     text-overflow: ellipsis
+    &:hover,
+    &:focus-visible
+        color: var(--nflx-text, #fff)
+        text-decoration: underline
+        outline: none
+
+.episode-poster__release
+    flex: 0 0 auto
+    font-variant-numeric: tabular-nums
 
 // Sits on its own line below the title/show block, which takes the full meta row.
 .episode-poster__subject

--- a/cultpodcasts/src/app/episode-poster/episode-poster.component.spec.ts
+++ b/cultpodcasts/src/app/episode-poster/episode-poster.component.spec.ts
@@ -42,12 +42,25 @@ describe('EpisodePosterComponent', () => {
   }
 
   it('hides the publication date unless showRelease is set', () => {
-    expect(query('.episode-poster__release')).toBeNull();
+    expect(query('.episode-poster__badge--release')).toBeNull();
 
     fixture.componentRef.setInput('showRelease', true);
     fixture.detectChanges();
 
-    expect(query('.episode-poster__release')?.textContent?.trim()).toBe('3 Nov 2019');
+    expect(query('.episode-poster__badge--release')?.textContent?.trim()).toBe('3 Nov 2019');
+  });
+
+  it('places the date on the action row before duration, not beside the podcast name', () => {
+    fixture.componentRef.setInput('showRelease', true);
+    fixture.detectChanges();
+
+    const badges = query('.episode-poster__meta-badges');
+    const release = badges?.querySelector('.episode-poster__badge--release');
+    const duration = badges?.querySelector('.episode-poster__badge--duration');
+    expect(release?.textContent?.trim()).toBe('3 Nov 2019');
+    expect(duration?.textContent?.trim()).toBe('1:00:00');
+    expect(release?.nextElementSibling).toBe(duration);
+    expect(query('.episode-poster__byline')?.textContent?.trim()).toBe('Show A');
   });
 
   it('still shows the date on podcast pages where the show name is hidden', () => {
@@ -56,8 +69,8 @@ describe('EpisodePosterComponent', () => {
     fixture.detectChanges();
 
     expect(query('.episode-poster__show')).toBeNull();
-    expect(query('.episode-poster__release')?.textContent?.trim()).toBe('3 Nov 2019');
-    expect(query('.episode-poster__byline-dot')).toBeNull();
+    expect(query('.episode-poster__byline')).toBeNull();
+    expect(query('.episode-poster__badge--release')?.textContent?.trim()).toBe('3 Nov 2019');
   });
 
   it('links the podcast name to that podcast page', () => {
@@ -72,8 +85,7 @@ describe('EpisodePosterComponent', () => {
     expect(title.querySelector('a')).toBeNull();
   });
 
-  it('omits the byline entirely when there is no show name and no usable date', () => {
-    fixture.componentRef.setInput('episode', ep({ release: undefined as unknown as Date }));
+  it('omits the byline entirely when the show name is hidden', () => {
     fixture.componentRef.setInput('showShow', false);
     fixture.componentRef.setInput('showRelease', true);
     fixture.detectChanges();

--- a/cultpodcasts/src/app/episode-poster/episode-poster.component.spec.ts
+++ b/cultpodcasts/src/app/episode-poster/episode-poster.component.spec.ts
@@ -1,0 +1,83 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { EpisodePosterComponent } from './episode-poster.component';
+import { SearchDisplayEpisode } from '../search-result-links';
+import { PlayerService } from '../player.service';
+
+function ep(overrides: Partial<SearchDisplayEpisode> = {}): SearchDisplayEpisode {
+  return {
+    id: 'a',
+    podcastName: 'Show A',
+    episodeTitle: 'Episode A',
+    episodeDescription: 'Desc A',
+    release: new Date('2019-11-03T12:00:00Z'),
+    duration: '01:00:00',
+    subjects: ['Subject A'],
+    youtube: new URL('https://www.youtube.com/watch?v=a'),
+    ...overrides,
+  } as SearchDisplayEpisode;
+}
+
+describe('EpisodePosterComponent', () => {
+  let fixture: ComponentFixture<EpisodePosterComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [EpisodePosterComponent],
+      providers: [
+        provideZonelessChangeDetection(),
+        provideRouter([]),
+        PlayerService,
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(EpisodePosterComponent);
+    fixture.componentRef.setInput('episode', ep());
+    fixture.detectChanges();
+  });
+
+  function query(selector: string): HTMLElement | null {
+    return fixture.nativeElement.querySelector(selector);
+  }
+
+  it('hides the publication date unless showRelease is set', () => {
+    expect(query('.episode-poster__release')).toBeNull();
+
+    fixture.componentRef.setInput('showRelease', true);
+    fixture.detectChanges();
+
+    expect(query('.episode-poster__release')?.textContent?.trim()).toBe('3 Nov 2019');
+  });
+
+  it('still shows the date on podcast pages where the show name is hidden', () => {
+    fixture.componentRef.setInput('showShow', false);
+    fixture.componentRef.setInput('showRelease', true);
+    fixture.detectChanges();
+
+    expect(query('.episode-poster__show')).toBeNull();
+    expect(query('.episode-poster__release')?.textContent?.trim()).toBe('3 Nov 2019');
+    expect(query('.episode-poster__byline-dot')).toBeNull();
+  });
+
+  it('links the podcast name to that podcast page', () => {
+    const show = query('.episode-poster__show') as HTMLAnchorElement | null;
+    expect(show?.textContent?.trim()).toBe('Show A');
+    expect(show?.getAttribute('href')).toBe('/podcast/Show%20A');
+  });
+
+  it('keeps the podcast link outside the episode link so neither anchor nests', () => {
+    const title = query('.episode-poster__titles') as HTMLAnchorElement;
+    expect(title.getAttribute('href')).toBe('/podcast/Show%20A/a');
+    expect(title.querySelector('a')).toBeNull();
+  });
+
+  it('omits the byline entirely when there is no show name and no usable date', () => {
+    fixture.componentRef.setInput('episode', ep({ release: undefined as unknown as Date }));
+    fixture.componentRef.setInput('showShow', false);
+    fixture.componentRef.setInput('showRelease', true);
+    fixture.detectChanges();
+
+    expect(query('.episode-poster__byline')).toBeNull();
+  });
+});

--- a/cultpodcasts/src/app/episode-poster/episode-poster.component.spec.ts
+++ b/cultpodcasts/src/app/episode-poster/episode-poster.component.spec.ts
@@ -79,10 +79,16 @@ describe('EpisodePosterComponent', () => {
     expect(show?.getAttribute('href')).toBe('/podcast/Show%20A');
   });
 
-  it('keeps the podcast link outside the episode link so neither anchor nests', () => {
+  it('keeps the podcast link after the title with its own flex order so title hover cannot cover it', () => {
+    const show = query('.episode-poster__show') as HTMLAnchorElement;
     const title = query('.episode-poster__titles') as HTMLAnchorElement;
+    const byline = query('.episode-poster__byline') as HTMLElement;
+
     expect(title.getAttribute('href')).toBe('/podcast/Show%20A/a');
     expect(title.querySelector('a')).toBeNull();
+    expect(title.contains(show)).toBe(false);
+    expect(getComputedStyle(title).order).toBe('1');
+    expect(getComputedStyle(byline).order).toBe('2');
   });
 
   it('omits the byline entirely when the show name is hidden', () => {

--- a/cultpodcasts/src/app/episode-poster/episode-poster.component.ts
+++ b/cultpodcasts/src/app/episode-poster/episode-poster.component.ts
@@ -31,8 +31,8 @@ export class EpisodePosterComponent {
   /** Show podcast name under the title (hide on podcast pages). */
   readonly showShow = input(true);
   /**
-   * Show the publication date under the title. Off by default: date-grouped rails
-   * already state it in their heading, where repeating it per card is noise.
+   * Show the publication date on the action row (before duration). Off by default:
+   * date-grouped rails already state it in their heading.
    */
   readonly showRelease = input(false);
   /** Search hit titles may contain highlight markup. */

--- a/cultpodcasts/src/app/episode-poster/episode-poster.component.ts
+++ b/cultpodcasts/src/app/episode-poster/episode-poster.component.ts
@@ -5,6 +5,7 @@ import { canPlayEpisode, playActionLabel } from '../episode-embed';
 import { languageFlagBadgeForEpisode, LanguageFlagBadge } from '../language-flag';
 import { SearchDisplayEpisode, episodeArtAspect, episodeImageUrl } from '../search-result-links';
 import { displayCatalogName } from '../display-catalog-name';
+import { releaseDateLabel } from '../release-label';
 import { pickCardSubject } from '../card-subject';
 import { SubjectChipComponent } from '../subject-chip/subject-chip.component';
 import { PlayerService } from '../player.service';
@@ -29,6 +30,11 @@ export class EpisodePosterComponent {
   readonly playing = input(false);
   /** Show podcast name under the title (hide on podcast pages). */
   readonly showShow = input(true);
+  /**
+   * Show the publication date under the title. Off by default: date-grouped rails
+   * already state it in their heading, where repeating it per card is noise.
+   */
+  readonly showRelease = input(false);
   /** Search hit titles may contain highlight markup. */
   readonly titleAsHtml = input(false);
   /** Subject-scoped views pass their own subject so the card's chip adds new information. */
@@ -67,6 +73,10 @@ export class EpisodePosterComponent {
 
   protected readonly languageBadge = computed((): LanguageFlagBadge | undefined =>
     languageFlagBadgeForEpisode(this.episode())
+  );
+
+  protected readonly releaseLabel = computed(() =>
+    releaseDateLabel(this.episode().release)
   );
 
   /** One subject per card so a title alone doesn't have to explain what the episode is about. */

--- a/cultpodcasts/src/app/episode-rail/episode-rail.component.sass
+++ b/cultpodcasts/src/app/episode-rail/episode-rail.component.sass
@@ -125,11 +125,11 @@
 
 @media screen and (min-width: 900px)
     .rail-poster
-        width: var(--rail-poster-w, 260px)
-        flex-basis: var(--rail-poster-w, 260px)
+        width: var(--rail-poster-w, 320px)
+        flex-basis: var(--rail-poster-w, 320px)
         &.episode-poster--square
-            width: var(--rail-poster-sq, 180px)
-            flex-basis: var(--rail-poster-sq, 180px)
+            width: var(--rail-poster-sq, 220px)
+            flex-basis: var(--rail-poster-sq, 220px)
 
 @media screen and (max-width: 600px)
     .rail-poster

--- a/cultpodcasts/src/app/episode-rail/episode-rail.component.sass
+++ b/cultpodcasts/src/app/episode-rail/episode-rail.component.sass
@@ -116,25 +116,27 @@
     min-height: calc(var(--rail-poster-w, min(42vw, 220px)) * 9 / 16 + 3.5rem)
     margin: 0 4vw
 
+// Wide posters use --rail-poster-w at 16:9. Square posters stay 1:1 but use the
+// wide poster's height as their width so every card in the rail is the same height.
 .rail-poster
     width: var(--rail-poster-w, min(42vw, 220px))
     flex: 0 0 var(--rail-poster-w, min(42vw, 220px))
     &.episode-poster--square
-        width: var(--rail-poster-sq, min(32vw, 160px))
-        flex-basis: var(--rail-poster-sq, min(32vw, 160px))
+        width: calc(var(--rail-poster-w, min(42vw, 220px)) * 9 / 16)
+        flex-basis: calc(var(--rail-poster-w, min(42vw, 220px)) * 9 / 16)
 
 @media screen and (min-width: 900px)
     .rail-poster
         width: var(--rail-poster-w, 320px)
         flex-basis: var(--rail-poster-w, 320px)
         &.episode-poster--square
-            width: var(--rail-poster-sq, 220px)
-            flex-basis: var(--rail-poster-sq, 220px)
+            width: calc(var(--rail-poster-w, 320px) * 9 / 16)
+            flex-basis: calc(var(--rail-poster-w, 320px) * 9 / 16)
 
 @media screen and (max-width: 600px)
     .rail-poster
         width: var(--rail-poster-w, 68vw)
         flex-basis: var(--rail-poster-w, 68vw)
         &.episode-poster--square
-            width: var(--rail-poster-sq, 48vw)
-            flex-basis: var(--rail-poster-sq, 48vw)
+            width: calc(var(--rail-poster-w, 68vw) * 9 / 16)
+            flex-basis: calc(var(--rail-poster-w, 68vw) * 9 / 16)

--- a/cultpodcasts/src/app/homepage-api/homepage-api.component.sass
+++ b/cultpodcasts/src/app/homepage-api/homepage-api.component.sass
@@ -56,8 +56,9 @@
 
 @media screen and (min-width: 900px)
     .nflx
-        --rail-poster-w: 260px
-        --rail-poster-sq: 180px
+        // Larger than mobile peek cards so desktop rails read as poster art, not thumbnails.
+        --rail-poster-w: 320px
+        --rail-poster-sq: 220px
         --obscure-card-w: 180px
         --obscure-yt-w: 260px
 

--- a/cultpodcasts/src/app/homepage-discover-rail/homepage-discover-rail.component.sass
+++ b/cultpodcasts/src/app/homepage-discover-rail/homepage-discover-rail.component.sass
@@ -49,8 +49,10 @@
 
 .obscure__card
     display: block
-    width: var(--obscure-card-w, min(42vw, 168px))
-    flex: 0 0 var(--obscure-card-w, min(42vw, 168px))
+    // Match YouTube card art height: wide is --obscure-yt-w at 16:9, so square
+    // width = that height while keeping aspect-ratio 1.
+    width: calc(var(--obscure-yt-w, min(55vw, 240px)) * 9 / 16)
+    flex: 0 0 calc(var(--obscure-yt-w, min(55vw, 240px)) * 9 / 16)
     text-decoration: none
     color: inherit
     scroll-snap-align: start

--- a/cultpodcasts/src/app/podcast-api/podcast-api.component.html
+++ b/cultpodcasts/src/app/podcast-api/podcast-api.component.html
@@ -79,7 +79,7 @@
     @for (result of results(); track result.id) {
     <app-episode-poster [episode]="result" [playing]="isPlayingId(result.id)"
       [queued]="isQueuedId(result.id)" [showShow]="false" [titleAsHtml]="true"
-      (play)="playEpisode($event)" />
+      [showRelease]="true" (play)="playEpisode($event)" />
     }
   </div>
 

--- a/cultpodcasts/src/app/podcast-episode/podcast-episode.component.ts
+++ b/cultpodcasts/src/app/podcast-episode/podcast-episode.component.ts
@@ -22,6 +22,7 @@ import { PostEpisodeDialogResponse } from '../post-episode-dialog-response.inter
 import { EpisodePublishResponseSnackbarComponent } from '../episode-publish-response-snackbar/episode-publish-response-snackbar.component';
 import { SearchDescriptionPipe } from '../search-description.pipe';
 import { displayCatalogName } from '../display-catalog-name';
+import { releaseDateLabel } from '../release-label';
 import { SearchDisplayEpisode, episodeImageUrl } from '../search-result-links';
 import { canPlayEpisode, playActionLabel } from '../episode-embed';
 import { PlayerService } from '../player.service';
@@ -116,21 +117,9 @@ export class PodcastEpisodeComponent {
   });
 
   /** Locale-safe release label (avoids DatePipe/locale hydration issues). */
-  protected readonly releaseLabel = computed(() => {
-    const release = this._episode()?.release;
-    if (!release) {
-      return undefined;
-    }
-    const date = release instanceof Date ? release : new Date(release);
-    if (Number.isNaN(date.getTime())) {
-      return undefined;
-    }
-    return date.toLocaleDateString('en-GB', {
-      day: 'numeric',
-      month: 'short',
-      year: 'numeric'
-    });
-  });
+  protected readonly releaseLabel = computed(() =>
+    releaseDateLabel(this._episode()?.release)
+  );
 
   protected readonly backdropUrl = computed(() => {
     const ep = this._episode();

--- a/cultpodcasts/src/app/release-label.spec.ts
+++ b/cultpodcasts/src/app/release-label.spec.ts
@@ -1,0 +1,22 @@
+import { releaseDateLabel } from './release-label';
+
+describe('releaseDateLabel', () => {
+  it('formats a Date as day, short month, year', () => {
+    expect(releaseDateLabel(new Date('2026-07-17T09:30:00Z'))).toBe('17 Jul 2026');
+  });
+
+  it('formats an ISO string the same as the equivalent Date', () => {
+    const iso = '2019-11-03T12:00:00Z';
+    expect(releaseDateLabel(iso)).toBe(releaseDateLabel(new Date(iso)));
+  });
+
+  it('keeps day-before-month ordering regardless of the runtime locale', () => {
+    // en-US default would render "Jul 7, 2026" and read as 7 November when re-parsed.
+    expect(releaseDateLabel(new Date(2026, 6, 7))).toBe('7 Jul 2026');
+  });
+
+  it('returns undefined for a missing or unparseable release', () => {
+    expect(releaseDateLabel(undefined)).toBeUndefined();
+    expect(releaseDateLabel('not-a-date')).toBeUndefined();
+  });
+});

--- a/cultpodcasts/src/app/release-label.ts
+++ b/cultpodcasts/src/app/release-label.ts
@@ -1,0 +1,21 @@
+/**
+ * Human-readable publication date for an episode (e.g. `17 Jul 2026`).
+ *
+ * The locale is pinned rather than left to the runtime default: server-side
+ * rendering commonly resolves to `en-US` while a UK browser resolves to
+ * `en-GB`, and the differing token order would produce a hydration mismatch.
+ */
+export function releaseDateLabel(release: Date | string | undefined): string | undefined {
+  if (!release) {
+    return undefined;
+  }
+  const date = release instanceof Date ? release : new Date(release);
+  if (Number.isNaN(date.getTime())) {
+    return undefined;
+  }
+  return date.toLocaleDateString('en-GB', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric'
+  });
+}

--- a/cultpodcasts/src/app/search-api/search-api.component.html
+++ b/cultpodcasts/src/app/search-api/search-api.component.html
@@ -68,7 +68,8 @@
   <div class="browse-grid">
     @for (result of results(); track result.id) {
     <app-episode-poster [episode]="result" [playing]="isPlayingId(result.id)"
-      [queued]="isQueuedId(result.id)" [titleAsHtml]="true" (play)="playEpisode($event)" />
+      [queued]="isQueuedId(result.id)" [titleAsHtml]="true" [showRelease]="true"
+      (play)="playEpisode($event)" />
     }
   </div>
 

--- a/cultpodcasts/src/app/search-result-links.spec.ts
+++ b/cultpodcasts/src/app/search-result-links.spec.ts
@@ -68,6 +68,42 @@ describe("search-result-links", () => {
     expect(episodeArtAspect(homepageYt)).toBe("wide");
   });
 
+  it("prefers a YouTube thumbnail when the index stored square cover but the episode is watchable", () => {
+    const watchWithSpotifyArt: SearchResult = {
+      ...searchResult,
+      image: "sab6765cover",
+      youtubeId: "ytWatchable1",
+    };
+    expect(episodeImageUrl(watchWithSpotifyArt)?.toString())
+      .toBe("https://i.ytimg.com/vi/ytWatchable1/hqdefault.jpg");
+    expect(episodeArtAspect(watchWithSpotifyArt)).toBe("wide");
+
+    const homepageWatch: HomepageEpisode = {
+      id: "id",
+      podcastName: "Podcast",
+      episodeTitle: "Title",
+      episodeDescription: "Description",
+      release: new Date("2026-07-17T00:00:00Z"),
+      duration: "00:01:02",
+      spotify: undefined,
+      apple: undefined,
+      youtube: new URL("https://www.youtube.com/watch?v=homeYt99"),
+      bbc: undefined,
+      internetArchive: undefined,
+      subjects: [],
+      image: new URL("https://i.scdn.co/image/opaque"),
+    };
+    expect(episodeImageUrl(homepageWatch)?.toString())
+      .toBe("https://i.ytimg.com/vi/homeYt99/hqdefault.jpg");
+    expect(episodeArtAspect(homepageWatch)).toBe("wide");
+  });
+
+  it("keeps indexed YouTube quality tokens instead of replacing with hqdefault", () => {
+    const probed: SearchResult = { ...searchResult, image: "ys", youtubeId: "probedVid" };
+    expect(episodeImageUrl(probed)?.toString())
+      .toBe("https://i.ytimg.com/vi/probedVid/sddefault.jpg");
+  });
+
   it("keeps opaque homepage URLs unchanged", () => {
     const homepage: HomepageEpisode = {
       id: "id",

--- a/cultpodcasts/src/app/search-result-links.ts
+++ b/cultpodcasts/src/app/search-result-links.ts
@@ -33,10 +33,51 @@ export function appleUrl(episode: SearchDisplayEpisode): URL | undefined {
 export function episodeImageUrl(episode: SearchDisplayEpisode): URL | undefined {
   // Homepage episodes come from a feed that always carries full image URLs.
   if (isHomepageEpisode(episode)) {
-    return toUrl(episode.image);
+    const image = toUrl(episode.image);
+    if (isYoutubeThumbnailUrl(image)) {
+      return image;
+    }
+    // Prefer a YouTube frame when the episode is watchable — feed art is often square
+    // podcast cover even for video episodes.
+    const ytId = youtubeIdFromWatchUrl(toUrl(episode.youtube));
+    return ytId ? youtubeThumbnailUrl(ytId) : image;
   }
 
+  // Search index may store Spotify/Apple cover as `image` even when `youtubeId` is set
+  // (Watch CTA). Show the video frame so Watch cards don't look like audio squares.
+  if (isYoutubeThumbnailUrl(episode.image)) {
+    return expandImage(episode.image, episode.youtubeId);
+  }
+  if (episode.youtubeId) {
+    return youtubeThumbnailUrl(episode.youtubeId);
+  }
   return expandImage(episode.image, episode.youtubeId);
+}
+
+function youtubeThumbnailUrl(youtubeId: string): URL | undefined {
+  return toUrl(`https://i.ytimg.com/vi/${encodeURIComponent(youtubeId)}/hqdefault.jpg`);
+}
+
+function youtubeIdFromWatchUrl(url: URL | undefined): string | undefined {
+  if (!url) {
+    return undefined;
+  }
+  const host = url.hostname.replace(/^www\./, '');
+  if (host === 'youtu.be') {
+    const id = url.pathname.split('/').filter(Boolean)[0];
+    return id || undefined;
+  }
+  if (host === 'youtube.com' || host === 'm.youtube.com' || host === 'music.youtube.com') {
+    const v = url.searchParams.get('v');
+    if (v) {
+      return v;
+    }
+    const parts = url.pathname.split('/').filter(Boolean);
+    if (parts[0] === 'embed' || parts[0] === 'shorts' || parts[0] === 'live') {
+      return parts[1] || undefined;
+    }
+  }
+  return undefined;
 }
 
 const youtubeQualityByCode: Record<string, string> = {

--- a/cultpodcasts/src/app/subject-api/subject-api.component.html
+++ b/cultpodcasts/src/app/subject-api/subject-api.component.html
@@ -92,7 +92,7 @@
     @for (result of results(); track result.id) {
     <app-episode-poster [episode]="result" [excludeSubject]="subjectName()"
       [playing]="isPlayingId(result.id)" [queued]="isQueuedId(result.id)" [titleAsHtml]="true"
-      (play)="playEpisode($event)" />
+      [showRelease]="true" (play)="playEpisode($event)" />
     }
   </div>
 

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -1067,9 +1067,16 @@ option {
 }
 
 @media screen and (min-width: 900px) {
+  /* Match the desktop rail poster scale so cover art reads as artwork, not thumbnails. */
   .browse-grid {
-    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-    gap: 22px 16px;
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+    gap: 26px 18px;
+  }
+}
+
+@media screen and (min-width: 1500px) {
+  .browse-grid {
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
   }
 }
 

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -1067,16 +1067,16 @@ option {
 }
 
 @media screen and (min-width: 900px) {
-  /* Match the desktop rail poster scale so cover art reads as artwork, not thumbnails. */
+  /* Larger than mobile, but not so large that a typical desktop collapses to 3 columns. */
   .browse-grid {
-    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
-    gap: 26px 18px;
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    gap: 24px 16px;
   }
 }
 
 @media screen and (min-width: 1500px) {
   .browse-grid {
-    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
   }
 }
 


### PR DESCRIPTION
## Summary
- Show publication date on episode cards in podcast, subject, and search result grids so older episodes are obvious
- Make the podcast name on subject/search cards a link to `/podcast/...` (split out of the episode title link so anchors do not nest)
- Enlarge desktop rail posters to 320px wide / 220px square (mobile unchanged)

## Test plan
- [ ] Podcast page: each episode card shows a date under the title (no podcast name)
- [ ] Subject + search pages: date shown; podcast name is clickable and navigates to that show
- [ ] Homepage / episode-detail rails: no per-card date (date still in rail headings); desktop posters visibly larger
- [ ] `ng test --include=''**/{episode-poster,release-label}*.spec.ts''` green