### PR TITLE
flix: rebuild bookmarks page and complete first browse row

### DIFF
--- a/cultpodcasts/src/app/api-episode-display.spec.ts
+++ b/cultpodcasts/src/app/api-episode-display.spec.ts
@@ -1,0 +1,40 @@
+import { ApiEpisode } from './api-episode.interface';
+import { apiEpisodeToHomepageEpisode } from './api-episode-display';
+
+describe('apiEpisodeToHomepageEpisode', () => {
+  it('maps API episode fields into the shared poster display shape', () => {
+    const episode = {
+      id: 'ep-1',
+      title: 'Raw Title',
+      displayTitle: 'Display Title',
+      podcastName: 'Show Name',
+      description: 'Raw description',
+      displayDescription: 'Display description',
+      posted: true,
+      tweeted: false,
+      ignored: false,
+      removed: false,
+      explicit: false,
+      release: new Date('2024-01-02T12:00:00Z'),
+      duration: '01:02:03',
+      urls: {
+        spotify: new URL('https://open.spotify.com/episode/abc'),
+        youtube: new URL('https://www.youtube.com/watch?v=xyz'),
+      },
+      subjects: ['Subject A'],
+      image: new URL('https://i.ytimg.com/vi/xyz/hqdefault.jpg'),
+      lang: 'es',
+    } as ApiEpisode;
+
+    const display = apiEpisodeToHomepageEpisode(episode);
+
+    expect(display.id).toBe('ep-1');
+    expect(display.episodeTitle).toBe('Display Title');
+    expect(display.episodeDescription).toBe('Display description');
+    expect(display.podcastName).toBe('Show Name');
+    expect(display.spotify?.toString()).toBe('https://open.spotify.com/episode/abc');
+    expect(display.youtube?.toString()).toBe('https://www.youtube.com/watch?v=xyz');
+    expect(display.language).toBe('es');
+    expect(display.image?.toString()).toBe('https://i.ytimg.com/vi/xyz/hqdefault.jpg');
+  });
+});

--- a/cultpodcasts/src/app/api-episode-display.ts
+++ b/cultpodcasts/src/app/api-episode-display.ts
@@ -1,0 +1,27 @@
+import { ApiEpisode } from './api-episode.interface';
+import { HomepageEpisode } from './homepage-episode.interface';
+import { toUrl } from './search-result-links';
+
+/** Map a public API episode into the shared poster / player display shape. */
+export function apiEpisodeToHomepageEpisode(episode: ApiEpisode): HomepageEpisode {
+  return {
+    id: episode.id,
+    podcastName: episode.podcastName ?? '',
+    episodeTitle: episode.displayTitle ?? episode.title,
+    episodeDescription: episode.displayDescription ?? episode.description,
+    release: episode.release,
+    duration: episode.duration,
+    spotify: toUrl(episode.urls?.spotify),
+    apple: toUrl(episode.urls?.apple),
+    youtube: toUrl(episode.urls?.youtube),
+    bbc: toUrl(episode.urls?.bbc),
+    internetArchive: toUrl(episode.urls?.internetArchive),
+    subjects: episode.subjects,
+    image: episode.image
+      ?? toUrl(episode.images?.youtube ?? undefined)
+      ?? toUrl(episode.images?.spotify ?? undefined)
+      ?? toUrl(episode.images?.apple ?? undefined)
+      ?? toUrl(episode.images?.other ?? undefined),
+    language: episode.lang ?? undefined,
+  };
+}

--- a/cultpodcasts/src/app/bookmark-api/bookmark-api.component.sass
+++ b/cultpodcasts/src/app/bookmark-api/bookmark-api.component.sass
@@ -16,3 +16,27 @@
     :host.has-menu
         .mdc-icon-button
             margin-right: 36px
