### PR TITLE
feat(ui): Flix dual-theme trial (OS light mode)

### DIFF
--- a/cultpodcasts/src/app/app.component.sass
+++ b/cultpodcasts/src/app/app.component.sass
@@ -75,6 +75,7 @@
                 background: var(--nflx-search-glass, rgba(20, 20, 20, 0.85)) !important
                 backdrop-filter: blur(10px)
                 color: var(--nflx-text, #fff) !important
+                box-shadow: 0 0 0 1px var(--nflx-border-strong), 0 1px 2px color-mix(in srgb, #000 12%, transparent)
             .mdc-notched-outline__leading,
             .mdc-notched-outline__notch,
             .mdc-notched-outline__trailing

--- a/cultpodcasts/src/app/app.component.sass
+++ b/cultpodcasts/src/app/app.component.sass
@@ -15,10 +15,35 @@
     background: var(--nflx-bg, #0b0b0b)
     // Keep <app-search-bar> in the DOM for stable hydration; hide visually on home.
     .chrome-search
-        display: none
+        display: none !important
 
 .browse-shell
     background: var(--nflx-bg, #0b0b0b)
+
+// Home toolbar: keep cinematic dark overlay (host-context can lose to light Material).
+.home-shell > app-toolbar
+    ::ng-deep
+        .app-toolbar
+            position: absolute
+            top: 0
+            left: 0
+            right: 0
+            z-index: 20
+            background: linear-gradient(to bottom, rgba(0, 0, 0, 0.8), transparent) !important
+            border-bottom-color: transparent !important
+            backdrop-filter: none !important
+            -webkit-backdrop-filter: none !important
+            color: #fff !important
+        #site
+            color: #fff !important
+        #site span
+            position: absolute !important
+            width: 1px !important
+            height: 1px !important
+            overflow: hidden !important
+            clip: rect(0, 0, 0, 0) !important
+        button#menu
+            color: #fff !important
 
 .browse-chrome-search
     // Match the horizontal rhythm of .browse-filters / .browse-grid (both use

--- a/cultpodcasts/src/app/app.component.sass
+++ b/cultpodcasts/src/app/app.component.sass
@@ -83,17 +83,30 @@
             input.mat-mdc-chip-input,
             #searchtext
                 font-size: 1.05rem
-                color: var(--nflx-text, #fff) !important
-                caret-color: var(--nflx-text, #fff) !important
+                color: var(--nflx-text, #0b0d12) !important
+                caret-color: var(--nflx-text, #0b0d12) !important
                 &::placeholder
-                    color: var(--nflx-muted, #b3b3b3) !important
-            .mat-mdc-chip
-                --mdc-chip-label-text-color: var(--nflx-text, #fff)
+                    color: var(--nflx-muted, #5c564c) !important
+                    opacity: 1 !important
+                &::-webkit-input-placeholder
+                    color: var(--nflx-muted, #5c564c) !important
+                    opacity: 1 !important
+            .mat-mdc-chip,
+            .mdc-evolution-chip
+                --mdc-chip-label-text-color: var(--nflx-text, #0b0d12)
                 --mdc-chip-outline-color: var(--nflx-border-strong)
-                color: var(--nflx-text, #fff)
+                --mdc-chip-elevated-container-color: color-mix(in srgb, var(--nflx-text, #0b0d12) 8%, transparent)
+                --mdc-chip-flat-selected-container-color: color-mix(in srgb, var(--nflx-text, #0b0d12) 8%, transparent)
+                color: var(--nflx-text, #0b0d12) !important
+                background: color-mix(in srgb, var(--nflx-text, #0b0d12) 10%, transparent) !important
+                border-color: var(--nflx-border-strong) !important
+            .mat-mdc-chip .mdc-evolution-chip__text-label,
+            .mat-mdc-chip .chiptext
+                color: var(--nflx-text, #0b0d12) !important
             .mat-mdc-chip-remove,
-            .mat-icon
-                color: var(--nflx-muted, #b3b3b3) !important
+            .mat-mdc-chip .mat-icon,
+            .mat-mdc-chip mat-icon
+                color: var(--nflx-muted, #5c564c) !important
         #searchcta
             background: var(--nflx-accent, #e8a23a) !important
             color: #111 !important

--- a/cultpodcasts/src/app/app.component.sass
+++ b/cultpodcasts/src/app/app.component.sass
@@ -12,13 +12,13 @@
     padding-bottom: 4px
 
 .home-shell
-    background: #0b0b0b
+    background: var(--nflx-bg, #0b0b0b)
     // Keep <app-search-bar> in the DOM for stable hydration; hide visually on home.
     .chrome-search
         display: none
 
 .browse-shell
-    background: #0b0b0b
+    background: var(--nflx-bg, #0b0b0b)
 
 .browse-chrome-search
     // Match the horizontal rhythm of .browse-filters / .browse-grid (both use
@@ -47,7 +47,7 @@
             .mdc-text-field,
             .mdc-text-field--outlined,
             .mdc-text-field--no-label
-                background: rgba(20, 20, 20, 0.85) !important
+                background: var(--nflx-search-glass, rgba(20, 20, 20, 0.85)) !important
                 backdrop-filter: blur(10px)
             input.mat-mdc-chip-input,
             #searchtext

--- a/cultpodcasts/src/app/app.component.sass
+++ b/cultpodcasts/src/app/app.component.sass
@@ -49,11 +49,27 @@
             .mdc-text-field--no-label
                 background: var(--nflx-search-glass, rgba(20, 20, 20, 0.85)) !important
                 backdrop-filter: blur(10px)
+                color: var(--nflx-text, #fff) !important
+            .mdc-notched-outline__leading,
+            .mdc-notched-outline__notch,
+            .mdc-notched-outline__trailing
+                border-color: var(--nflx-border-strong) !important
             input.mat-mdc-chip-input,
             #searchtext
                 font-size: 1.05rem
+                color: var(--nflx-text, #fff) !important
+                caret-color: var(--nflx-text, #fff) !important
+                &::placeholder
+                    color: var(--nflx-muted, #b3b3b3) !important
+            .mat-mdc-chip
+                --mdc-chip-label-text-color: var(--nflx-text, #fff)
+                --mdc-chip-outline-color: var(--nflx-border-strong)
+                color: var(--nflx-text, #fff)
+            .mat-mdc-chip-remove,
+            .mat-icon
+                color: var(--nflx-muted, #b3b3b3) !important
         #searchcta
-            background: #e8a23a !important
+            background: var(--nflx-accent, #e8a23a) !important
             color: #111 !important
 
 .drop-overlay

--- a/cultpodcasts/src/app/bookmarks-api/bookmarks-api.component.sass
+++ b/cultpodcasts/src/app/bookmarks-api/bookmarks-api.component.sass
@@ -26,15 +26,15 @@
     width: 36px
     height: 36px
     padding: 0
-    border: 1px solid rgba(255, 255, 255, 0.35)
+    border: 1px solid var(--nflx-border-strong, rgba(255, 255, 255, 0.35))
     border-radius: 50%
-    background: rgba(26, 26, 26, 0.9)
-    color: #fff
+    background: color-mix(in srgb, var(--nflx-panel, #1a1a1a) 90%, transparent)
+    color: var(--nflx-on-media, #fff)
     mat-icon
         color: inherit
     &:hover,
     &:focus-visible
-        background: rgba(255, 255, 255, 0.15)
+        background: var(--nflx-hover, rgba(255, 255, 255, 0.15))
         border-color: var(--nflx-accent, #e8a23a)
         outline: none
 

--- a/cultpodcasts/src/app/discovery-api/discovery-api.component.sass
+++ b/cultpodcasts/src/app/discovery-api/discovery-api.component.sass
@@ -21,7 +21,7 @@
     margin: 0 0 14px
     padding: 10px 12px
     border-radius: var(--cp-radius, 14px)
-    border: 1px solid color-mix(in srgb, #fff 10%, transparent)
+    border: 1px solid color-mix(in srgb, var(--mat-sys-outline-variant, #fff) 65%, transparent)
     background: color-mix(in srgb, var(--cp-ink-elevated, #141821) 94%, transparent)
     backdrop-filter: blur(10px)
 

--- a/cultpodcasts/src/app/discovery-item/discovery-item.component.sass
+++ b/cultpodcasts/src/app/discovery-item/discovery-item.component.sass
@@ -1,9 +1,9 @@
 mat-card.curator-card
     margin-bottom: 12px
     padding: 12px
-    border: 1px solid color-mix(in srgb, #fff 10%, transparent)
+    border: 1px solid color-mix(in srgb, var(--mat-sys-outline-variant, #fff) 65%, transparent)
     border-radius: var(--cp-radius, 14px)
-    background: color-mix(in srgb, var(--cp-ink-elevated, #141821) 92%, #1c2433)
+    background: var(--mat-sys-surface-container, color-mix(in srgb, var(--cp-ink-elevated, #141821) 92%, #1c2433))
     h3
         font-weight: bold
         margin-bottom: 2px
@@ -32,9 +32,9 @@ mat-card.curator-card
     font-weight: 600
     padding: 3px 10px
     border-radius: 999px
-    background: color-mix(in srgb, #fff 10%, transparent)
+    background: color-mix(in srgb, var(--mat-sys-on-surface, #fff) 8%, transparent)
     color: color-mix(in srgb, var(--mat-sys-on-surface, #e8e8e8) 85%, transparent)
-    border: 1px solid color-mix(in srgb, #fff 12%, transparent)
+    border: 1px solid color-mix(in srgb, var(--mat-sys-outline-variant, #fff) 65%, transparent)
 
 .score-likely
     background: color-mix(in srgb, var(--cp-amber, #e8a23a) 22%, transparent)
@@ -52,7 +52,7 @@ mat-card.curator-card
     color: #ef9a9a
 
 .score-unscored
-    background: color-mix(in srgb, #fff 8%, transparent)
+    background: color-mix(in srgb, var(--mat-sys-on-surface, #fff) 8%, transparent)
     color: color-mix(in srgb, var(--mat-sys-on-surface, #e8e8e8) 55%, transparent)
 
 .multipleMatchingPodcasts

--- a/cultpodcasts/src/app/episode-poster/episode-poster.component.sass
+++ b/cultpodcasts/src/app/episode-poster/episode-poster.component.sass
@@ -79,7 +79,7 @@
         font-size: 40px
         width: 40px
         height: 40px
-        color: #fff
+        color: var(--nflx-on-media, #fff)
         // text-shadow instead of filter:drop-shadow — filter forces a layer on every poster.
         text-shadow: 0 2px 8px rgba(0, 0, 0, 0.6)
 
@@ -88,7 +88,7 @@
     font-weight: 700
     letter-spacing: 0.04em
     text-transform: uppercase
-    color: #fff
+    color: var(--nflx-on-media, #fff)
     text-shadow: 0 1px 6px rgba(0, 0, 0, 0.7)
 
 .episode-poster__promote
@@ -240,7 +240,7 @@
     font-size: 0.92rem
     font-weight: 600
     line-height: 1.25
-    color: #fff
+    color: var(--nflx-text)
 
 // Result grids have wider cards and no date heading — give titles room to finish.
 :host-context(.browse-grid) .episode-poster__episode

--- a/cultpodcasts/src/app/episode-rail/episode-rail.component.sass
+++ b/cultpodcasts/src/app/episode-rail/episode-rail.component.sass
@@ -23,7 +23,7 @@
     font-size: 1.25rem
     font-weight: 700
     letter-spacing: 0.01em
-    color: #fff
+    color: var(--nflx-text)
 
 .rail__title--link
     display: inline-flex
@@ -59,9 +59,9 @@
     height: 32px
     padding: 0
     border-radius: 50%
-    border: 1px solid color-mix(in srgb, #fff 18%, transparent)
-    background: color-mix(in srgb, #000 45%, transparent)
-    color: color-mix(in srgb, #fff 55%, transparent)
+    border: 1px solid var(--nflx-border, color-mix(in srgb, #fff 18%, transparent))
+    background: color-mix(in srgb, var(--nflx-bg, #000) 45%, transparent)
+    color: color-mix(in srgb, var(--nflx-text, #fff) 55%, transparent)
     cursor: pointer
     transition: color 0.15s ease, border-color 0.15s ease, background 0.15s ease, transform 0.15s ease
     mat-icon
@@ -71,7 +71,7 @@
         transform: rotate(45deg)
     &:hover,
     &:focus-visible
-        color: #fff
+        color: var(--nflx-text)
         border-color: var(--nflx-accent)
         outline: none
     &.is-pinned
@@ -89,7 +89,7 @@
     white-space: nowrap
     &:hover,
     &:focus-visible
-        color: #fff
+        color: var(--nflx-text)
         outline: none
 
 .rail__scroller

--- a/cultpodcasts/src/app/episodes-api/episodes-api.component.sass
+++ b/cultpodcasts/src/app/episodes-api/episodes-api.component.sass
@@ -13,7 +13,7 @@
     margin: 0 0 14px
     padding: 10px 12px
     border-radius: var(--cp-radius, 14px)
-    border: 1px solid color-mix(in srgb, #fff 10%, transparent)
+    border: 1px solid color-mix(in srgb, var(--mat-sys-outline-variant, #fff) 65%, transparent)
     background: color-mix(in srgb, var(--cp-ink-elevated, #141821) 94%, transparent)
     backdrop-filter: blur(10px)
 
@@ -42,9 +42,9 @@
 .curator-card
     margin-bottom: 12px
     padding: 12px
-    border: 1px solid color-mix(in srgb, #fff 10%, transparent)
+    border: 1px solid color-mix(in srgb, var(--mat-sys-outline-variant, #fff) 65%, transparent)
     border-radius: var(--cp-radius, 14px)
-    background: color-mix(in srgb, var(--cp-ink-elevated, #141821) 92%, #1c2433)
+    background: var(--mat-sys-surface-container, color-mix(in srgb, var(--cp-ink-elevated, #141821) 92%, #1c2433))
 
 .curator-card__body
     display: flex

--- a/cultpodcasts/src/app/hero-manage-dialog/hero-manage-dialog.component.sass
+++ b/cultpodcasts/src/app/hero-manage-dialog/hero-manage-dialog.component.sass
@@ -33,8 +33,8 @@
     gap: 10px
     padding: 8px 10px
     border-radius: 10px
-    background: color-mix(in srgb, var(--cp-ink-elevated, #141821) 88%, #1c2433)
-    border: 1px solid color-mix(in srgb, #fff 10%, transparent)
+    background: var(--mat-sys-surface-container, color-mix(in srgb, var(--cp-ink-elevated, #141821) 88%, #1c2433))
+    border: 1px solid color-mix(in srgb, var(--mat-sys-outline-variant, #fff) 65%, transparent)
     &.cdk-drag-preview
         box-shadow: 0 12px 32px #000000a6
     &--autofill
@@ -48,7 +48,7 @@
     padding: 0
     border: 0
     background: transparent
-    color: color-mix(in srgb, #fff 55%, transparent)
+    color: color-mix(in srgb, var(--mat-sys-on-surface, #fff) 55%, transparent)
     cursor: grab
     &:active
         cursor: grabbing

--- a/cultpodcasts/src/app/homepage-api/homepage-api.component.sass
+++ b/cultpodcasts/src/app/homepage-api/homepage-api.component.sass
@@ -39,7 +39,7 @@
             .mdc-text-field,
             .mdc-text-field--outlined,
             .mdc-text-field--no-label
-                background: rgba(20, 20, 20, 0.72) !important
+                background: var(--nflx-search-glass-on-media, rgba(20, 20, 20, 0.72)) !important
                 backdrop-filter: blur(10px)
             input.mat-mdc-chip-input,
             #searchtext

--- a/cultpodcasts/src/app/homepage-api/homepage-api.component.sass
+++ b/cultpodcasts/src/app/homepage-api/homepage-api.component.sass
@@ -35,41 +35,44 @@
         #searchbar
             gap: 12px
         #searchbox
-            // Dark glass over hero — keep light ink even when OS prefers light.
+            // Always dark panel on the billboard (ignore light --nflx-search-glass).
             .mat-mdc-text-field-wrapper,
             .mdc-text-field,
             .mdc-text-field--outlined,
             .mdc-text-field--no-label
-                background: var(--nflx-search-glass-on-media, rgba(20, 20, 20, 0.72)) !important
+                background: rgba(12, 12, 12, 0.88) !important
                 backdrop-filter: blur(10px)
-                color: var(--nflx-on-media, #fff) !important
+                color: #fff !important
             .mdc-notched-outline__leading,
             .mdc-notched-outline__notch,
             .mdc-notched-outline__trailing
-                border-color: color-mix(in srgb, var(--nflx-on-media, #fff) 35%, transparent) !important
+                border-color: rgba(255, 255, 255, 0.45) !important
             .mat-mdc-form-field:hover .mdc-notched-outline__leading,
             .mat-mdc-form-field:hover .mdc-notched-outline__notch,
             .mat-mdc-form-field:hover .mdc-notched-outline__trailing,
             .mdc-text-field--focused .mdc-notched-outline__leading,
             .mdc-text-field--focused .mdc-notched-outline__notch,
             .mdc-text-field--focused .mdc-notched-outline__trailing
-                border-color: color-mix(in srgb, var(--nflx-on-media, #fff) 55%, transparent) !important
+                border-color: rgba(255, 255, 255, 0.7) !important
             input.mat-mdc-chip-input,
             #searchtext
                 font-size: 1.05rem
-                color: var(--nflx-on-media, #fff) !important
-                caret-color: var(--nflx-on-media, #fff) !important
+                color: #fff !important
+                caret-color: #fff !important
                 &::placeholder
-                    color: color-mix(in srgb, var(--nflx-on-media, #fff) 55%, transparent) !important
+                    color: rgba(255, 255, 255, 0.65) !important
+                    opacity: 1 !important
             .mat-mdc-chip
-                --mdc-chip-label-text-color: var(--nflx-on-media, #fff)
-                --mdc-chip-outline-color: color-mix(in srgb, var(--nflx-on-media, #fff) 35%, transparent)
-                color: var(--nflx-on-media, #fff)
+                --mdc-chip-label-text-color: #fff
+                --mdc-chip-outline-color: rgba(255, 255, 255, 0.4)
+                --mdc-chip-elevated-container-color: rgba(255, 255, 255, 0.12)
+                color: #fff !important
+                background: rgba(255, 255, 255, 0.12) !important
             .mat-mdc-chip-remove,
             .mat-icon
-                color: color-mix(in srgb, var(--nflx-on-media, #fff) 75%, transparent) !important
+                color: rgba(255, 255, 255, 0.8) !important
         #searchcta
-            background: var(--nflx-accent) !important
+            background: var(--nflx-accent, #e8a23a) !important
             color: #111 !important
 
 @media screen and (max-width: 900px), (hover: none) and (pointer: coarse)

--- a/cultpodcasts/src/app/homepage-api/homepage-api.component.sass
+++ b/cultpodcasts/src/app/homepage-api/homepage-api.component.sass
@@ -35,15 +35,39 @@
         #searchbar
             gap: 12px
         #searchbox
+            // Dark glass over hero — keep light ink even when OS prefers light.
             .mat-mdc-text-field-wrapper,
             .mdc-text-field,
             .mdc-text-field--outlined,
             .mdc-text-field--no-label
                 background: var(--nflx-search-glass-on-media, rgba(20, 20, 20, 0.72)) !important
                 backdrop-filter: blur(10px)
+                color: var(--nflx-on-media, #fff) !important
+            .mdc-notched-outline__leading,
+            .mdc-notched-outline__notch,
+            .mdc-notched-outline__trailing
+                border-color: color-mix(in srgb, var(--nflx-on-media, #fff) 35%, transparent) !important
+            .mat-mdc-form-field:hover .mdc-notched-outline__leading,
+            .mat-mdc-form-field:hover .mdc-notched-outline__notch,
+            .mat-mdc-form-field:hover .mdc-notched-outline__trailing,
+            .mdc-text-field--focused .mdc-notched-outline__leading,
+            .mdc-text-field--focused .mdc-notched-outline__notch,
+            .mdc-text-field--focused .mdc-notched-outline__trailing
+                border-color: color-mix(in srgb, var(--nflx-on-media, #fff) 55%, transparent) !important
             input.mat-mdc-chip-input,
             #searchtext
                 font-size: 1.05rem
+                color: var(--nflx-on-media, #fff) !important
+                caret-color: var(--nflx-on-media, #fff) !important
+                &::placeholder
+                    color: color-mix(in srgb, var(--nflx-on-media, #fff) 55%, transparent) !important
+            .mat-mdc-chip
+                --mdc-chip-label-text-color: var(--nflx-on-media, #fff)
+                --mdc-chip-outline-color: color-mix(in srgb, var(--nflx-on-media, #fff) 35%, transparent)
+                color: var(--nflx-on-media, #fff)
+            .mat-mdc-chip-remove,
+            .mat-icon
+                color: color-mix(in srgb, var(--nflx-on-media, #fff) 75%, transparent) !important
         #searchcta
             background: var(--nflx-accent) !important
             color: #111 !important

--- a/cultpodcasts/src/app/homepage-catalogue/homepage-catalogue.component.sass
+++ b/cultpodcasts/src/app/homepage-catalogue/homepage-catalogue.component.sass
@@ -16,9 +16,9 @@
     margin: 0 auto
     padding: 28px 28px 32px
     border-radius: 18px
-    background: linear-gradient(145deg, #1c1c1cf2, #0e0e0efa)
-    border: 1px solid #ffffff14
-    box-shadow: 0 24px 60px #00000073
+    background: linear-gradient(145deg, var(--nflx-panel-solid, #1c1c1c), var(--nflx-panel, #0e0e0e))
+    border: 1px solid var(--nflx-panel-edge, #ffffff14)
+    box-shadow: 0 24px 60px color-mix(in srgb, #000 45%, transparent)
 
 .catalogue__stat
     text-align: center
@@ -26,7 +26,7 @@
 
 .catalogue__stat--hero
     padding: 0 8px
-    border-inline: 1px solid #ffffff14
+    border-inline: 1px solid var(--nflx-panel-edge, #ffffff14)
 
 .catalogue__value
     margin: 0 0 6px
@@ -35,7 +35,7 @@
     font-weight: 400
     line-height: 1
     letter-spacing: -0.03em
-    color: #fff
+    color: var(--nflx-text)
     font-variant-numeric: tabular-nums
 
 .catalogue__value--count
@@ -61,7 +61,7 @@
         text-decoration: underline dashed 1px
         text-underline-offset: 3px
         &:hover
-            color: #fff
+            color: var(--nflx-text)
 
 @media screen and (max-width: 700px)
     .catalogue__inner
@@ -72,4 +72,4 @@
         order: -1
         padding: 0 0 18px
         border-inline: 0
-        border-bottom: 1px solid #ffffff14
+        border-bottom: 1px solid var(--nflx-panel-edge, #ffffff14)

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
@@ -31,7 +31,8 @@
     background-size: 160px 160px
 
 .billboard__scrim
-    background: linear-gradient(85deg, rgba(0, 0, 0, 0.94) 0%, rgba(0, 0, 0, 0.62) 38%, rgba(0, 0, 0, 0.15) 68%, transparent 82%), linear-gradient(to top, var(--nflx-bg, #0b0b0b) 0%, transparent 45%), linear-gradient(to bottom, rgba(0, 0, 0, 0.55) 0%, transparent 22%)
+    // Always fade into near-black — never --nflx-bg (cream in light mode washes out on-media copy).
+    background: linear-gradient(85deg, rgba(0, 0, 0, 0.94) 0%, rgba(0, 0, 0, 0.62) 38%, rgba(0, 0, 0, 0.15) 68%, transparent 82%), linear-gradient(to top, #0b0b0b 0%, transparent 45%), linear-gradient(to bottom, rgba(0, 0, 0, 0.55) 0%, transparent 22%)
 
 .billboard__vignette
     background: radial-gradient(ellipse at 70% 40%, transparent 20%, rgba(0, 0, 0, 0.45) 100%)

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
@@ -55,6 +55,7 @@
     z-index: 2
     width: min(640px, 100%)
     pointer-events: auto
+    color: var(--nflx-on-media, #fff)
 
 .billboard__feature
     opacity: 1
@@ -90,14 +91,15 @@
     font-weight: 400
     line-height: 1.02
     letter-spacing: -0.025em
+    color: var(--nflx-on-media, #fff)
     text-shadow: 0 4px 40px #000000bf
 
 .billboard__meta
     margin: 0 0 12px
     font-size: 0.95rem
-    color: var(--nflx-muted)
+    color: var(--nflx-on-media-muted, #e8e8e8)
     a
-        color: var(--nflx-text, #fff)
+        color: var(--nflx-on-media, #fff)
         text-decoration: none
         font-weight: 600
         &:hover
@@ -112,7 +114,7 @@
     border-radius: 999px
     background: #ffffff1f
     border: 1px solid #ffffff38
-    color: #fff
+    color: var(--nflx-on-media, #fff)
     font-size: 0.78rem
     font-weight: 600
     vertical-align: middle
@@ -129,7 +131,7 @@
     margin: 0 0 22px
     font-size: 1.05rem
     line-height: 1.45
-    color: #e8e8e8
+    color: var(--nflx-on-media-muted, #e8e8e8)
     max-width: 36em
     text-shadow: 0 1px 12px #0000008c
 

--- a/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.sass
+++ b/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.sass
@@ -13,7 +13,7 @@
     margin: 0 0 14px
     padding: 10px 12px
     border-radius: var(--cp-radius, 14px)
-    border: 1px solid color-mix(in srgb, #fff 10%, transparent)
+    border: 1px solid color-mix(in srgb, var(--mat-sys-outline-variant, #fff) 65%, transparent)
     background: color-mix(in srgb, var(--cp-ink-elevated, #141821) 94%, transparent)
     backdrop-filter: blur(10px)
 
@@ -45,9 +45,9 @@
 .curator-card
     margin-bottom: 12px
     padding: 12px
-    border: 1px solid color-mix(in srgb, #fff 10%, transparent)
+    border: 1px solid color-mix(in srgb, var(--mat-sys-outline-variant, #fff) 65%, transparent)
     border-radius: var(--cp-radius, 14px)
-    background: color-mix(in srgb, var(--cp-ink-elevated, #141821) 92%, #1c2433)
+    background: var(--mat-sys-surface-container, color-mix(in srgb, var(--cp-ink-elevated, #141821) 92%, #1c2433))
 
 .curator-card__body
     display: flex

--- a/cultpodcasts/src/app/podcast-episode/podcast-episode.component.sass
+++ b/cultpodcasts/src/app/podcast-episode/podcast-episode.component.sass
@@ -24,7 +24,8 @@
 .episode-backdrop__scrim
     position: absolute
     inset: 0
-    background: linear-gradient(180deg, rgba(0, 0, 0, 0.25) 0%, rgba(0, 0, 0, 0.65) 55%, var(--nflx-bg) 98%), linear-gradient(100deg, rgba(0, 0, 0, 0.8) 0%, rgba(0, 0, 0, 0.3) 48%, transparent 78%)
+    // Always fade to near-black — cream --nflx-bg in light mode washes out hero copy.
+    background: linear-gradient(180deg, rgba(0, 0, 0, 0.35) 0%, rgba(0, 0, 0, 0.72) 55%, #0b0b0b 98%), linear-gradient(100deg, rgba(0, 0, 0, 0.85) 0%, rgba(0, 0, 0, 0.4) 48%, transparent 78%)
 
 .episode-toolbar
     position: absolute
@@ -58,6 +59,7 @@
     padding: 0 4vw
     max-width: 900px
     box-sizing: border-box
+    color: var(--nflx-on-media, #fff)
 
 .episode-hero__eyebrow
     margin: 0 0 8px
@@ -90,6 +92,7 @@
     font-weight: 400
     line-height: 1.05
     letter-spacing: -0.02em
+    color: var(--nflx-on-media, #fff)
     text-shadow: 0 4px 32px rgba(0, 0, 0, 0.7)
 
 .episode-hero__meta
@@ -99,7 +102,7 @@
     gap: 8px
     font-size: 0.95rem
     font-weight: 600
-    color: var(--nflx-muted)
+    color: var(--nflx-on-media-muted, #e8e8e8)
     font-variant-numeric: tabular-nums
 
 .episode-hero__dot
@@ -129,8 +132,10 @@
     max-width: 42em
     font-size: 1.05rem
     line-height: 1.5
-    color: #e8e8e8
-    text-shadow: 0 1px 10px rgba(0, 0, 0, 0.4)
+    color: var(--nflx-on-media-muted, #e8e8e8)
+    text-shadow: 0 1px 10px rgba(0, 0, 0, 0.55)
+    a
+        color: var(--nflx-on-media, #fff)
 
 .episode-hero__subjects
     display: flex
@@ -160,9 +165,9 @@
     gap: 6px
     margin: 0
     padding: 9px 16px
-    border: 1px solid rgba(255, 255, 255, 0.4)
+    border: 1px solid rgba(255, 255, 255, 0.45)
     border-radius: 4px
-    background: rgba(109, 109, 110, 0.35)
+    background: rgba(20, 20, 20, 0.55)
     color: #fff
     font: inherit
     font-size: 0.92rem

--- a/cultpodcasts/src/app/podcast-episode/podcast-episode.component.sass
+++ b/cultpodcasts/src/app/podcast-episode/podcast-episode.component.sass
@@ -55,11 +55,17 @@
 .episode-hero
     position: relative
     z-index: 2
+    // Pull up over the backdrop, then sit on a full-bleed black band so
+    // light-mode cream --nflx-bg never shows behind on-media copy.
     margin-top: -140px
-    padding: 0 4vw
-    max-width: 900px
+    padding: 28px 4vw 48px
+    max-width: none
+    width: 100%
     box-sizing: border-box
     color: var(--nflx-on-media, #fff)
+    background: linear-gradient(180deg, transparent 0%, rgba(11, 11, 11, 0.88) 56px, #0b0b0b 130px)
+    > *
+        max-width: 900px
 
 .episode-hero__eyebrow
     margin: 0 0 8px

--- a/cultpodcasts/src/app/rails-manage-dialog/rails-manage-dialog.component.sass
+++ b/cultpodcasts/src/app/rails-manage-dialog/rails-manage-dialog.component.sass
@@ -33,8 +33,8 @@
     gap: 10px
     padding: 8px 10px
     border-radius: 10px
-    background: color-mix(in srgb, var(--cp-ink-elevated, #141821) 88%, #1c2433)
-    border: 1px solid color-mix(in srgb, #fff 10%, transparent)
+    background: var(--mat-sys-surface-container, color-mix(in srgb, var(--cp-ink-elevated, #141821) 88%, #1c2433))
+    border: 1px solid color-mix(in srgb, var(--mat-sys-outline-variant, #fff) 65%, transparent)
     &.cdk-drag-preview
         box-shadow: 0 12px 32px #000000a6
 
@@ -45,7 +45,7 @@
     padding: 0
     border: 0
     background: transparent
-    color: color-mix(in srgb, #fff 55%, transparent)
+    color: color-mix(in srgb, var(--mat-sys-on-surface, #fff) 55%, transparent)
     cursor: grab
     &:active
         cursor: grabbing

--- a/cultpodcasts/src/app/search-bar/search-bar.component.sass
+++ b/cultpodcasts/src/app/search-bar/search-bar.component.sass
@@ -94,7 +94,7 @@
                     opacity: 0.6
                 &:hover,
                 &.active
-                    background: rgba(255, 255, 255, 0.08)
+                    background: color-mix(in srgb, var(--mat-sys-on-surface) 8%, transparent)
         #searchcta
             align-self: center
             display: inline-flex

--- a/cultpodcasts/src/app/toolbar/toolbar.component.sass
+++ b/cultpodcasts/src/app/toolbar/toolbar.component.sass
@@ -102,9 +102,9 @@ button#menu
         border-bottom-color: transparent
         backdrop-filter: none
         -webkit-backdrop-filter: none
-        color: #fff
+        color: var(--nflx-on-media, #fff)
     #site
-        color: #fff
+        color: var(--nflx-on-media, #fff)
     #site span
         position: absolute
         width: 1px
@@ -112,4 +112,16 @@ button#menu
         overflow: hidden
         clip: rect(0, 0, 0, 0)
     button#menu
-        color: #fff
+        color: var(--nflx-on-media, #fff)
+
+// Browse routes use the same frosted bar as Material chrome, but tinted with
+// Flix tokens so light OS theme does not sit cream-on-black.
+:host-context(.browse-shell)
+    .app-toolbar
+        background: color-mix(in srgb, var(--nflx-panel, var(--cp-ink-elevated)) 78%, transparent) !important
+        color: var(--nflx-text, var(--mat-sys-on-surface))
+        border-bottom: 1px solid var(--nflx-border, color-mix(in srgb, var(--mat-sys-outline-variant) 45%, transparent))
+    #site
+        color: var(--nflx-text, var(--mat-sys-on-surface))
+    button#menu
+        color: var(--nflx-text, var(--mat-sys-on-surface))

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -625,6 +625,21 @@ option {
     --cp-amber: #b86a00;
     --cp-amber-soft: color-mix(in srgb, #e8a23a 28%, transparent);
     --cp-mist: color-mix(in srgb, #2a6f8a 10%, transparent);
+    // Flix dual-theme trial — browse/homepage chrome follows OS light mode.
+    // --nflx-on-media* stay light for text over artwork scrims.
+    --nflx-bg: #f4f0e8;
+    --nflx-panel: #fffdf8;
+    --nflx-text: #0b0d12;
+    --nflx-muted: #5c564c;
+    --nflx-accent: #b86a00;
+    --nflx-border: color-mix(in srgb, #0b0d12 14%, transparent);
+    --nflx-border-strong: color-mix(in srgb, #0b0d12 28%, transparent);
+    --nflx-hover: color-mix(in srgb, #0b0d12 8%, transparent);
+    --nflx-search-glass: color-mix(in srgb, #fffdf8 82%, transparent);
+    --nflx-panel-solid: #fffdf8;
+    --nflx-panel-edge: color-mix(in srgb, #0b0d12 12%, transparent);
+    --nflx-pill-active-bg: #0b0d12;
+    --nflx-pill-active-fg: #f4f0e8;
   }
 
   body {
@@ -806,13 +821,27 @@ option {
   }
 }
 
-/* Shared flix / browse chrome tokens (homepage .nflx, episode .episode, .browse). */
+/* Shared flix / browse chrome tokens (homepage .nflx, episode .episode, .browse).
+   Light overrides live in the prefers-color-scheme: light block above. */
 :root {
   --nflx-bg: #0b0b0b;
   --nflx-panel: #141414;
   --nflx-text: #fff;
   --nflx-muted: #b3b3b3;
   --nflx-accent: #e8a23a;
+  --nflx-border: color-mix(in srgb, #fff 18%, transparent);
+  --nflx-border-strong: color-mix(in srgb, #fff 35%, transparent);
+  --nflx-hover: color-mix(in srgb, #fff 10%, transparent);
+  --nflx-search-glass: rgba(20, 20, 20, 0.72);
+  /* Homepage search sits on the hero — always dark glass for contrast on artwork. */
+  --nflx-search-glass-on-media: rgba(20, 20, 20, 0.72);
+  --nflx-panel-solid: #1c1c1c;
+  --nflx-panel-edge: color-mix(in srgb, #fff 8%, transparent);
+  --nflx-pill-active-bg: #fff;
+  --nflx-pill-active-fg: #111;
+  /* Always-light ink for hero / poster overlays on dark media scrims. */
+  --nflx-on-media: #fff;
+  --nflx-on-media-muted: #e8e8e8;
 }
 
 /* ——— Browse shell (search / subject / podcast — matches nflx homepage) ——— */
@@ -852,7 +881,7 @@ option {
   font-size: clamp(1.6rem, 4vw, 2.2rem);
   font-weight: 400;
   letter-spacing: -0.02em;
-  color: #fff;
+  color: var(--nflx-text);
   line-height: 1.15;
 }
 
@@ -862,10 +891,10 @@ option {
   gap: 2px;
   margin: 0;
   padding: 6px 4px 6px 10px;
-  border: 1px solid rgba(255, 255, 255, 0.35);
+  border: 1px solid var(--nflx-border-strong);
   border-radius: 2px;
   background: transparent;
-  color: #fff;
+  color: var(--nflx-text);
   font: inherit;
   font-size: 0.9rem;
   font-weight: 500;
@@ -880,7 +909,7 @@ option {
   }
   &:hover,
   &:focus-visible {
-    background: rgba(255, 255, 255, 0.08);
+    background: var(--nflx-hover);
     outline: none;
   }
 }
@@ -923,10 +952,10 @@ option {
   scroll-snap-align: start;
   margin: 0;
   padding: 7px 16px;
-  border: 1px solid rgba(255, 255, 255, 0.35);
+  border: 1px solid var(--nflx-border-strong);
   border-radius: 999px;
   background: transparent;
-  color: #fff;
+  color: var(--nflx-text);
   font: inherit;
   font-size: 0.88rem;
   font-weight: 500;
@@ -936,13 +965,13 @@ option {
   transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
   &:hover,
   &:focus-visible {
-    background: rgba(255, 255, 255, 0.1);
+    background: var(--nflx-hover);
     outline: none;
   }
   &.is-active {
-    background: #fff;
-    border-color: #fff;
-    color: #111;
+    background: var(--nflx-pill-active-bg);
+    border-color: var(--nflx-pill-active-bg);
+    color: var(--nflx-pill-active-fg);
     font-weight: 700;
   }
 }
@@ -973,7 +1002,7 @@ option {
   text-underline-offset: 3px;
   &:hover,
   &:focus-visible {
-    color: #fff;
+    color: var(--nflx-text);
     outline: none;
   }
 }
@@ -1044,7 +1073,7 @@ option {
   color: var(--nflx-muted);
 
   h2 {
-    color: #fff;
+    color: var(--nflx-text);
     font-family: var(--cp-font-display, 'Instrument Serif', Georgia, serif);
     font-weight: 400;
   }

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -625,21 +625,6 @@ option {
     --cp-amber: #b86a00;
     --cp-amber-soft: color-mix(in srgb, #e8a23a 28%, transparent);
     --cp-mist: color-mix(in srgb, #2a6f8a 10%, transparent);
-    // Flix dual-theme trial — browse/homepage chrome follows OS light mode.
-    // --nflx-on-media* stay light for text over artwork scrims.
-    --nflx-bg: #f4f0e8;
-    --nflx-panel: #fffdf8;
-    --nflx-text: #0b0d12;
-    --nflx-muted: #5c564c;
-    --nflx-accent: #b86a00;
-    --nflx-border: color-mix(in srgb, #0b0d12 14%, transparent);
-    --nflx-border-strong: color-mix(in srgb, #0b0d12 28%, transparent);
-    --nflx-hover: color-mix(in srgb, #0b0d12 8%, transparent);
-    --nflx-search-glass: color-mix(in srgb, #fffdf8 82%, transparent);
-    --nflx-panel-solid: #fffdf8;
-    --nflx-panel-edge: color-mix(in srgb, #0b0d12 12%, transparent);
-    --nflx-pill-active-bg: #0b0d12;
-    --nflx-pill-active-fg: #f4f0e8;
   }
 
   body {
@@ -821,8 +806,7 @@ option {
   }
 }
 
-/* Shared flix / browse chrome tokens (homepage .nflx, episode .episode, .browse).
-   Light overrides live in the prefers-color-scheme: light block above. */
+/* Shared flix / browse chrome tokens (homepage .nflx, episode .episode, .browse). */
 :root {
   --nflx-bg: #0b0b0b;
   --nflx-panel: #141414;
@@ -842,6 +826,25 @@ option {
   /* Always-light ink for hero / poster overlays on dark media scrims. */
   --nflx-on-media: #fff;
   --nflx-on-media-muted: #e8e8e8;
+}
+
+/* Must follow :root dark defaults or light tokens lose the cascade. */
+@media (prefers-color-scheme: light) {
+  :root {
+    --nflx-bg: #f4f0e8;
+    --nflx-panel: #fffdf8;
+    --nflx-text: #0b0d12;
+    --nflx-muted: #5c564c;
+    --nflx-accent: #b86a00;
+    --nflx-border: color-mix(in srgb, #0b0d12 14%, transparent);
+    --nflx-border-strong: color-mix(in srgb, #0b0d12 28%, transparent);
+    --nflx-hover: color-mix(in srgb, #0b0d12 8%, transparent);
+    --nflx-search-glass: color-mix(in srgb, #fffdf8 92%, transparent);
+    --nflx-panel-solid: #fffdf8;
+    --nflx-panel-edge: color-mix(in srgb, #0b0d12 12%, transparent);
+    --nflx-pill-active-bg: #0b0d12;
+    --nflx-pill-active-fg: #f4f0e8;
+  }
 }
 
 /* ——— Browse shell (search / subject / podcast — matches nflx homepage) ——— */

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -836,12 +836,12 @@ option {
     --nflx-text: #0b0d12;
     --nflx-muted: #5c564c;
     --nflx-accent: #b86a00;
-    --nflx-border: color-mix(in srgb, #0b0d12 14%, transparent);
-    --nflx-border-strong: color-mix(in srgb, #0b0d12 28%, transparent);
+    --nflx-border: color-mix(in srgb, #0b0d12 18%, transparent);
+    --nflx-border-strong: color-mix(in srgb, #0b0d12 36%, transparent);
     --nflx-hover: color-mix(in srgb, #0b0d12 8%, transparent);
-    --nflx-search-glass: color-mix(in srgb, #fffdf8 92%, transparent);
+    --nflx-search-glass: #fffdf8;
     --nflx-panel-solid: #fffdf8;
-    --nflx-panel-edge: color-mix(in srgb, #0b0d12 12%, transparent);
+    --nflx-panel-edge: color-mix(in srgb, #0b0d12 18%, transparent);
     --nflx-pill-active-bg: #0b0d12;
     --nflx-pill-active-fg: #f4f0e8;
   }


### PR DESCRIPTION
## Summary
- Trial dual-theme for Flix: light `--nflx-*` tokens follow `prefers-color-scheme: light` (after dark `:root` defaults so cascade wins)
- Keep cinematic on-media chrome for homepage/episode heroes (dark search glass, black scrims/bands, light ink over artwork)
- Theme browse chrome, rails, posters, catalogue, toolbar; fix manage-dialog and curator borders for Material light surfaces
- Raise browse search chip/placeholder/border contrast on cream chrome

Preview: https://flix-dual-theme-trial.website-83e.pages.dev

## Test plan
- [ ] OS light mode: homepage hero + search readable; stats/rails on cream look intentional
- [ ] OS light mode: episode detail description/meta readable on black hero band
- [ ] OS light mode: browse/search pages — search field, chips, placeholder high contrast
- [ ] OS dark mode: no regression vs current Flix
- [ ] Curator manage hero/rails dialogs: borders and drag handles visible in light mode
- [ ] Spot-check discovery/episodes curator lists for outline visibility
