### PR TITLE
fix(flix): subject language falls back to All when empty

### DIFF
--- a/cultpodcasts/src/app/subject-api/subject-api.component.ts
+++ b/cultpodcasts/src/app/subject-api/subject-api.component.ts
@@ -163,10 +163,10 @@ export class SubjectApiComponent {
     }
 
     const baseFilter = this.filter + this.podcastFilter;
-    const resultFilter = baseFilter + this.langFilter();
     // Facets must omit the language filter so Azure returns non-null lang buckets.
-    const facetFilter = subsequent ? baseFilter : resultFilter;
+    // Result filter is read at request time so an All-language fallback can widen it first.
     const runResults = (facetsFromResponse?: SearchResultsFacets, facetCount?: number) => {
+      const resultFilter = baseFilter + this.langFilter();
       this.oDataService.getEntitiesWithFacets<SearchResult>(
         new URL("/search", environment.api).toString(),
         {
@@ -231,7 +231,7 @@ export class SubjectApiComponent {
         new URL("/search", environment.api).toString(),
         {
           search: this.query(),
-          filter: facetFilter,
+          filter: baseFilter,
           searchMode: 'any',
           queryType: 'simple',
           count: true,
@@ -244,7 +244,20 @@ export class SubjectApiComponent {
           ],
           orderby: sort
         }).subscribe({
-          next: facetData => runResults(facetData.facets, facetData.metadata.get("count")),
+          next: facetData => {
+            const langFacets = facetData.facets.lang ?? [];
+            const scopedTotal = facetData.metadata.get("count") ?? 0;
+            // Default English (or any specific language) with 0 hits while other
+            // language facets have episodes → widen to All before the results query.
+            const nextChips = reconcileLanguageChipsForPodcasts(
+              this.languageSelection(),
+              availableLanguageChipValues(scopedTotal, langFacets)
+            );
+            if (nextChips) {
+              this.setLanguageSelection(nextChips);
+            }
+            runResults(facetData.facets, scopedTotal);
+          },
           error: (e) => {
             console.error(e);
             this.errorMessage.set("Something went wrong. Please try again.");
@@ -356,7 +369,7 @@ export class SubjectApiComponent {
    * Re-fetch lang facets for the current subject (+ selected shows).
    * Podcast chips stay subject-wide; language chips shrink to the active show filter.
    * When the active language filter would exclude all episodes for the selected shows,
-   * widen language to All so later show picks are not stuck on a narrow code.
+   * widen language to All (same helper as initial subject load).
    */
   private refreshLanguageFacets(options?: {
     reconcileSelection?: boolean;

--- a/cultpodcasts/src/app/subject-language-filter.spec.ts
+++ b/cultpodcasts/src/app/subject-language-filter.spec.ts
@@ -95,6 +95,13 @@ describe("subject-language-filter", () => {
         .toEqual([ALL_LANGUAGES_VALUE]);
     });
 
+    it("widens to All when default English finds no episodes but Spanish facets exist", () => {
+      // Subject page: English preference, Spanish-only subject (e.g. Edelweiss).
+      expect(reconcileLanguageChipsForPodcasts({ mode: "english" }, ["es"]))
+        .toEqual([ALL_LANGUAGES_VALUE]);
+      expect(availableLanguageChipValues(12, [{ value: "es", count: 12 }])).toEqual(["es"]);
+    });
+
     it("does not switch to the show's specific language codes", () => {
       expect(reconcileLanguageChipsForPodcasts({ mode: "codes", codes: ["es"] }, ["fr"]))
         .toEqual([ALL_LANGUAGES_VALUE]);

--- a/cultpodcasts/src/app/subject-language-filter.ts
+++ b/cultpodcasts/src/app/subject-language-filter.ts
@@ -107,9 +107,10 @@ export function languageSelectionIntersectsAvailable(
 }
 
 /**
- * After show selection changes: if the current language filter would match nothing
- * for the selected shows, widen to All — not the show's specific languages — so
- * later show picks are not stuck on a narrow auto-selected code.
+ * When a specific language filter would match nothing but other languages have
+ * episodes (initial subject load, or after show selection changes), widen to All
+ * — not a specific code — so the user is not stuck on an empty English/default
+ * filter and later show picks are not stuck on a narrow auto-selected code.
  * Returns chip values to apply, or null when the current selection should stay.
  */
 export function reconcileLanguageChipsForPodcasts(


### PR DESCRIPTION
## Summary
- On subject pages, after lang facets load, if the active specific language filter (default English) intersects no available language chips while other languages have episodes, auto-select Language=All before fetching results.
- Reuses existing `reconcileLanguageChipsForPodcasts` (same as show-filter reconcile); result filter is read at request time so the widened selection is applied without a second facet round-trip or loop.
- Adds a unit case for Spanish-only subjects with English default (Edelweiss-style).

## Test plan
- [ ] Open https://flix.cultpodcasts.com/subject/Edelweiss (or preview) with Language defaulting to English — should show Spanish episodes with Language=All selected, not empty state
- [ ] Subject with English episodes still defaults to English and shows results
- [ ] Manually selecting English on a Spanish-only subject after All still allowed; reloading again falls back to All
- [ ] Show filter reconcile still widens to All when selected shows have no episodes in the active language
- [ ] `npx ng test --watch=false --isolate=false --filter=subject-language-filter` (26 passed)
