### PR TITLE
fix(flix): keep YouTube thumbs 16:9 in tile rows

### DIFF
--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.10.1",
+      "version": "1.10.2",
       "dependencies": {
         "@angular/cdk": "^22.0.6",
         "@angular/common": "^22.0.8",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/src/app/episode-image/episode-image.component.html
+++ b/cultpodcasts/src/app/episode-image/episode-image.component.html
@@ -1,5 +1,5 @@
 @if (this.imageUrl) {
-<div class="container" [class.layout-tile]="layout === 'tile'" (click)="overlay($event, true)" [class.hasOverlay]="linksOverlay && !overlayVisible()"
+<div class="container" [class.layout-tile]="layout === 'tile'" [class.layout-tile--wide]="layout === 'tile' && isWideArt" (click)="overlay($event, true)" [class.hasOverlay]="linksOverlay && !overlayVisible()"
     [class.overlayVisible]="overlayVisible()">
     <div class="overlay" [class.show]="overlayVisible()">
         <button class="close" mat-icon-button (click)="overlay($event, false)">

--- a/cultpodcasts/src/app/episode-image/episode-image.component.sass
+++ b/cultpodcasts/src/app/episode-image/episode-image.component.sass
@@ -14,6 +14,13 @@
             height: 100%
             width: 100%
             object-fit: cover
+    // YouTube thumbs are 16:9 — keep them wide in tile rows instead of a square
+    // crop; letterboxed hqdefault stills use the standard crop offsets.
+    &.layout-tile.layout-tile--wide
+        aspect-ratio: 16/9
+        img.cropped
+            top: -16.65%
+            height: 133.3%
     img
         object-fit: cover
         height: 100%

--- a/cultpodcasts/src/app/episode-image/episode-image.component.ts
+++ b/cultpodcasts/src/app/episode-image/episode-image.component.ts
@@ -61,6 +61,12 @@ export class EpisodeImageComponent {
     return false;
   }
 
+  /** YouTube thumbs are 16:9 — tile rows must not square-crop them. */
+  get isWideArt(): boolean {
+    const imageUrl = this.imageUrl;
+    return !!imageUrl && imageUrl.host.indexOf("i.ytimg.com") == 0;
+  }
+
   overlay($event: Event, show: boolean) {
     if (this.linksOverlay) {
       this.overlayVisible.set(show);


### PR DESCRIPTION
## Summary
- Discovery (and the episodes / outgoing-episodes lists) render episode art through `app-episode-image` with `layout="tile"`, which forces a 1:1 frame with `object-fit: cover` — 16:9 YouTube thumbnails were being square-cropped.
- Adds a `layout-tile--wide` variant that keeps `i.ytimg.com` art at 16:9 inside tile rows; letterboxed `hqdefault` stills keep the existing crop offsets so the black bars stay hidden.
- Square podcast art (Spotify/Apple covers) is unchanged.

## Test plan
- [ ] Discovery: YouTube results show wide 16:9 thumbnails, no square crop
- [ ] Discovery: Spotify results still show square art
- [ ] Episodes / outgoing-episodes lists: YouTube art wide, podcast covers square
