### PR TITLE
fix(ui): edit-episode getPodcast must use /podcast/{guid} for ids

### DIFF
--- a/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.ts
+++ b/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.ts
@@ -413,9 +413,12 @@ export class EditEpisodeDialogComponent {
     try {
       // encodeURIComponent so names ending in '?' (e.g. "Was I In A Cult?") are not
       // treated as the start of a query string by `new URL(...)`.
-      const path = this.episodeId
-        ? `/podcast/${encodeURIComponent(podcastIdentifier)}/${this.episodeId}`
-        : `/podcast/${encodeURIComponent(podcastIdentifier)}`;
+      // Only append episodeId for *name* lookups (disambiguation). Guid identifiers must
+      // hit GET /podcast/{id} — /podcast/{guid}/{episodeId} is treated as a name route and 404s.
+      const encoded = encodeURIComponent(podcastIdentifier);
+      const path = this.episodeId && !isPodcastGuid(podcastIdentifier)
+        ? `/podcast/${encoded}/${this.episodeId}`
+        : `/podcast/${encoded}`;
       const podcastEndpoint = new URL(path, environment.api).toString();
       const podcast = await firstValueFrom(this.http.get<Podcast>(podcastEndpoint, { headers: headers }));
       return podcast;
@@ -423,4 +426,10 @@ export class EditEpisodeDialogComponent {
       return null;
     }
   }
+}
+
+const podcastGuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function isPodcastGuid(identifier: string): boolean {
+  return podcastGuidPattern.test(identifier);
 }


### PR DESCRIPTION
## Summary
- Regression from #443: always appending episode id made curator episode-review edits call `GET /podcast/{podcastGuid}/{episodeGuid}`
- API treats that first segment as a **name**, so guid ids 404
- Only append episode id when the identifier is a podcast **name** (still encoded for `?`); guids use `GET /podcast/{id}`

## Test plan
- [ ] From `/episodes/[\"{podcastId}/{episodeId}\"]` (index/submit review), Edit Episode loads (200 on `/podcast/{guid}`)
- [ ] Edit episode on `Was I In A Cult?` still calls `/podcast/Was%20I%20In%20A%20Cult%3F/{episodeId}` and loads