### PR TITLE
fix(flix): stop hero admin tools overlapping at narrow widths

### DIFF
--- a/cultpodcasts/src/app/homepage-api/homepage-api.component.sass
+++ b/cultpodcasts/src/app/homepage-api/homepage-api.component.sass
@@ -48,6 +48,16 @@
             background: var(--nflx-accent) !important
             color: #111 !important
 
+@media screen and (max-width: 900px), (hover: none) and (pointer: coarse)
+    .nflx-search
+        ::ng-deep
+            #searchbox
+                .mat-mdc-text-field-wrapper,
+                .mdc-text-field,
+                .mdc-text-field--outlined,
+                .mdc-text-field--no-label
+                    backdrop-filter: none !important
+
 .nflx-error
     padding: 160px 16px
     text-align: center

--- a/cultpodcasts/src/app/homepage-api/homepage-api.component.sass
+++ b/cultpodcasts/src/app/homepage-api/homepage-api.component.sass
@@ -5,6 +5,11 @@
     --rail-poster-sq: min(32vw, 160px)
     --obscure-card-w: min(42vw, 168px)
     --obscure-yt-w: min(55vw, 240px)
+    // Absolute .nflx-search overlays the hero; homepage-hero reads this to keep
+    // titles/actions below the search hit box (esp. short mobile viewports).
+    --nflx-search-top: 72px
+    --nflx-search-h: 48px
+    --nflx-hero-search-clearance: calc(var(--nflx-search-top) + var(--nflx-search-h) + 20px)
     position: relative
     color: var(--nflx-text)
     background: var(--nflx-bg)
@@ -15,12 +20,11 @@
     padding-bottom: min(52vh, 420px)
 
 .nflx-search
-    --nflx-search-h: 48px
     --search-bar-control-h: var(--nflx-search-h)
     --mat-form-field-container-height: var(--nflx-search-h)
     --mat-form-field-container-vertical-padding: 0px
     position: absolute
-    top: 72px
+    top: var(--nflx-search-top)
     left: 50%
     z-index: 15
     transform: translateX(-50%)
@@ -66,8 +70,8 @@
     .nflx
         --obscure-card-w: 42vw
         --obscure-yt-w: 55vw
+        --nflx-search-top: 64px
     .nflx-search
-        top: 64px
         width: min(640px, calc(100% - 1.5rem))
 
 @media screen and (max-width: 600px)

--- a/cultpodcasts/src/app/homepage-api/homepage-api.component.ts
+++ b/cultpodcasts/src/app/homepage-api/homepage-api.component.ts
@@ -332,9 +332,7 @@ export class HomepageApiComponent {
         autofilled,
         updatedAt: this.curatedUpdatedAt(),
       },