+
+:host.bookmark-overlay
+    .mdc-icon-button
+        position: static
+        top: auto
+        right: auto
+        margin: 0
+        width: 36px
+        height: 36px
+        padding: 0
+        border: 1px solid rgba(255, 255, 255, 0.35)
+        border-radius: 50%
+        background: rgba(26, 26, 26, 0.9)
+        color: #fff
+        mat-icon
+            color: inherit
+        &:hover,
+        &:focus-visible
+            background: rgba(255, 255, 255, 0.15)
+            border-color: var(--nflx-accent, #e8a23a)
+            outline: none
+:host.bookmark-overlay.has-menu
+    .mdc-icon-button
+        margin-right: 0

--- a/cultpodcasts/src/app/bookmark-api/bookmark-api.component.ts
+++ b/cultpodcasts/src/app/bookmark-api/bookmark-api.component.ts
@@ -29,6 +29,8 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 export class BookmarkApiComponent implements OnInit {
   episodeId = input.required<string>();
   hasMenu = input<boolean>(false);
+  /** Circular dark control for flix poster overlays (bookmarks grid). */
+  overlay = input(false);
   protected readonly waitingCallback = signal(true);
   protected readonly bookmarkTimeout = signal(false);
   protected readonly isAuthenticated = toSignal(
@@ -48,6 +50,9 @@ export class BookmarkApiComponent implements OnInit {
 
   @HostBinding('class.has-menu')
   get hasMenuGet() { return this.hasMenu(); }
+
+  @HostBinding('class.bookmark-overlay')
+  get overlayGet() { return this.overlay(); }
 
   constructor() {
     setTimeout(() => this.bookmarkTimeout.set(true), 5000);

--- a/cultpodcasts/src/app/bookmark/bookmark.component.html
+++ b/cultpodcasts/src/app/bookmark/bookmark.component.html
@@ -1,5 +1,5 @@
 @defer {
-<app-bookmark-api [episodeId]="episodeId()" [hasMenu]="hasMenu()" />
+<app-bookmark-api [episodeId]="episodeId()" [hasMenu]="hasMenu()" [overlay]="overlay()" />
 } @error {
   <span></span>
 }

--- a/cultpodcasts/src/app/bookmark/bookmark.component.ts
+++ b/cultpodcasts/src/app/bookmark/bookmark.component.ts
@@ -11,4 +11,5 @@ import { BookmarkApiComponent } from '../bookmark-api/bookmark-api.component';
 export class BookmarkComponent {
   episodeId = input.required<string>();
   hasMenu = input<boolean>(false);
+  overlay = input(false);
 }

--- a/cultpodcasts/src/app/bookmarks-api/bookmarks-api.component.html
+++ b/cultpodcasts/src/app/bookmarks-api/bookmarks-api.component.html
@@ -1,106 +1,84 @@
-<section id="results">
-    <div id="progresswrapper">
-        @if (isLoading()) {
-        <mat-progress-bar mode="indeterminate"></mat-progress-bar>
-        }
-    </div>
-    @if (!isLoading() && error()) {
-    <ng-container>
-        <p id="error">
-            An error occurred.
-        </p>
-    </ng-container>
-    }
-    @if (!isLoading() && removedEpisodesNotice()) {
-    <ng-container>
-        <p id="removed-episodes-notice">
-            {{ removedEpisodesMessage }}
-        </p>
-    </ng-container>
-    }
-    <section id="resultsheading">
-        <h2>Bookmarks</h2>
-        @if (!isLoading() && !error()) {
-        <button id="sort" mat-icon-button [matMenuTriggerFor]="sort">
-            <mat-icon>more_vert</mat-icon>
-        </button>
-        }
-        <mat-menu #sort="matMenu">
-            <button mat-menu-item id="dateaddedasc" (click)="setSort(sortMode.addDatedAsc)"
-                [class.selected]="sortDirection()==sortMode.addDatedAsc">
-                <mat-icon>arrow_upward</mat-icon>
-                <span>Date Bookmarked</span>
-            </button>
-            <button mat-menu-item id="dateaddeddesc" (click)="setSort(sortMode.addDatedDesc)"
-                [class.selected]="sortDirection()==sortMode.addDatedDesc">
-                <mat-icon>arrow_downward</mat-icon>
-                <span>Date Bookmarked Descending</span>
-            </button>
+<app-site-loading [active]="isLoading() || isSubsequentLoading()"
+  [label]="isSubsequentLoading() ? 'Loading more bookmarks' : 'Loading bookmarks'" />
 
-        </mat-menu>
-    </section>
-    @if (!isLoading() && noBookmarks()) {
-    <p>You have no bookmarks. Use the <mat-icon class="material-symbols-outlined">bookmark</mat-icon> icon to save your
-        favourites.</p>
-    }
-
-    @for (result of episodes() ; track result.id){
-    <mat-card class="result">
-        <mat-card-header>
-            <app-bookmark [episodeId]="result.id" [hasMenu]="authRoles().includes('Curator')" />
-            @if (authRoles().includes("Curator") && result.podcastName) {
-            <button mat-icon-button [matMenuTriggerFor]="menu">
-                <mat-icon>more_vert</mat-icon>
-            </button>
-            <mat-menu #menu="matMenu">
-                <button mat-menu-item (click)="edit(result.podcastId!, result.id)">
-                    <mat-icon>edit</mat-icon>
-                    <span>Edit Episode</span>
-                </button>
-                <button mat-menu-item (click)="post(result.podcastId!, result.id)">
-                    <mat-icon>send</mat-icon>
-                    <span>Post Episode</span>
-                </button>
-            </mat-menu>
-            }
-            <mat-card-title [class.hasMenu]="authRoles().includes('Curator')" [class.hasBookmark]="isSignedIn()">
-                <a [routerLink]="['/podcast', result.podcastName, result.id]"><span
-                        [outerHTML]="result.title"></span></a>
-            </mat-card-title>
-            <mat-card-subtitle>
-                <a [routerLink]="['/podcast', result.podcastName]">
-                    {{result.podcastName}}
-                </a>
-            </mat-card-subtitle>
-            <mat-card-subtitle>{{result.release | date:'d MMM yyyy H:mm'}}
-                @if (result.duration) {
-                [{{result.duration.startsWith("0")?result.duration.split(".")[0].substring(1):result.duration.split(".")[0]}}]
-                }
-            </mat-card-subtitle>
-        </mat-card-header>
-        <mat-card-content class="resultdescription">
-            <app-episode-image [apiEpisode]="result" [linksOverlay]="true"></app-episode-image>
-            <p>{{result.description}}</p>
-        </mat-card-content>
-        <mat-card-actions>
-            <app-episode-podcast-links [episode]="result"></app-episode-podcast-links>
-            <mat-card-footer class="subjects">
-                <app-subjects [subjects]="result.subjects"></app-subjects>
-            </mat-card-footer>
-        </mat-card-actions>
-    </mat-card>
-    }
-    @if (isSubsequentLoading()) {
-    <div class="progresswrapper">
-        <mat-progress-bar mode="indeterminate"></mat-progress-bar>
-    </div>
-    }
+@if (!isLoading() && error() && displayEpisodes().length === 0) {
+<section class="browse-error">
+  <h2>An error occurred.</h2>
+  <div id="cta-button">
+    <button mat-flat-button color="primary" (click)="populatePage()">Try again</button>
+  </div>
 </section>
-
-@if (!isLoading() && error()) {
-<ng-container>
-    <div id="cta-button">
-        <button mat-flat-button color="primary" (click)="ngOnInit()">Try again</button>
+} @else if (!isLoading() && noBookmarks()) {
+<section class="browse-empty">
+  <h2>You have no bookmarks</h2>
+  <p>Use the <mat-icon class="material-symbols-outlined">bookmark</mat-icon> icon to save your favourites.</p>
+</section>
+} @else {
+<section class="browse" [class.browse--playing]="!!playerService.episode() && playerService.mode() === 'dock'"
+  [class.is-updating]="isLoading() && displayEpisodes().length > 0" id="results">
+  <div class="browse-filters">
+    <div class="browse-toolbar">
+      <h2>{{ resultsHeading() }}</h2>
+      @if (!isLoading() && !error() && !noBookmarks()) {
+      <button type="button" class="browse-sort" [matMenuTriggerFor]="sort" id="sort">
+        {{ sortLabel() }}
+        <mat-icon>arrow_drop_down</mat-icon>
+      </button>
+      }
+      <mat-menu #sort="matMenu">
+        <button mat-menu-item id="dateaddeddesc" (click)="setSort(sortMode.addDatedDesc)"
+          [class.selected]="sortDirection()==sortMode.addDatedDesc">
+          <span>Newest bookmarked</span>
+        </button>
+        <button mat-menu-item id="dateaddedasc" (click)="setSort(sortMode.addDatedAsc)"
+          [class.selected]="sortDirection()==sortMode.addDatedAsc">
+          <span>Oldest bookmarked</span>
+        </button>
+      </mat-menu>
     </div>
-</ng-container>
+
+    @if (!isLoading() && removedEpisodesNotice()) {
+    <p class="bookmarks-notice">{{ removedEpisodesMessage }}</p>
+    }
+    @if (!isLoading() && error() && displayEpisodes().length > 0) {
+    <p class="bookmarks-notice bookmarks-notice--error">Some bookmarks could not be loaded.</p>
+    }
+  </div>
+
+  <div class="browse-grid">
+    @for (result of displayEpisodes(); track result.id; let i = $index) {
+    <div class="bookmarks-cell">
+      <div class="bookmarks-cell__actions">
+        <app-bookmark [episodeId]="result.id" [hasMenu]="authRoles().includes('Curator')" [overlay]="true" />
+        @if (authRoles().includes('Curator') && episodes()[i]?.podcastName) {
+        <button type="button" mat-icon-button class="bookmarks-cell__menu" [matMenuTriggerFor]="menu"
+          aria-label="Episode actions">
+          <mat-icon>more_vert</mat-icon>
+        </button>
+        <mat-menu #menu="matMenu">
+          <button mat-menu-item (click)="edit(episodes()[i].podcastId!, result.id)">
+            <mat-icon>edit</mat-icon>
+            <span>Edit Episode</span>
+          </button>
+          <button mat-menu-item (click)="post(episodes()[i].podcastId!, result.id)">
+            <mat-icon>send</mat-icon>
+            <span>Post Episode</span>
+          </button>
+        </mat-menu>
+        }
+      </div>
+      <app-episode-poster [episode]="result" [playing]="isPlayingId(result.id)"
+        [queued]="isQueuedId(result.id)" [showRelease]="true"
+        (play)="playEpisode($event)" />
+    </div>
+    }
+  </div>
+
+  @if (isSubsequentLoading()) {
+  <div class="browse-more" aria-hidden="true">
+    <div class="browse-more__dots"><span></span><span></span><span></span></div>
+    Loading more
+  </div>
+  }
+</section>
 }

--- a/cultpodcasts/src/app/bookmarks-api/bookmarks-api.component.sass
+++ b/cultpodcasts/src/app/bookmarks-api/bookmarks-api.component.sass
@@ -1,59 +1,52 @@
-#progresswrapper,.progresswrapper
-    height: 15px
-.result
-    margin-bottom: 14px
-    padding: 6px 10px 12px
-    h3
-        font-weight: bold
-        margin-bottom: 2px
-.resultdescription
-    padding-top: 5px
-    display: -webkit-box
-    -webkit-box-orient: vertical
-    -webkit-line-clamp: 15
-    overflow: hidden
-mat-card-title.hasMenu.hasBookmark
-    margin-right: 78px
-@media screen and (max-width: 400px)
-    mat-card-title.hasMenu.hasBookmark
-        margin-right: 64px
-mat-card-title.hasMenu,
-mat-card-title.hasBookmark 
-    margin-right: 30px
-#resultsheading
+.bookmarks-notice
+    margin: 0 0 12px
+    color: var(--nflx-muted, #b3b3b3)
+    font-size: 0.9rem
+
+.bookmarks-notice--error
+    color: #f4b4b4
+
+.bookmarks-cell
+    position: relative
+
+.bookmarks-cell__actions
+    position: absolute
+    top: 8px
+    right: 8px
+    z-index: 4
     display: flex
-    margin-bottom: 10px
-    h2
-        margin: 10px 8px 0 8px
-    #sort
-        margin-left: auto
-        display: flex
-        justify-content: flex-end
-        margin-bottom: 0px
-button.selected
-    span
-        font-weight: bold
-mat-card-header
-    .mdc-icon-button
-        position: absolute
-        top: 12px
-        right: 12px
-        margin-right: 0
-@media screen and (max-width: 400px)
-    mat-card-header
-        .mdc-icon-button
-            right: 0
-#error,#removed-episodes-notice
-    margin-left: 12px
-app-episode-podcast-links
-    display: flex
-mat-card-content img,mat-card-content span.img
-    max-height: 300px
-    max-width: 100%
-    margin: 0 auto 10px
-    display: block
-#results > p
-    margin-left: 8px
-    margin-right: 8px
+    align-items: center
+    gap: 4px
+    pointer-events: none
+    app-bookmark,
+    .bookmarks-cell__menu
+        pointer-events: auto
+
+.bookmarks-cell__menu
+    width: 36px
+    height: 36px
+    padding: 0
+    border: 1px solid rgba(255, 255, 255, 0.35)
+    border-radius: 50%
+    background: rgba(26, 26, 26, 0.9)
+    color: #fff
     mat-icon
-        vertical-align: bottom
+        color: inherit
+    &:hover,
+    &:focus-visible
+        background: rgba(255, 255, 255, 0.15)
+        border-color: var(--nflx-accent, #e8a23a)
+        outline: none
+
+.browse-empty
+    p
+        display: flex
+        align-items: center
+        justify-content: center
+        gap: 6px
+        margin: 12px 0 0
+        color: var(--nflx-muted, #b3b3b3)
+        mat-icon
+            font-size: 20px
+            width: 20px
+            height: 20px

--- a/cultpodcasts/src/app/bookmarks-api/bookmarks-api.component.ts
+++ b/cultpodcasts/src/app/bookmarks-api/bookmarks-api.component.ts
@@ -1,39 +1,36 @@
-import { ChangeDetectionStrategy, Component, DestroyRef, inject, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, DestroyRef, inject, signal } from '@angular/core';
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
-import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { ProfileService } from '../profile.service';
 import { catchError, firstValueFrom, forkJoin, map, Observable, of, take } from 'rxjs';
 import { AuthServiceWrapper } from '../auth-service-wrapper.class';
 import { HttpClient, HttpErrorResponse, HttpHeaders } from '@angular/common/http';
 import { environment } from './../../environments/environment';
 import { ApiEpisode } from '../api-episode.interface';
-import { DatePipe } from '@angular/common';
 import { MatButtonModule } from '@angular/material/button';
-import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
 import { MatMenuModule } from '@angular/material/menu';
-import { RouterLink } from '@angular/router';
-import { EpisodeImageComponent } from '../episode-image/episode-image.component';
-import { EpisodePodcastLinksComponent } from '../episode-podcast-links/episode-podcast-links.component';
 import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { EditEpisodeDialogComponent } from '../edit-episode-dialog/edit-episode-dialog.component';
 import { PostEpisodeDialogComponent } from '../post-episode-dialog/post-episode-dialog.component';
-import { BookmarkComponent } from "../bookmark/bookmark.component";
-import { SubjectsComponent } from "../subjects/subjects.component";
+import { BookmarkComponent } from '../bookmark/bookmark.component';
 import { ScrollDispatcher, ScrollingModule } from '@angular/cdk/scrolling';
 import { InfiniteScrollStrategy } from '../infinite-scroll-strategy';
 import { SiteService } from '../site.service';
 import { EditEpisodeDialogResponse } from '../edit-episode-dialog-response.interface';
 import { EpisodePublishResponseSnackbarComponent } from '../episode-publish-response-snackbar/episode-publish-response-snackbar.component';
 import { PostEpisodeDialogResponse } from '../post-episode-dialog-response.interface';
+import { EpisodePosterComponent } from '../episode-poster/episode-poster.component';
+import { SiteLoadingComponent } from '../site-loading/site-loading.component';
+import { apiEpisodeToHomepageEpisode } from '../api-episode-display';
+import { SearchDisplayEpisode } from '../search-result-links';
+import { canPlayEpisode } from '../episode-embed';
+import { PlayerService } from '../player.service';
 
 export enum sortMode {
   addDatedAsc = 1,
   addDatedDesc
 }
-
-const pageSize = 10;
 
 const removedEpisodesMessage =
   'Cultpodcasts.com has removed episodes it finds unsuitable.';
@@ -47,18 +44,13 @@ interface BookmarkEpisodeLoadResult {
 @Component({
   selector: 'app-bookmarks-api',
   imports: [
-    MatProgressBarModule,
     MatButtonModule,
     MatMenuModule,
     MatIconModule,
-    MatCardModule,
-    RouterLink,
-    DatePipe,
-    EpisodePodcastLinksComponent,
-    EpisodeImageComponent,
     BookmarkComponent,
-    SubjectsComponent,
-    ScrollingModule
+    ScrollingModule,
+    EpisodePosterComponent,
+    SiteLoadingComponent,
   ],
   templateUrl: './bookmarks-api.component.html',
   styleUrl: './bookmarks-api.component.sass',
@@ -74,14 +66,31 @@ export class BookmarksApiComponent {
   protected sortMode = sortMode;
   protected auth = inject(AuthServiceWrapper);
   protected authRoles = toSignal(this.auth.roles, { initialValue: [] as string[] });
-  protected isSignedIn = toSignal(this.auth.isSignedIn, { initialValue: false });
   protected noBookmarks = signal<boolean>(false);
   protected episodes = signal<ApiEpisode[]>([]);
+  protected displayEpisodes = computed(() =>
+    this.episodes().map(apiEpisodeToHomepageEpisode)
+  );
   protected sortDirection = signal<sortMode>(sortMode.addDatedDesc);
+  protected readonly playerService = inject(PlayerService);
+  protected bookmarkTotal = signal(0);
+  protected readonly resultsHeading = computed(() => {
+    const n = this.bookmarkTotal();
+    if (this.noBookmarks() || n === 0) {
+      return 'My Bookmarks';
+    }
+    return n === 1 ? '1 bookmark' : `${n} bookmarks`;
+  });
+  protected readonly sortLabel = computed(() =>
+    this.sortDirection() === sortMode.addDatedAsc
+      ? 'Oldest bookmarked'
+      : 'Newest bookmarked'
+  );
   private page: number = 0;
   private bookmarks: Set<string> | undefined;
   private scrollSubscribed = false;
   private destroyRef = inject(DestroyRef);
+  private readonly pageSize: number;
 
   constructor(
     private profileService: ProfileService,
@@ -92,6 +101,7 @@ export class BookmarksApiComponent {
     private infiniteScrollStrategy: InfiniteScrollStrategy,
     private siteService: SiteService
   ) {
+    this.pageSize = this.infiniteScrollStrategy.getTake(1);
   }
 
   ngOnInit() {
@@ -109,6 +119,7 @@ export class BookmarksApiComponent {
     this.page = 0;
 
     if (this.bookmarks) {
+      this.bookmarkTotal.set(this.bookmarks.size);
       await this.batch(true);
       return;
     }
@@ -118,19 +129,21 @@ export class BookmarksApiComponent {
       takeUntilDestroyed(this.destroyRef)
     ).subscribe(async bookmarks => {
       this.bookmarks = bookmarks;
+      this.bookmarkTotal.set(bookmarks.size);
       await this.batch(true);
     });
   }
 
   async batch(first: boolean = false) {
-    const start = this.page * pageSize;
-    const end = start + pageSize;
+    const start = this.page * this.pageSize;
+    const end = start + this.pageSize;
     if (start >= this.bookmarks!.size) {
       if (this.bookmarks!.size == 0) {
         this.zeroBookmarks();
       }
       return;
     }
+    this.bookmarkTotal.set(this.bookmarks!.size);
     if (!first) {
       this.isSubsequentLoading.set(true);
     }
@@ -175,7 +188,7 @@ export class BookmarksApiComponent {
             }
             this.isLoading.set(false);
             this.isSubsequentLoading.set(false);
-            if (!this.scrollSubscribed && first && this.bookmarks!.size > pageSize) {
+            if (!this.scrollSubscribed && first && this.bookmarks!.size > this.pageSize) {
               this.scrollSubscribed = true;
               this.scrollDispatcher.scrolled().pipe(
                 takeUntilDestroyed(this.destroyRef)
@@ -215,6 +228,7 @@ export class BookmarksApiComponent {
     this.isLoading.set(false);
     this.isSubsequentLoading.set(false);
     this.noBookmarks.set(true);
+    this.bookmarkTotal.set(0);
   }
 
   handleRequest() {
@@ -246,9 +260,9 @@ export class BookmarksApiComponent {
     dialogRef.afterClosed().subscribe(async result => {
       if (result) {
         if (result.updated) {
-          let snackBarRef = this.snackBar.open("Episode updated", "Ok", { duration: 10000 });
+          this.snackBar.open("Episode updated", "Ok", { duration: 10000 });
         } else if (result.noChange) {
-          let snackBarRef = this.snackBar.open("No change", "Ok", { duration: 3000 });
+          this.snackBar.open("No change", "Ok", { duration: 3000 });
         }
       }
     });
@@ -279,6 +293,21 @@ export class BookmarksApiComponent {
   async setSort(mode: sortMode) {
     this.sortDirection.set(mode);
     await this.reset();
+  }
+
+  playEpisode(episode: SearchDisplayEpisode): void {
+    if (!canPlayEpisode(episode)) {
+      return;
+    }
+    this.playerService.play(episode);
+  }
+
+  isPlayingId(id: string): boolean {
+    return this.playerService.episode()?.id === id;
+  }
+
+  isQueuedId(id: string): boolean {
+    return this.playerService.isQueuedId(id);
   }
 
   private isScrolledToBottom(): boolean {

--- a/cultpodcasts/src/app/infinite-scroll-strategy.spec.ts
+++ b/cultpodcasts/src/app/infinite-scroll-strategy.spec.ts
@@ -1,0 +1,15 @@
+import { InfiniteScrollStrategy } from './infinite-scroll-strategy';
+
+describe('InfiniteScrollStrategy', () => {
+  const strategy = new InfiniteScrollStrategy();
+
+  it('loads enough first-page results to fill complete browse-grid rows', () => {
+    expect(strategy.getTake(1)).toBe(20);
+  });
+
+  it('loads larger subsequent pages after the first', () => {
+    expect(strategy.getTake(2)).toBe(100);
+    expect(strategy.getSkip(2)).toBe(20);
+    expect(strategy.getSkip(3)).toBe(120);
+  });
+});

--- a/cultpodcasts/src/app/infinite-scroll-strategy.ts
+++ b/cultpodcasts/src/app/infinite-scroll-strategy.ts
@@ -7,7 +7,9 @@ export class InfiniteScrollStrategy {
         if (page > 1) {
             return 100;
         }
-        return 10;
+        // First page must fill complete browse-grid rows (≈3–4 cols on desktop).
+        // 10 left a short last row and could fail to fill a tall viewport (no scroll → no load-more).
+        return 20;
     }
 
     public getSkip(page: number): number {


### PR DESCRIPTION
## Summary
- Rebuild My Bookmarks as the shared flix `episode-poster` browse grid (count + sort header, bookmark overlay, empty/loading/removed states) instead of the legacy Material card feed.
- Bump infinite-scroll first-page `take` from 10 → 20 so search/podcast/subject grids fill complete desktop rows before scroll is required.

## Test plan
- [ ] Signed-in `/bookmarks` shows poster grid with count heading and sort control
- [ ] Bookmark toggle still works on each poster; empty and removed-episode states look correct
- [ ] Search/podcast/subject first page no longer ends on a short incomplete row on desktop
- [ ] Infinite scroll still loads subsequent pages after scrolling

Made with [Cursor](https://cursor.com)