### PR TITLE
fix(ui): encode podcast names ending in ? for edit episode

### DIFF
--- a/cultpodcasts/src/app/add-episode-dialog/add-episode-dialog.component.ts
+++ b/cultpodcasts/src/app/add-episode-dialog/add-episode-dialog.component.ts
@@ -137,6 +137,7 @@ export class AddEpisodeDialogComponent {
 
       const podcast = await this.getPodcast(headers, this.podcastId);
       if (!podcast) {
+        this.isLoading.set(false);
         this.isInError.set(true);
         return;
       }

--- a/cultpodcasts/src/app/add-episode-dialog/add-episode-dialog.component.ts
+++ b/cultpodcasts/src/app/add-episode-dialog/add-episode-dialog.component.ts
@@ -445,7 +445,7 @@ export class AddEpisodeDialogComponent {
       return null;
     }
     try {
-      const podcastEndpoint = new URL(`/podcast/${podcastId}`, environment.api).toString();
+      const podcastEndpoint = new URL(`/podcast/${encodeURIComponent(podcastId)}`, environment.api).toString();
       const podcast = await firstValueFrom(this.http.get<Podcast>(podcastEndpoint, { headers: headers }));
       return podcast;
     } catch {

--- a/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.ts
+++ b/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.ts
@@ -136,6 +136,7 @@ export class EditEpisodeDialogComponent {
 
       const podcast = await this.getPodcast(headers, this.podcastIdentifier);
       if (!podcast) {
+        this.isLoading.set(false);
         this.isInError.set(true);
         return;
       }
@@ -410,7 +411,12 @@ export class EditEpisodeDialogComponent {
       return null;
     }
     try {
-      const podcastEndpoint = new URL(`/podcast/${podcastIdentifier}`, environment.api).toString();
+      // encodeURIComponent so names ending in '?' (e.g. "Was I In A Cult?") are not
+      // treated as the start of a query string by `new URL(...)`.
+      const path = this.episodeId
+        ? `/podcast/${encodeURIComponent(podcastIdentifier)}/${this.episodeId}`
+        : `/podcast/${encodeURIComponent(podcastIdentifier)}`;
+      const podcastEndpoint = new URL(path, environment.api).toString();
       const podcast = await firstValueFrom(this.http.get<Podcast>(podcastEndpoint, { headers: headers }));
       return podcast;
     } catch {


### PR DESCRIPTION
## Summary
- Encode podcast names in edit-episode `getPodcast` and include the episode id (same pattern as edit-podcast), so names like "Was I In A Cult?" are not truncated at `?` by `new URL(...)`
- Clear the loading spinner when podcast fetch fails so the dialog shows the error instead of spinning forever
- Same spinner + encode hardening on add-episode

## Test plan
- [ ] Open Edit Episode on https://cultpodcasts.com/podcast/Was%20I%20In%20A%20Cult%3F/{episodeId}
- [ ] Confirm network call is `GET /podcast/Was%20I%20In%20A%20Cult%3F/{episodeId}` (200) and the form loads
- [ ] If the podcast call fails, dialog shows "An error occurred" (not infinite spinner)