### PR TITLE
fix(ui): greyscale Android footer social icon

### DIFF
--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -314,7 +314,6 @@ footer {
     padding: 0;
     margin: 0;
     line-height: 16px;
-    filter: none;
   }
 }
 


### PR DESCRIPTION
## Summary
- Remove `filter: none` on the footer Android `mat-icon` so it uses the same `grayscale(1)` treatment as Reddit, GitHub, Twitter, and Bluesky preview icons.

## Test plan
- [ ] Open site footer with socials enabled
- [ ] Confirm Android preview icon matches the muted grey of the other social icons
- [ ] Confirm social menu still shows brand-coloured icons

Made with [Cursor](https://cursor.com)