### PR TITLE
fix(flix): sync hero text with backdrop readiness

### DIFF
--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.10.0",
+      "version": "1.10.1",
       "dependencies": {
         "@angular/cdk": "^22.0.6",
         "@angular/common": "^22.0.8",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
@@ -58,11 +58,11 @@
 
 .billboard__feature
     opacity: 1
-    transition: opacity 0.4s cubic-bezier(0.33, 0.1, 0.25, 1)
+    transition: opacity 0.55s cubic-bezier(0.33, 0.1, 0.25, 1)
     &.is-hidden
         opacity: 0
         pointer-events: none
-        transition-duration: 0.32s
+        transition-duration: 0.55s
 
 .billboard__eyebrow
     margin: 0 0 10px

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.spec.ts
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.spec.ts
@@ -101,7 +101,7 @@ describe('HomepageHeroComponent', () => {
 
     // Bug regression: restartHeroCycle used to clear heroContentTimer and leave index at 0.
     expect(component['heroIndex']()).toBe(0);
-    vi.advanceTimersByTime(280 + 320);
+    vi.advanceTimersByTime(450 + 550);
     expect(component['heroIndex']()).toBe(1);
     expect(component['featured']()?.id).toBe('b');
   });
@@ -117,7 +117,7 @@ describe('HomepageHeroComponent', () => {
       'button.billboard__nav--prev'
     ) as HTMLButtonElement;
     prev.click();
-    vi.advanceTimersByTime(280 + 320);
+    vi.advanceTimersByTime(450 + 550);
 
     expect(component['heroIndex']()).toBe(0);
     expect(component['featured']()?.id).toBe('a');
@@ -255,12 +255,17 @@ describe('HomepageHeroComponent', () => {
     component['lastFeaturedId'] = 'a';
     component['transitionTo'](1);
 
-    vi.advanceTimersByTime(280 + 320);
-    expect(component['heroIndex']()).toBe(1);
+    // Hold finishes with a cached image: backdrop and copy leave together.
+    vi.advanceTimersByTime(450);
     expect(component['heroLayerB']()).toContain('/b/');
+    expect(component['heroIndex']()).toBe(0);
+    expect(component['heroContentVisible']()).toBe(false);
+
+    vi.advanceTimersByTime(550);
+    expect(component['heroIndex']()).toBe(1);
   });
 
-  it('holds copy hidden until the next backdrop is ready', () => {
+  it('holds copy until the next backdrop is ready, then fades with the image', () => {
     vi.useFakeTimers();
     const deferred: { fire: (() => void) | null } = { fire: null };
     class DeferredImage {
@@ -285,19 +290,20 @@ describe('HomepageHeroComponent', () => {
     component['heroContentVisible'].set(true);
     component['transitionTo'](1);
 
-    // Linger on the current title briefly before fading it out.
+    // Hold elapsed but backdrop not ready yet — keep current title on screen.
+    vi.advanceTimersByTime(450);
     expect(component['heroContentVisible']()).toBe(true);
-    vi.advanceTimersByTime(280);
-    expect(component['heroContentVisible']()).toBe(false);
-    vi.advanceTimersByTime(320);
-    // Content-out finished, but the incoming image has not decoded yet —
-    // index and copy must not advance ahead of the backdrop.
     expect(component['heroIndex']()).toBe(0);
-    expect(component['heroContentVisible']()).toBe(false);
     expect(component['featured']()?.id).toBe('a');
 
     expect(deferred.fire).toBeTruthy();
     deferred.fire!();
+    // Image + text leave together; copy content swaps only after the out fade.
+    expect(component['heroContentVisible']()).toBe(false);
+    expect(component['heroIndex']()).toBe(0);
+    expect(component['heroLayerB']() ?? component['heroLayerA']()).toContain('/b/');
+
+    vi.advanceTimersByTime(550);
     expect(component['heroIndex']()).toBe(1);
     expect(component['featured']()?.id).toBe('b');
     expect(component['heroImageReady']()).toBe(true);
@@ -322,7 +328,7 @@ describe('HomepageHeroComponent', () => {
     component['startHeroCycle']();
 
     vi.advanceTimersByTime(7500 + 250);
-    vi.advanceTimersByTime(280 + 320);
+    vi.advanceTimersByTime(450 + 550);
     expect(component['heroIndex']()).toBe(1);
   });
 

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.spec.ts
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.spec.ts
@@ -101,7 +101,7 @@ describe('HomepageHeroComponent', () => {
 
     // Bug regression: restartHeroCycle used to clear heroContentTimer and leave index at 0.
     expect(component['heroIndex']()).toBe(0);
-    vi.advanceTimersByTime(320);
+    vi.advanceTimersByTime(280 + 320);
     expect(component['heroIndex']()).toBe(1);
     expect(component['featured']()?.id).toBe('b');
   });
@@ -117,7 +117,7 @@ describe('HomepageHeroComponent', () => {
       'button.billboard__nav--prev'
     ) as HTMLButtonElement;
     prev.click();
-    vi.advanceTimersByTime(320);
+    vi.advanceTimersByTime(280 + 320);
 
     expect(component['heroIndex']()).toBe(0);
     expect(component['featured']()?.id).toBe('a');
@@ -255,7 +255,7 @@ describe('HomepageHeroComponent', () => {
     component['lastFeaturedId'] = 'a';
     component['transitionTo'](1);
 
-    vi.advanceTimersByTime(320);
+    vi.advanceTimersByTime(280 + 320);
     expect(component['heroIndex']()).toBe(1);
     expect(component['heroLayerB']()).toContain('/b/');
   });
@@ -285,6 +285,9 @@ describe('HomepageHeroComponent', () => {
     component['heroContentVisible'].set(true);
     component['transitionTo'](1);
 
+    // Linger on the current title briefly before fading it out.
+    expect(component['heroContentVisible']()).toBe(true);
+    vi.advanceTimersByTime(280);
     expect(component['heroContentVisible']()).toBe(false);
     vi.advanceTimersByTime(320);
     // Content-out finished, but the incoming image has not decoded yet —
@@ -319,7 +322,7 @@ describe('HomepageHeroComponent', () => {
     component['startHeroCycle']();
 
     vi.advanceTimersByTime(7500 + 250);
-    vi.advanceTimersByTime(320);
+    vi.advanceTimersByTime(280 + 320);
     expect(component['heroIndex']()).toBe(1);
   });
 

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.spec.ts
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.spec.ts
@@ -23,11 +23,28 @@ function ep(id: string): HomepageEpisode {
   };
 }
 
+/** Image that is already decoded when `src` is assigned (cache hit). */
+class ImmediateImage {
+  onload: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  complete = false;
+  decode = undefined;
+  fetchPriority = '';
+  decoding = '';
+  set src(_value: string) {
+    this.complete = true;
+  }
+}
+
 describe('HomepageHeroComponent', () => {
   let fixture: ComponentFixture<HomepageHeroComponent>;
   let component: HomepageHeroComponent;
+  let originalImage: typeof Image;
 
   beforeEach(async () => {
+    originalImage = globalThis.Image;
+    globalThis.Image = ImmediateImage as unknown as typeof Image;
+
     await TestBed.configureTestingModule({
       imports: [HomepageHeroComponent],
       providers: [
@@ -46,6 +63,7 @@ describe('HomepageHeroComponent', () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    globalThis.Image = originalImage;
     component['stopHeroCycle']();
   });
 
@@ -206,30 +224,27 @@ describe('HomepageHeroComponent', () => {
 
   it('image gate stays blocked until the fallback timeout when decode never completes', () => {
     vi.useFakeTimers();
-    const originalImage = globalThis.Image;
     class StuckImage {
       onload: (() => void) | null = null;
       onerror: (() => void) | null = null;
       complete = false;
       decode = undefined;
+      fetchPriority = '';
+      decoding = '';
       set src(_value: string) {
         /* never completes */
       }
     }
     globalThis.Image = StuckImage as unknown as typeof Image;
 
-    try {
-      component['heroImageReady'].set(false);
-      component['beginHeroImageGate']();
-      expect(component['heroImageReady']()).toBe(false);
-      // A slow-but-working backdrop must still gate the dwell timer.
-      vi.advanceTimersByTime(7500);
-      expect(component['heroImageReady']()).toBe(false);
-      vi.advanceTimersByTime(4500);
-      expect(component['heroImageReady']()).toBe(true);
-    } finally {
-      globalThis.Image = originalImage;
-    }
+    component['heroImageReady'].set(false);
+    component['beginHeroImageGate']();
+    expect(component['heroImageReady']()).toBe(false);
+    // A slow-but-working backdrop must still gate the dwell timer.
+    vi.advanceTimersByTime(7500);
+    expect(component['heroImageReady']()).toBe(false);
+    vi.advanceTimersByTime(4500);
+    expect(component['heroImageReady']()).toBe(true);
   });
 
   it('crossfade flips the front layer onto the incoming stage', () => {
@@ -242,7 +257,47 @@ describe('HomepageHeroComponent', () => {
 
     vi.advanceTimersByTime(320);
     expect(component['heroIndex']()).toBe(1);
-    expect(component['heroLayerB']()).toContain('b.jpg');
+    expect(component['heroLayerB']()).toContain('/b/');
+  });
+
+  it('holds copy hidden until the next backdrop is ready', () => {
+    vi.useFakeTimers();
+    const deferred: { fire: (() => void) | null } = { fire: null };
+    class DeferredImage {
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      complete = false;
+      decode = undefined;
+      fetchPriority = '';
+      decoding = '';
+      set src(_value: string) {
+        deferred.fire = () => {
+          this.complete = true;
+          this.onload?.();
+        };
+      }
+    }
+    globalThis.Image = DeferredImage as unknown as typeof Image;
+
+    component['reduceMotion'] = false;
+    component['heroIndex'].set(0);
+    component['lastFeaturedId'] = 'a';
+    component['heroContentVisible'].set(true);
+    component['transitionTo'](1);
+
+    expect(component['heroContentVisible']()).toBe(false);
+    vi.advanceTimersByTime(320);
+    // Content-out finished, but the incoming image has not decoded yet —
+    // index and copy must not advance ahead of the backdrop.
+    expect(component['heroIndex']()).toBe(0);
+    expect(component['heroContentVisible']()).toBe(false);
+    expect(component['featured']()?.id).toBe('a');
+
+    expect(deferred.fire).toBeTruthy();
+    deferred.fire!();
+    expect(component['heroIndex']()).toBe(1);
+    expect(component['featured']()?.id).toBe('b');
+    expect(component['heroImageReady']()).toBe(true);
   });
 
   it('reduce-motion jumps index immediately without starting the cycle timer', () => {

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.ts
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.ts
@@ -118,6 +118,11 @@ export class HomepageHeroComponent {
   private pointerInside = false;
   /** Focus is inside the billboard (keyboard pause). */
   private focusInside = false;
+  /**
+   * Mid-transition latch: content stays faded out until the outgoing fade finishes
+   * AND the incoming backdrop has decoded (or hit the safety fallback).
+   */
+  private heroTransitionToken = 0;
 
   /**
    * Window resize and dots-strip scroll are bound outside Angular's event manager: in a
@@ -174,7 +179,11 @@ export class HomepageHeroComponent {
         this.lastFeaturedId = undefined;
         this.lastSlideSignature = undefined;
         this.heroIndex.set(0);
+        this.heroTransitionToken++;
+        this.heroImageToken++;
         this.stopHeroCycle();
+        this.clearHeroContentTransition();
+        this.clearHeroImageWait();
         return;
       }
 
@@ -402,19 +411,68 @@ export class HomepageHeroComponent {
       return;
     }
 
+    // Hide copy immediately. Do not swap title/desc until the next backdrop is
+    // decoded — revealing text first spoils the crossfade.
     this.heroContentVisible.set(false);
-    if (this.heroContentTimer) {
-      clearTimeout(this.heroContentTimer);
-    }
-    this.heroContentTimer = setTimeout(() => {
+    this.heroImageReady.set(false);
+    this.clearHeroContentTransition();
+    this.clearHeroImageWait();
+
+    const slides = this.slides();
+    const nextSlide = slides[index];
+    const nextUrl = nextSlide ? episodeImageUrl(nextSlide)?.toString() : undefined;
+    const transitionToken = ++this.heroTransitionToken;
+    const imageToken = ++this.heroImageToken;
+
+    let contentOutDone = false;
+    let imageReady = !nextUrl;
+
+    const commit = (): void => {
+      if (transitionToken !== this.heroTransitionToken || imageToken !== this.heroImageToken) {
+        return;
+      }
+      if (!contentOutDone || !imageReady) {
+        return;
+      }
+
       this.heroIndex.set(index);
-      this.lastFeaturedId = this.slides()[index]?.id;
+      this.lastFeaturedId = nextSlide?.id;
       this.syncHeroLayers(false);
-      this.beginHeroImageGate();
+      this.clearHeroImageWait();
+      this.heroImageReady.set(true);
+      this.enableKenBurnsOnFront();
       requestAnimationFrame(() => {
-        requestAnimationFrame(() => this.heroContentVisible.set(true));
+        requestAnimationFrame(() => {
+          if (transitionToken !== this.heroTransitionToken) {
+            return;
+          }
+          this.heroContentVisible.set(true);
+        });
       });
+    };
+
+    this.heroContentTimer = setTimeout(() => {
+      contentOutDone = true;
+      commit();
     }, HomepageHeroComponent.heroContentOutMs);
+
+    if (!nextUrl) {
+      return;
+    }
+
+    this.heroImageFallbackTimer = setTimeout(() => {
+      if (imageToken !== this.heroImageToken) {
+        return;
+      }
+      imageReady = true;
+      commit();
+    }, HomepageHeroComponent.heroImageFallbackMs);
+
+    this.preloadHeroImage(nextUrl, imageToken, () => {
+      imageReady = true;
+      this.clearHeroImageWait();
+      commit();
+    });
   }
 
   private syncHeroLayers(immediate: boolean): void {
@@ -495,6 +553,18 @@ export class HomepageHeroComponent {
       }
     }, HomepageHeroComponent.heroImageFallbackMs);
 
+    this.preloadHeroImage(url, token, () => {
+      this.clearHeroImageWait();
+      this.heroImageReady.set(true);
+      this.enableKenBurnsOnFront();
+    });
+  }
+
+  /**
+   * Warm + decode the next backdrop. Used both for the initial image gate and
+   * for slide transitions so copy never advances ahead of a painted image.
+   */
+  private preloadHeroImage(url: string, token: number, onReady: () => void): void {
     const img = new Image();
     // The billboard backdrop is the page's largest visual; a plain `new Image()`
     // (like the CSS background-image it warms the cache for) fetches at Low priority.
@@ -504,9 +574,7 @@ export class HomepageHeroComponent {
       if (token !== this.heroImageToken) {
         return;
       }
-      this.clearHeroImageWait();
-      this.heroImageReady.set(true);
-      this.enableKenBurnsOnFront();
+      onReady();
     };
     img.onload = () => {
       if (typeof img.decode === 'function') {
@@ -556,8 +624,8 @@ export class HomepageHeroComponent {
 
   /**
    * Reset the dwell clock after a manual prev/next/dash jump.
-   * Must not cancel `heroContentTimer` or re-run the image gate — `transitionTo`
-   * owns both, and clearing them here made the chevrons appear dead.
+   * Must not cancel `heroContentTimer` or the in-flight image preload —
+   * `transitionTo` owns both, and clearing them here made the chevrons appear dead.
    */
   private restartHeroCycle(): void {
     this.stopHeroCycle();

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.ts
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.ts
@@ -41,9 +41,10 @@ export class HomepageHeroComponent {
    */
   private static readonly heroImageFallbackMs = 12000;
   private static readonly heroTransitionMs = 1200;
-  /** Linger on the current title before fading it out — fading immediately feels abrupt. */
-  private static readonly heroContentOutDelayMs = 280;
-  private static readonly heroContentOutMs = 320;
+  /** Hold the current title before text and image leave together. */
+  private static readonly heroContentHoldMs = 450;
+  /** Keep in sync with `.billboard__feature.is-hidden` transition-duration. */
+  private static readonly heroContentOutMs = 550;
 
   readonly slides = input.required<HomepageEpisode[]>();
   readonly curatedEpisodeIds = input<readonly string[]>([]);
@@ -413,9 +414,9 @@ export class HomepageHeroComponent {
       return;
     }
 
-    // Preload immediately, but keep the current title on screen briefly before
-    // fading it out. Do not swap title/desc until the next backdrop is decoded —
-    // revealing text first spoils the crossfade.
+    // Hold the current slide while the next backdrop preloads. Once both the
+    // hold and the image are ready, fade the copy out and crossfade the image
+    // together — text leaving ahead of the backdrop is what spoils the effect.
     this.heroImageReady.set(false);
     this.clearHeroContentTransition();
     this.clearHeroImageWait();
@@ -426,43 +427,47 @@ export class HomepageHeroComponent {
     const transitionToken = ++this.heroTransitionToken;
     const imageToken = ++this.heroImageToken;
 
-    let contentOutDone = false;
+    let holdDone = false;
     let imageReady = !nextUrl;
+    let crossfadeStarted = false;
 
-    const commit = (): void => {
+    const beginCrossfade = (): void => {
       if (transitionToken !== this.heroTransitionToken || imageToken !== this.heroImageToken) {
         return;
       }
-      if (!contentOutDone || !imageReady) {
+      if (!holdDone || !imageReady || crossfadeStarted) {
         return;
       }
+      crossfadeStarted = true;
 
-      this.heroIndex.set(index);
-      this.lastFeaturedId = nextSlide?.id;
-      this.syncHeroLayers(false);
+      // Image + text leave on the same beat.
+      this.syncHeroLayers(false, nextUrl);
+      this.heroContentVisible.set(false);
       this.clearHeroImageWait();
       this.heroImageReady.set(true);
-      this.enableKenBurnsOnFront();
-      requestAnimationFrame(() => {
+
+      this.heroContentTimer = setTimeout(() => {
+        if (transitionToken !== this.heroTransitionToken) {
+          return;
+        }
+        // Swap copy while hidden, then fade in alongside the incoming backdrop.
+        this.heroIndex.set(index);
+        this.lastFeaturedId = nextSlide?.id;
         requestAnimationFrame(() => {
-          if (transitionToken !== this.heroTransitionToken) {
-            return;
-          }
-          this.heroContentVisible.set(true);
+          requestAnimationFrame(() => {
+            if (transitionToken !== this.heroTransitionToken) {
+              return;
+            }
+            this.heroContentVisible.set(true);
+          });
         });
-      });
+      }, HomepageHeroComponent.heroContentOutMs);
     };
 
     this.heroContentTimer = setTimeout(() => {
-      if (transitionToken !== this.heroTransitionToken) {
-        return;
-      }
-      this.heroContentVisible.set(false);
-      this.heroContentTimer = setTimeout(() => {
-        contentOutDone = true;
-        commit();
-      }, HomepageHeroComponent.heroContentOutMs);
-    }, HomepageHeroComponent.heroContentOutDelayMs);
+      holdDone = true;
+      beginCrossfade();
+    }, HomepageHeroComponent.heroContentHoldMs);
 
     if (!nextUrl) {
       return;
@@ -473,18 +478,18 @@ export class HomepageHeroComponent {
         return;
       }
       imageReady = true;
-      commit();
+      beginCrossfade();
     }, HomepageHeroComponent.heroImageFallbackMs);
 
     this.preloadHeroImage(nextUrl, imageToken, () => {
       imageReady = true;
       this.clearHeroImageWait();
-      commit();
+      beginCrossfade();
     });
   }
 
-  private syncHeroLayers(immediate: boolean): void {
-    const url = this.featuredImage();
+  private syncHeroLayers(immediate: boolean, urlOverride?: string): void {
+    const url = urlOverride ?? this.featuredImage();
     if (immediate || this.reduceMotion) {
       if (this.heroKenBurnsClearTimer) {
         clearTimeout(this.heroKenBurnsClearTimer);
@@ -504,6 +509,7 @@ export class HomepageHeroComponent {
       requestAnimationFrame(() => {
         requestAnimationFrame(() => {
           this.heroFrontLayer.set('b');
+          this.heroKenBurnsB.set(!!url && !this.reduceMotion);
           this.scheduleOutgoingKenBurnsClear('a');
         });
       });
@@ -513,6 +519,7 @@ export class HomepageHeroComponent {
       requestAnimationFrame(() => {
         requestAnimationFrame(() => {
           this.heroFrontLayer.set('a');
+          this.heroKenBurnsA.set(!!url && !this.reduceMotion);
           this.scheduleOutgoingKenBurnsClear('b');
         });
       });

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.ts
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.ts
@@ -41,6 +41,8 @@ export class HomepageHeroComponent {
    */
   private static readonly heroImageFallbackMs = 12000;
   private static readonly heroTransitionMs = 1200;
+  /** Linger on the current title before fading it out — fading immediately feels abrupt. */
+  private static readonly heroContentOutDelayMs = 280;
   private static readonly heroContentOutMs = 320;
 
   readonly slides = input.required<HomepageEpisode[]>();
@@ -411,9 +413,9 @@ export class HomepageHeroComponent {
       return;
     }
 
-    // Hide copy immediately. Do not swap title/desc until the next backdrop is
-    // decoded — revealing text first spoils the crossfade.
-    this.heroContentVisible.set(false);
+    // Preload immediately, but keep the current title on screen briefly before
+    // fading it out. Do not swap title/desc until the next backdrop is decoded —
+    // revealing text first spoils the crossfade.
     this.heroImageReady.set(false);
     this.clearHeroContentTransition();
     this.clearHeroImageWait();
@@ -452,9 +454,15 @@ export class HomepageHeroComponent {
     };
 
     this.heroContentTimer = setTimeout(() => {
-      contentOutDone = true;
-      commit();
-    }, HomepageHeroComponent.heroContentOutMs);
+      if (transitionToken !== this.heroTransitionToken) {
+        return;
+      }
+      this.heroContentVisible.set(false);
+      this.heroContentTimer = setTimeout(() => {
+        contentOutDone = true;
+        commit();
+      }, HomepageHeroComponent.heroContentOutMs);
+    }, HomepageHeroComponent.heroContentOutDelayMs);
 
     if (!nextUrl) {
       return;


### PR DESCRIPTION
## Summary
- Hero slide transitions no longer reveal new title/copy before the next backdrop is decoded.
- Copy fades out, the next image is preloaded (with the existing ~12s safety fallback), then index, layers, and copy commit together once the image is ready.
- Adds a regression test covering text-before-image timing.

## Test plan
- [ ] Open flix homepage and watch auto-advance: text should not appear for the next slide before/without its image.
- [ ] Use chevrons and dash jumps: same coordinated swap; dwell timer still resumes after navigation.
- [ ] Hover/focus pause still works (`.is-paused`).
- [ ] Slow network / throttling: copy stays faded until backdrop arrives (or ~12s fallback).
- [ ] `ng test` homepage-hero spec (16 passing locally).