-      width: '520px',
-      maxWidth: '94vw',
-      autoFocus: 'dialog',
+      ...this.manageDialogOptions(),
     });
     ref.afterClosed().subscribe((result: HeroManageDialogResult | undefined) => {
       if (result?.episodeIds) {
@@ -382,9 +380,7 @@ export class HomepageApiComponent {
         episodeCounts,
         updatedAt: this.curatedUpdatedAt(),
       },
-      width: '520px',
-      maxWidth: '94vw',
-      autoFocus: 'dialog',
+      ...this.manageDialogOptions(),
     });
     ref.afterClosed().subscribe((result: RailsManageDialogResult | undefined) => {
       if (result?.railSubjects) {
@@ -394,6 +390,30 @@ export class HomepageApiComponent {
         this.curatedUpdatedAt.set(result.updatedAt ?? null);
       }
     });
+  }
+
+  private manageDialogOptions(): {
+    width: string;
+    maxWidth: string;
+    maxHeight: string;
+    autoFocus: 'dialog';
+    panelClass: string;
+    enterAnimationDuration?: number;
+    exitAnimationDuration?: number;
+  } {
+    const cheapMotion =
+      typeof window !== 'undefined' &&
+      window.matchMedia('(max-width: 900px), (hover: none) and (pointer: coarse)').matches;
+    return {
+      width: '520px',
+      maxWidth: '94vw',
+      maxHeight: '90dvh',
+      autoFocus: 'dialog',
+      panelClass: 'flix-manage-dialog',
+      ...(cheapMotion
+        ? { enterAnimationDuration: 0, exitAnimationDuration: 0 }
+        : {}),
+    };
   }
 
   populatePage() {

--- a/cultpodcasts/src/app/homepage-discover-rail/homepage-discover-rail.component.sass
+++ b/cultpodcasts/src/app/homepage-discover-rail/homepage-discover-rail.component.sass
@@ -56,13 +56,19 @@
     text-decoration: none
     color: inherit
     scroll-snap-align: start
-    transition: transform 0.22s ease
-    &:hover,
+    @media (hover: hover) and (pointer: fine)
+        transition: transform 0.22s ease
+        &:hover,
+        &:focus-visible
+            transform: translateY(-4px) scale(1.03)
+            outline: none
+            .obscure__art
+                box-shadow: 0 0 0 2px var(--nflx-accent), 0 16px 32px #00000080
+            .obscure__name
+                color: var(--nflx-accent)
     &:focus-visible
-        transform: translateY(-4px) scale(1.03)
-        outline: none
-        .obscure__art
-            box-shadow: 0 0 0 2px var(--nflx-accent), 0 16px 32px #00000080
+        outline: 2px solid var(--nflx-accent)
+        outline-offset: 2px
         .obscure__name
             color: var(--nflx-accent)
 
@@ -86,7 +92,8 @@
         height: 100%
         object-fit: cover
         display: block
-        filter: saturate(1.05) contrast(1.04)
+        @media (hover: hover) and (pointer: fine)
+            filter: saturate(1.05) contrast(1.04)
 
 .obscure__placeholder
     width: 100%
@@ -107,6 +114,10 @@
     letter-spacing: 0.04em
     text-transform: uppercase
     backdrop-filter: blur(4px)
+
+@media screen and (max-width: 900px), (hover: none) and (pointer: coarse)
+    .obscure__count
+        backdrop-filter: none
 
 .obscure__name
     display: -webkit-box

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.html
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.html
@@ -60,29 +60,31 @@
           [routerLink]="['/podcast', feature.podcastName, feature.id]">
           More info
         </a>
-        @if (isCurator() && featuredIsCurated()) {
-        <button type="button" mat-stroked-button class="billboard__curate"
-          (click)="removeFeatured.emit(feature.id)" aria-label="Remove from hero">
-          <mat-icon>star</mat-icon>
-          Remove from hero
-        </button>
-        }
       </div>
     </div>
   </div>
 
   <div class="billboard__controls">
     @if (isCurator()) {
-    <button type="button" class="billboard__manage" (click)="manageHero.emit()"
-      aria-label="Manage hero curation">
-      <mat-icon>playlist_add_check</mat-icon>
-      <span>Manage hero</span>
-    </button>
-    <button type="button" class="billboard__manage" (click)="manageRails.emit()"
-      aria-label="Manage subject rails">
-      <mat-icon>view_week</mat-icon>
-      <span>Manage rails</span>
-    </button>
+    <div class="billboard__admin" role="toolbar" aria-label="Hero curation">
+      <button type="button" class="billboard__manage" (click)="manageHero.emit()"
+        aria-label="Manage hero curation">
+        <mat-icon>playlist_add_check</mat-icon>
+        <span>Manage hero</span>
+      </button>
+      @if (featuredIsCurated()) {
+      <button type="button" class="billboard__manage billboard__manage--curate"
+        (click)="removeFeatured.emit(feature.id)" aria-label="Remove from hero">
+        <mat-icon>star</mat-icon>
+        <span>Remove from hero</span>
+      </button>
+      }
+      <button type="button" class="billboard__manage" (click)="manageRails.emit()"
+        aria-label="Manage subject rails">
+        <mat-icon>view_week</mat-icon>
+        <span>Manage rails</span>
+      </button>
+    </div>
     }
     @if (slides().length > 1) {
     <div class="billboard__pager">

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
@@ -159,27 +159,24 @@
     background: #2a2a2acc !important
     font-weight: 600
 
-.billboard__curate
-    border-color: #e8a23a99 !important
-    color: var(--nflx-accent) !important
-    background: #1a140fcc !important
-    font-weight: 600
-    mat-icon
-        margin-right: 4px
-        color: var(--nflx-accent)
-
 .billboard__controls
     position: absolute
     right: 4vw
     bottom: 56px
     z-index: 3
     display: flex
-    align-items: center
+    flex-direction: column
+    align-items: flex-end
     gap: 10px
+    max-width: min(520px, calc(100% - 8vw))
+    pointer-events: auto
+
+.billboard__admin
+    display: flex
     flex-wrap: wrap
     justify-content: flex-end
-    max-width: calc(100% - 8vw)
-    pointer-events: auto
+    gap: 8px
+    max-width: 100%
 
 .billboard__manage
     display: inline-flex
@@ -195,23 +192,29 @@
     font-weight: 600
     cursor: pointer
     transition: background 0.2s ease, border-color 0.2s ease
+    white-space: nowrap
     mat-icon
         font-size: 18px
         width: 18px
         height: 18px
         color: var(--nflx-accent)
+        flex: 0 0 auto
     &:hover,
     &:focus-visible
         background: #2a2a2a
         border-color: var(--nflx-accent)
         outline: none
+    &--curate
+        border-color: #e8a23a99
+        color: var(--nflx-accent)
 
 .billboard__pager
     display: flex
     align-items: center
     gap: 8px
     min-width: 0
-    max-width: min(420px, calc(100vw - 8vw))
+    width: 100%
+    max-width: min(420px, 100%)
 
 .billboard__nav
     width: 44px
@@ -326,23 +329,48 @@
     .billboard__pager
         max-width: min(480px, 42vw)
 
+// Below ~1280px the left feature actions and right admin/pager share the same
+// bottom band and collide; pull controls into flow under the copy.
+@media screen and (max-width: 1280px)
+    .billboard
+        flex-direction: column
+        justify-content: flex-end
+        align-items: stretch
+        gap: 16px
+        padding-bottom: 24px
+    .billboard__content
+        width: 100%
+        max-width: min(640px, 100%)
+    .billboard__controls
+        position: relative
+        right: auto
+        bottom: auto
+        left: auto
+        width: 100%
+        max-width: none
+        align-items: stretch
+    .billboard__admin
+        justify-content: flex-start
+    .billboard__pager
+        max-width: none
+        width: 100%
+
 @media screen and (max-width: 600px)
     .billboard
         min-height: 78vh
-        padding-bottom: 72px
+        padding-bottom: 20px
+        gap: 12px
     .billboard__actions
         flex-direction: column
         align-items: stretch
-    .billboard__controls
-        left: 4vw
-        right: 4vw
-        bottom: 20px
-        justify-content: space-between
-        max-width: none
-    .billboard__pager
-        flex: 1 1 auto
-        max-width: none
+    .billboard__admin
+        // Keep each control on its own hit target; wrapping pills must not stack.
+        display: grid
+        grid-template-columns: 1fr
+        gap: 8px
+    .billboard__manage
         width: 100%
+        justify-content: center
     .billboard__nav
         width: 40px
         height: 40px

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
@@ -8,7 +8,8 @@
     min-height: min(88vh, 720px)
     display: flex
     align-items: flex-end
-    padding: 0 4vw 48px
+    // Keep feature copy below the absolute homepage search overlay.
+    padding: var(--nflx-hero-search-clearance, 140px) 4vw 48px
     box-sizing: border-box
     overflow: hidden
 
@@ -53,7 +54,6 @@
     position: relative
     z-index: 2
     width: min(640px, 100%)
-    padding-top: 96px
     pointer-events: auto
 
 .billboard__feature
@@ -334,13 +334,23 @@
 @media screen and (max-width: 1280px)
     .billboard
         flex-direction: column
-        justify-content: flex-end
+        // Spacer (not flex-end) keeps copy below the absolute search even when
+        // title + admin + pager nearly fill the viewport.
+        justify-content: flex-start
         align-items: stretch
         gap: 16px
+        padding-top: 0
         padding-bottom: 24px
+        &::before
+            content: ''
+            flex: 1 0 var(--nflx-hero-search-clearance, 140px)
+            min-height: var(--nflx-hero-search-clearance, 140px)
+            width: 100%
+            pointer-events: none
     .billboard__content
         width: 100%
         max-width: min(640px, 100%)
+        flex: 0 1 auto
     .billboard__controls
         position: relative
         right: auto
@@ -349,6 +359,7 @@
         width: 100%
         max-width: none
         align-items: stretch
+        flex: 0 0 auto
     .billboard__admin
         justify-content: flex-start
     .billboard__pager

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
@@ -325,6 +325,24 @@
     .billboard__dots-viewport
         scroll-behavior: auto
 
+// Touch / narrow: drop continuous GPU effects that fight dialog compositing.
+@media screen and (max-width: 900px), (hover: none) and (pointer: coarse)
+    .billboard__grain
+        display: none
+    .billboard__stage.is-kenburns
+        animation: none
+        transform: scale(1.05)
+    .billboard__live
+        animation: none
+        box-shadow: none
+
+// While a Material dialog holds scroll-lock, freeze any leftover stage motion.
+:host-context(.cdk-global-scrollblock)
+    .billboard__stage.is-kenburns
+        animation-play-state: paused
+    .billboard__live
+        animation-play-state: paused
+
 @media screen and (min-width: 900px)
     .billboard__pager
         max-width: min(480px, 42vw)

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.spec.ts
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.spec.ts
@@ -341,6 +341,27 @@ describe('HomepageHeroComponent', () => {
     expect(component['heroTimer']).toBeUndefined();
   });
 
+  it('still auto-advances on saveGpu mobile mode (Ken Burns off, timer on)', () => {
+    // Arrange — mobile GPU saver must not reuse reduceMotion's "no cycle" path.
+    vi.useFakeTimers();
+    component['reduceMotion'] = false;
+    component['saveGpu'] = true;
+    component['heroPaused'].set(false);
+    component['heroImageReady'].set(true);
+    component['heroIndex'].set(0);
+    component['lastFeaturedId'] = 'a';
+
+    // Act
+    component['startHeroCycle']();
+    vi.advanceTimersByTime(7500 + 250);
+    vi.advanceTimersByTime(450 + 550);
+
+    // Assert
+    expect(component['heroTimer']).toBeTruthy();
+    expect(component['heroIndex']()).toBe(1);
+    expect(component['kenBurnsAllowed']()).toBe(false);
+  });
+
   it('auto-advances after the dwell interval when not paused and image-ready', () => {
     vi.useFakeTimers();
     component['reduceMotion'] = false;

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.spec.ts
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.spec.ts
@@ -202,7 +202,9 @@ describe('HomepageHeroComponent', () => {
     fixture.componentRef.setInput('curatedEpisodeIds', ['a']);
     fixture.detectChanges();
 
-    const button = fixture.nativeElement.querySelector('button.billboard__curate') as HTMLButtonElement | null;
+    const button = fixture.nativeElement.querySelector(
+      'button.billboard__manage--curate'
+    ) as HTMLButtonElement | null;
     expect(button).toBeTruthy();
     button?.click();
     expect(removed).toEqual(['a']);
@@ -215,11 +217,32 @@ describe('HomepageHeroComponent', () => {
     fixture.componentRef.setInput('isCurator', true);
     fixture.detectChanges();
 
-    const buttons = fixture.nativeElement.querySelectorAll('button.billboard__manage') as NodeListOf<HTMLButtonElement>;
+    const buttons = fixture.nativeElement.querySelectorAll(
+      '.billboard__admin > button.billboard__manage:not(.billboard__manage--curate)'
+    ) as NodeListOf<HTMLButtonElement>;
     expect(buttons.length).toBe(2);
     buttons[0].click();
     buttons[1].click();
     expect(managed).toEqual(['hero', 'rails']);
+  });
+
+  it('keeps remove-from-hero inside the curator admin toolbar', () => {
+    fixture.componentRef.setInput('isCurator', true);
+    fixture.componentRef.setInput('curatedEpisodeIds', ['a']);
+    fixture.detectChanges();
+
+    const admin = fixture.nativeElement.querySelector('.billboard__admin') as HTMLElement | null;
+    const remove = fixture.nativeElement.querySelector(
+      'button.billboard__manage--curate'
+    ) as HTMLButtonElement | null;
+    const actionsRemove = fixture.nativeElement.querySelector(
+      '.billboard__actions button.billboard__manage--curate'
+    );
+
+    expect(admin).toBeTruthy();
+    expect(remove).toBeTruthy();
+    expect(admin?.contains(remove!)).toBe(true);
+    expect(actionsRemove).toBeNull();
   });
 
   it('image gate stays blocked until the fallback timeout when decode never completes', () => {

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.ts
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.ts
@@ -111,7 +111,10 @@ export class HomepageHeroComponent {
   private heroImageToken = 0;
   private heroDotsOverflowTimer: ReturnType<typeof setTimeout> | undefined;
   private reduceMotion = false;
+  /** Touch/narrow: skip Ken Burns only — auto-advance must keep running. */
+  private saveGpu = false;
   private motionQuery: MediaQueryList | undefined;
+  private gpuQuery: MediaQueryList | undefined;
   private hasInitializedIndex = false;
   private lastFeaturedId: string | undefined;
   private lastSlideSignature: string | undefined;
@@ -144,15 +147,24 @@ export class HomepageHeroComponent {
   };
 
   private readonly onMotionQueryChange = (): void => {
-    this.syncReduceMotion();
-    if (this.reduceMotion) {
+    this.syncMotionFlags();
+    if (this.reduceMotion || this.saveGpu) {
       this.heroKenBurnsA.set(false);
       this.heroKenBurnsB.set(false);
     }
+    // Restoring auto-advance when leaving reduced-motion (e.g. desktop resize).
+    if (!this.reduceMotion && this.slides().length > 1 && !this.heroTimer) {
+      this.startHeroCycle();
+    }
   };
 
-  private syncReduceMotion(): void {
+  private syncMotionFlags(): void {
     this.reduceMotion = !!this.motionQuery?.matches;
+    this.saveGpu = !!this.gpuQuery?.matches;
+  }
+
+  private kenBurnsAllowed(): boolean {
+    return !this.reduceMotion && !this.saveGpu;
   }
 
   private readonly onDotsScrollEvent = (): void => {
@@ -233,19 +245,22 @@ export class HomepageHeroComponent {
     });
 
     if (isPlatformBrowser(this.platformId)) {
-      // Phones/tablets: skip Ken Burns + crossfade GPU work (also avoids incomplete
-      // dialog compositing while a full-bleed transform is animating behind).
-      this.motionQuery = window.matchMedia(
-        '(prefers-reduced-motion: reduce), (max-width: 900px), (hover: none) and (pointer: coarse)'
+      // Accessibility only — disables auto-advance as well as Ken Burns.
+      this.motionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+      // Phones/tablets: skip Ken Burns GPU work; keep slide rotation.
+      this.gpuQuery = window.matchMedia(
+        '(max-width: 900px), (hover: none) and (pointer: coarse)'
       );
-      this.syncReduceMotion();
+      this.syncMotionFlags();
       this.motionQuery.addEventListener('change', this.onMotionQueryChange);
+      this.gpuQuery.addEventListener('change', this.onMotionQueryChange);
       window.addEventListener('resize', this.onResizeEvent, { passive: true });
       this.destroyRef.onDestroy(() => {
         this.stopHeroCycle();
         this.clearHeroContentTransition();
         this.clearHeroImageWait();
         this.motionQuery?.removeEventListener('change', this.onMotionQueryChange);
+        this.gpuQuery?.removeEventListener('change', this.onMotionQueryChange);
         window.removeEventListener('resize', this.onResizeEvent);
         this.dotsScrollTarget?.removeEventListener('scroll', this.onDotsScrollEvent);
         this.dotsScrollTarget = undefined;
@@ -518,7 +533,7 @@ export class HomepageHeroComponent {
       this.heroLayerA.set(url);
       this.heroLayerB.set(undefined);
       this.heroFrontLayer.set('a');
-      this.heroKenBurnsA.set(!!url && !this.reduceMotion);
+      this.heroKenBurnsA.set(!!url && this.kenBurnsAllowed());
       this.heroKenBurnsB.set(false);
       return;
     }
@@ -529,7 +544,7 @@ export class HomepageHeroComponent {
       requestAnimationFrame(() => {
         requestAnimationFrame(() => {
           this.heroFrontLayer.set('b');
-          this.heroKenBurnsB.set(!!url && !this.reduceMotion);
+          this.heroKenBurnsB.set(!!url && this.kenBurnsAllowed());
           this.scheduleOutgoingKenBurnsClear('a');
         });
       });
@@ -539,7 +554,7 @@ export class HomepageHeroComponent {
       requestAnimationFrame(() => {
         requestAnimationFrame(() => {
           this.heroFrontLayer.set('a');
-          this.heroKenBurnsA.set(!!url && !this.reduceMotion);
+          this.heroKenBurnsA.set(!!url && this.kenBurnsAllowed());
           this.scheduleOutgoingKenBurnsClear('b');
         });
       });
@@ -626,7 +641,7 @@ export class HomepageHeroComponent {
   }
 
   private enableKenBurnsOnFront(): void {
-    if (this.reduceMotion) {
+    if (!this.kenBurnsAllowed()) {
       return;
     }
     if (this.heroFrontLayer() === 'a') {

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.ts
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.ts
@@ -111,6 +111,7 @@ export class HomepageHeroComponent {
   private heroImageToken = 0;
   private heroDotsOverflowTimer: ReturnType<typeof setTimeout> | undefined;
   private reduceMotion = false;
+  private motionQuery: MediaQueryList | undefined;
   private hasInitializedIndex = false;
   private lastFeaturedId: string | undefined;
   private lastSlideSignature: string | undefined;
@@ -141,6 +142,18 @@ export class HomepageHeroComponent {
       this.scrollActiveHeroDotIntoView(this.heroIndex(), 'auto');
     });
   };
+
+  private readonly onMotionQueryChange = (): void => {
+    this.syncReduceMotion();
+    if (this.reduceMotion) {
+      this.heroKenBurnsA.set(false);
+      this.heroKenBurnsB.set(false);
+    }
+  };
+
+  private syncReduceMotion(): void {
+    this.reduceMotion = !!this.motionQuery?.matches;
+  }
 
   private readonly onDotsScrollEvent = (): void => {
     if (this.dotsScrollFrame) {
@@ -220,12 +233,19 @@ export class HomepageHeroComponent {
     });
 
     if (isPlatformBrowser(this.platformId)) {
-      this.reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      // Phones/tablets: skip Ken Burns + crossfade GPU work (also avoids incomplete
+      // dialog compositing while a full-bleed transform is animating behind).
+      this.motionQuery = window.matchMedia(
+        '(prefers-reduced-motion: reduce), (max-width: 900px), (hover: none) and (pointer: coarse)'
+      );
+      this.syncReduceMotion();
+      this.motionQuery.addEventListener('change', this.onMotionQueryChange);
       window.addEventListener('resize', this.onResizeEvent, { passive: true });
       this.destroyRef.onDestroy(() => {
         this.stopHeroCycle();
         this.clearHeroContentTransition();
         this.clearHeroImageWait();
+        this.motionQuery?.removeEventListener('change', this.onMotionQueryChange);
         window.removeEventListener('resize', this.onResizeEvent);
         this.dotsScrollTarget?.removeEventListener('scroll', this.onDotsScrollEvent);
         this.dotsScrollTarget = undefined;

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -1121,3 +1121,51 @@ option {
   from { width: 0; }
   to { width: 100%; }
 }
+
+/* Flix manage dialogs on mobile: avoid transform enter animations fighting
+   full-bleed hero layers (incomplete title paint until zoom/reflow). */
+.flix-manage-dialog.mat-mdc-dialog-panel,
+.cdk-overlay-pane.flix-manage-dialog {
+  max-height: min(90dvh, 90vh);
+}
+
+.flix-manage-dialog .mat-mdc-dialog-surface,
+.cdk-overlay-pane.flix-manage-dialog .mat-mdc-dialog-surface {
+  max-height: min(90dvh, 90vh);
+  display: flex;
+  flex-direction: column;
+  /* Own compositor layer so the title band paints without a forced zoom. */
+  transform: translateZ(0);
+  -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
+}
+
+.flix-manage-dialog .mat-mdc-dialog-title,
+.cdk-overlay-pane.flix-manage-dialog .mat-mdc-dialog-title {
+  flex-shrink: 0;
+}
+
+.flix-manage-dialog .mat-mdc-dialog-content,
+.cdk-overlay-pane.flix-manage-dialog .mat-mdc-dialog-content {
+  flex: 1 1 auto;
+  min-height: 0;
+  max-height: none;
+  overflow: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.flix-manage-dialog .mat-mdc-dialog-actions,
+.cdk-overlay-pane.flix-manage-dialog .mat-mdc-dialog-actions {
+  flex-shrink: 0;
+}
+
+@media screen and (max-width: 900px), (hover: none) and (pointer: coarse) {
+  .back-to-top {
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+
+  .cdk-overlay-container {
+    transform: translateZ(0);
+  }
+}


### PR DESCRIPTION
## Summary
- Move **Remove from hero** into the curator admin toolbar with Manage hero / Manage rails so it no longer sits under absolute-positioned controls.
- Stack admin tools above the pager, and below ~1280px place controls in normal flow under the feature copy (no overlay clash).
- On mobile (≤600px), admin buttons become full-width so each has its own hit target.
- Keep the hero title below the absolute homepage search on short/mobile viewports via shared `--nflx-hero-search-clearance` and a non-shrinking spacer.
- Mobile perf: disable Ken Burns, grain, and backdrop-blur on touch/narrow; open manage dialogs with `90dvh` + no enter animation so the title band paints without zooming.

## Test plan
- [ ] As curator on flix homepage at ~900–1200px width: Manage hero, Remove from hero, and Manage rails are all separately clickable
- [ ] At phone width: Remove from hero is not covered by Manage hero/rails; tap works
- [ ] Watch / More info remain usable and do not collide with admin tools
- [ ] Wide desktop still shows admin + pager bottom-right without overlapping feature actions
- [ ] Non-curator view unchanged (Watch / More info / pager only)
- [ ] Phone width with a long hero title: title does not sit under the Search field/button
- [ ] Desktop homepage: search + hero still look correct (no large empty gap)
- [ ] Phone: homepage scroll feels smoother (no continuous Ken Burns zoom)
- [ ] Phone: open Manage hero / Manage rails — dialog title and top content visible without zooming
- [ ] Desktop: Ken Burns still runs on the hero when motion is allowed
- [ ] `npx ng test --watch=false --include=**/homepage-hero.component.spec.ts` (and related) passed