### PR TITLE
fix(ui): Watch CTA and wide art for BBC iPlayer / Internet Archive

### DIFF
--- a/cultpodcasts/src/app/bookmarks-api/bookmarks-api.component.ts
+++ b/cultpodcasts/src/app/bookmarks-api/bookmarks-api.component.ts
@@ -25,7 +25,7 @@ import { SiteLoadingComponent } from '../site-loading/site-loading.component';
 import { BrowseLoadingSkeletonComponent } from '../browse-loading-skeleton/browse-loading-skeleton.component';
 import { apiEpisodeToHomepageEpisode } from '../api-episode-display';
 import { SearchDisplayEpisode } from '../search-result-links';
-import { canPlayEpisode } from '../episode-embed';
+import { startEpisodePlayback } from '../episode-embed';
 import { PlayerService } from '../player.service';
 
 export enum sortMode {
@@ -298,10 +298,7 @@ export class BookmarksApiComponent {
   }
 
   playEpisode(episode: SearchDisplayEpisode): void {
-    if (!canPlayEpisode(episode)) {
-      return;
-    }
-    this.playerService.play(episode);
+    startEpisodePlayback(episode, (playable) => this.playerService.play(playable));
   }
 
   isPlayingId(id: string): boolean {

--- a/cultpodcasts/src/app/episode-embed.spec.ts
+++ b/cultpodcasts/src/app/episode-embed.spec.ts
@@ -1,12 +1,16 @@
 import {
   appleEmbedUrl,
+  canEmbedEpisode,
+  canPlayEpisode,
   episodeEmbedOptions,
   playActionLabel,
   preferredEmbedService,
   spotifyEmbedUrl,
+  startEpisodePlayback,
   youtubeEmbedUrl,
 } from './episode-embed';
 import { HomepageEpisode } from './homepage-episode.interface';
+import { SearchDisplayEpisode } from './search-result-links';
 
 function episode(partial: Partial<HomepageEpisode> = {}): HomepageEpisode {
   return {
@@ -64,7 +68,61 @@ describe('episode-embed', () => {
     expect(playActionLabel(episode())).toBe('Listen');
   });
 
-  it('returns no options when no embeddable links exist', () => {
+  it('returns no embed options when no embeddable links exist', () => {
     expect(episodeEmbedOptions(episode())).toEqual([]);
+    expect(canEmbedEpisode(episode())).toBe(false);
+  });
+
+  it('offers Watch for BBC iPlayer and Internet Archive without embedding', () => {
+    const iplayer = episode({
+      bbc: new URL('https://www.bbc.co.uk/iplayer/episode/p0abc123/jared-leto'),
+      image: new URL('https://i.scdn.co/image/opaque'),
+    });
+    const archive = episode({
+      internetArchive: new URL('https://archive.org/details/example-video'),
+    });
+    const sounds = episode({
+      bbc: new URL('https://www.bbc.co.uk/sounds/play/m001abcd'),
+    });
+
+    expect(canEmbedEpisode(iplayer)).toBe(false);
+    expect(canPlayEpisode(iplayer)).toBe(true);
+    expect(playActionLabel(iplayer)).toBe('Watch');
+
+    expect(canPlayEpisode(archive)).toBe(true);
+    expect(playActionLabel(archive)).toBe('Watch');
+
+    expect(canPlayEpisode(sounds)).toBe(false);
+    expect(playActionLabel(sounds)).toBe('Listen');
+  });
+
+  it('prefers in-app Listen over outbound Watch when Spotify and iPlayer both exist', () => {
+    const both = episode({
+      spotify: new URL('https://open.spotify.com/episode/7ouMYWpwJ422jRcDASZB7P'),
+      bbc: new URL('https://www.bbc.co.uk/iplayer/episode/p0abc123/jared-leto'),
+    });
+    expect(canEmbedEpisode(both)).toBe(true);
+    expect(playActionLabel(both)).toBe('Listen');
+  });
+
+  it('starts embed playback or opens external Watch', () => {
+    const yt = episode({
+      youtube: new URL('https://www.youtube.com/watch?v=abc123DEF45'),
+    });
+    const iplayer = episode({
+      bbc: new URL('https://www.bbc.co.uk/iplayer/episode/p0abc123/jared-leto'),
+    });
+    const played: SearchDisplayEpisode[] = [];
+    const opened: string[] = [];
+
+    expect(startEpisodePlayback(yt, (ep) => played.push(ep), (url) => opened.push(url.toString()))).toBe(true);
+    expect(played).toHaveLength(1);
+    expect(opened).toHaveLength(0);
+
+    expect(startEpisodePlayback(iplayer, (ep) => played.push(ep), (url) => opened.push(url.toString()))).toBe(true);
+    expect(played).toHaveLength(1);
+    expect(opened).toEqual(['https://www.bbc.co.uk/iplayer/episode/p0abc123/jared-leto']);
+
+    expect(startEpisodePlayback(episode(), (ep) => played.push(ep), (url) => opened.push(url.toString()))).toBe(false);
   });
 });

--- a/cultpodcasts/src/app/episode-embed.spec.ts
+++ b/cultpodcasts/src/app/episode-embed.spec.ts
@@ -92,7 +92,8 @@ describe('episode-embed', () => {
     expect(canPlayEpisode(archive)).toBe(true);
     expect(playActionLabel(archive)).toBe('Watch');
 
-    expect(canPlayEpisode(sounds)).toBe(false);
+    expect(canEmbedEpisode(sounds)).toBe(false);
+    expect(canPlayEpisode(sounds)).toBe(true);
     expect(playActionLabel(sounds)).toBe('Listen');
   });
 
@@ -105,12 +106,15 @@ describe('episode-embed', () => {
     expect(playActionLabel(both)).toBe('Listen');
   });
 
-  it('starts embed playback or opens external Watch', () => {
+  it('starts embed playback or opens external Watch / Listen', () => {
     const yt = episode({
       youtube: new URL('https://www.youtube.com/watch?v=abc123DEF45'),
     });
     const iplayer = episode({
       bbc: new URL('https://www.bbc.co.uk/iplayer/episode/p0abc123/jared-leto'),
+    });
+    const sounds = episode({
+      bbc: new URL('https://www.bbc.co.uk/sounds/play/m001abcd'),
     });
     const played: SearchDisplayEpisode[] = [];
     const opened: string[] = [];
@@ -122,6 +126,13 @@ describe('episode-embed', () => {
     expect(startEpisodePlayback(iplayer, (ep) => played.push(ep), (url) => opened.push(url.toString()))).toBe(true);
     expect(played).toHaveLength(1);
     expect(opened).toEqual(['https://www.bbc.co.uk/iplayer/episode/p0abc123/jared-leto']);
+
+    expect(startEpisodePlayback(sounds, (ep) => played.push(ep), (url) => opened.push(url.toString()))).toBe(true);
+    expect(played).toHaveLength(1);
+    expect(opened).toEqual([
+      'https://www.bbc.co.uk/iplayer/episode/p0abc123/jared-leto',
+      'https://www.bbc.co.uk/sounds/play/m001abcd',
+    ]);
 
     expect(startEpisodePlayback(episode(), (ep) => played.push(ep), (url) => opened.push(url.toString()))).toBe(false);
   });

--- a/cultpodcasts/src/app/episode-embed.ts
+++ b/cultpodcasts/src/app/episode-embed.ts
@@ -1,4 +1,10 @@
-import { SearchDisplayEpisode, appleUrl, spotifyUrl, youtubeUrl } from './search-result-links';
+import {
+  SearchDisplayEpisode,
+  appleUrl,
+  externalWatchUrl,
+  spotifyUrl,
+  youtubeUrl,
+} from './search-result-links';
 
 export type EmbedService = 'youtube' | 'spotify' | 'apple';
 
@@ -58,14 +64,57 @@ export function preferredEmbedService(options: EpisodeEmbedOption[]): EmbedServi
   return options[0]?.service;
 }
 
-/** Primary CTA label: Watch when YouTube is preferred, otherwise Listen. */
-export function playActionLabel(episode: SearchDisplayEpisode): 'Watch' | 'Listen' {
-  const preferred = preferredEmbedService(episodeEmbedOptions(episode));
-  return preferred === 'youtube' ? 'Watch' : 'Listen';
+/** True when the episode can play in the in-app player (YouTube / Spotify / Apple embed). */
+export function canEmbedEpisode(episode: SearchDisplayEpisode): boolean {
+  return episodeEmbedOptions(episode).length > 0;
 }
 
+/**
+ * Primary CTA visibility: in-app embed **or** outbound video Watch (BBC iPlayer /
+ * Internet Archive). Embeddable audio/video still wins for the actual click handler.
+ */
 export function canPlayEpisode(episode: SearchDisplayEpisode): boolean {
-  return episodeEmbedOptions(episode).length > 0;
+  return canEmbedEpisode(episode) || !!externalWatchUrl(episode);
+}
+
+/** Primary CTA label: Watch for YouTube or external video; Listen for Spotify/Apple. */
+export function playActionLabel(episode: SearchDisplayEpisode): 'Watch' | 'Listen' {
+  const preferred = preferredEmbedService(episodeEmbedOptions(episode));
+  if (preferred === 'youtube') {
+    return 'Watch';
+  }
+  if (preferred === 'spotify' || preferred === 'apple') {
+    return 'Listen';
+  }
+  if (externalWatchUrl(episode)) {
+    return 'Watch';
+  }
+  return 'Listen';
+}
+
+/**
+ * Start in-app embed playback, or open BBC iPlayer / Internet Archive in a new tab.
+ * Returns whether a playback action was taken.
+ */
+export function startEpisodePlayback(
+  episode: SearchDisplayEpisode,
+  playEmbed: (episode: SearchDisplayEpisode) => void,
+  openExternal: (url: URL) => void = defaultOpenExternal
+): boolean {
+  if (canEmbedEpisode(episode)) {
+    playEmbed(episode);
+    return true;
+  }
+  const external = externalWatchUrl(episode);
+  if (external) {
+    openExternal(external);
+    return true;
+  }
+  return false;
+}
+
+function defaultOpenExternal(url: URL): void {
+  window.open(url.toString(), '_blank', 'noopener,noreferrer');
 }
 
 export function youtubeEmbedUrl(watchUrl: URL): string | undefined {

--- a/cultpodcasts/src/app/episode-embed.ts
+++ b/cultpodcasts/src/app/episode-embed.ts
@@ -1,6 +1,8 @@
 import {
   SearchDisplayEpisode,
   appleUrl,
+  externalListenUrl,
+  externalPlaybackUrl,
   externalWatchUrl,
   spotifyUrl,
   youtubeUrl,
@@ -70,14 +72,17 @@ export function canEmbedEpisode(episode: SearchDisplayEpisode): boolean {
 }
 
 /**
- * Primary CTA visibility: in-app embed **or** outbound video Watch (BBC iPlayer /
- * Internet Archive). Embeddable audio/video still wins for the actual click handler.
+ * Primary CTA visibility: in-app embed **or** outbound Watch/Listen (BBC iPlayer /
+ * Internet Archive / BBC Sounds). Embeddable audio/video still wins for the click handler.
  */
 export function canPlayEpisode(episode: SearchDisplayEpisode): boolean {
-  return canEmbedEpisode(episode) || !!externalWatchUrl(episode);
+  return canEmbedEpisode(episode) || !!externalPlaybackUrl(episode);
 }
 
-/** Primary CTA label: Watch for YouTube or external video; Listen for Spotify/Apple. */
+/**
+ * Primary CTA label: Watch for YouTube or external video; Listen for Spotify/Apple
+ * or external audio (BBC Sounds).
+ */
 export function playActionLabel(episode: SearchDisplayEpisode): 'Watch' | 'Listen' {
   const preferred = preferredEmbedService(episodeEmbedOptions(episode));
   if (preferred === 'youtube') {
@@ -89,12 +94,15 @@ export function playActionLabel(episode: SearchDisplayEpisode): 'Watch' | 'Liste
   if (externalWatchUrl(episode)) {
     return 'Watch';
   }
+  if (externalListenUrl(episode)) {
+    return 'Listen';
+  }
   return 'Listen';
 }
 
 /**
- * Start in-app embed playback, or open BBC iPlayer / Internet Archive in a new tab.
- * Returns whether a playback action was taken.
+ * Start in-app embed playback, or open BBC iPlayer / Internet Archive / Sounds
+ * in a new tab. Returns whether a playback action was taken.
  */
 export function startEpisodePlayback(
   episode: SearchDisplayEpisode,
@@ -105,7 +113,7 @@ export function startEpisodePlayback(
     playEmbed(episode);
     return true;
   }
-  const external = externalWatchUrl(episode);
+  const external = externalPlaybackUrl(episode);
   if (external) {
     openExternal(external);
     return true;

--- a/cultpodcasts/src/app/episode-image/episode-image.component.html
+++ b/cultpodcasts/src/app/episode-image/episode-image.component.html
@@ -10,50 +10,50 @@
             <div class="links">
                 @if (youtube) {
                 <div class="link">
-                    <a href="{{youtube}}" mat-icon-button>
+                    <a href="{{youtube}}" mat-icon-button target="_blank" rel="noopener noreferrer">
                         <mat-icon svgIcon="youtube"></mat-icon>
                     </a>
-                    <label><a href="{{youtube}}">YouTube</a></label>
+                    <label><a href="{{youtube}}" target="_blank" rel="noopener noreferrer">YouTube</a></label>
                 </div>
                 }
                 @if (spotify) {
                 <div class="link">
-                    <a href="{{spotify}}" mat-icon-button>
+                    <a href="{{spotify}}" mat-icon-button target="_blank" rel="noopener noreferrer">
                         <mat-icon svgIcon="spotify"></mat-icon>
                     </a>
-                    <label><a href="{{spotify}}">Spotify</a></label>
+                    <label><a href="{{spotify}}" target="_blank" rel="noopener noreferrer">Spotify</a></label>
                 </div>
                 }
                 @if (applePodcasts) {
                 <div class="link">
-                    <a href="{{applePodcasts}}" mat-icon-button>
+                    <a href="{{applePodcasts}}" mat-icon-button target="_blank" rel="noopener noreferrer">
                         <mat-icon><app-apple-podcasts-svg></app-apple-podcasts-svg></mat-icon>
                     </a>
-                    <label><a href="{{applePodcasts}}">Apple</a></label>
+                    <label><a href="{{applePodcasts}}" target="_blank" rel="noopener noreferrer">Apple</a></label>
                 </div>
                 }
                 @if (bbciPlayer) {
                 <div class="link">
-                    <a href="{{bbciPlayer}}" mat-icon-button>
+                    <a href="{{bbciPlayer}}" mat-icon-button target="_blank" rel="noopener noreferrer">
                         <mat-icon svgIcon="bbc-iplayer"></mat-icon>
                     </a>
-                    <label><a href="{{bbciPlayer}}">BBC iPlayer</a></label>
+                    <label><a href="{{bbciPlayer}}" target="_blank" rel="noopener noreferrer">BBC iPlayer</a></label>
                 </div>
                 }
                 @if (bbcSounds) {
                 <div class="link">
-                    <a href="{{bbcSounds}}" mat-icon-button>
+                    <a href="{{bbcSounds}}" mat-icon-button target="_blank" rel="noopener noreferrer">
                         <mat-icon svgIcon="bbc-sounds"></mat-icon>
                     </a>
-                    <label><a href="{{bbcSounds}}">BBC Sounds</a></label>
+                    <label><a href="{{bbcSounds}}" target="_blank" rel="noopener noreferrer">BBC Sounds</a></label>
                 </div>
                 }
                 @if (internetArchive) {
                 <div class="link">
-                    <a href="{{internetArchive}}" mat-icon-button>
+                    <a href="{{internetArchive}}" mat-icon-button target="_blank" rel="noopener noreferrer">
                         <mat-icon svgIcon="internet-archive"></mat-icon>
                     </a>
-                    <label><a href="{{internetArchive}}">Archive.org</a></label>
+                    <label><a href="{{internetArchive}}" target="_blank" rel="noopener noreferrer">Archive.org</a></label>
                 </div>
                 }
             </div>

--- a/cultpodcasts/src/app/episode-links/episode-links.component.html
+++ b/cultpodcasts/src/app/episode-links/episode-links.component.html
@@ -1,32 +1,32 @@
 @if (episode) {
 <div id="episodelinks">
     @if (youtube) {
-    <a href="{{youtube}}" mat-icon-button>
+    <a href="{{youtube}}" mat-icon-button target="_blank" rel="noopener noreferrer">
         <mat-icon svgIcon="youtube"></mat-icon>
     </a>
     }
     @if (spotify) {
-    <a href="{{spotify}}" mat-icon-button>
+    <a href="{{spotify}}" mat-icon-button target="_blank" rel="noopener noreferrer">
         <mat-icon svgIcon="spotify"></mat-icon>
     </a>
     }
     @if (applePodcasts) {
-    <a href="{{applePodcasts}}" mat-icon-button>
+    <a href="{{applePodcasts}}" mat-icon-button target="_blank" rel="noopener noreferrer">
         <mat-icon><app-apple-podcasts-svg></app-apple-podcasts-svg></mat-icon>
     </a>
     }
     @if (bbciPlayer) {
-    <a href="{{bbciPlayer}}" mat-icon-button>
+    <a href="{{bbciPlayer}}" mat-icon-button target="_blank" rel="noopener noreferrer">
         <mat-icon svgIcon="bbc-iplayer"></mat-icon>
     </a>
     }
     @if (bbcSounds) {
-    <a href="{{bbcSounds}}" mat-icon-button>
+    <a href="{{bbcSounds}}" mat-icon-button target="_blank" rel="noopener noreferrer">
         <mat-icon svgIcon="bbc-sounds"></mat-icon>
     </a>
     }
     @if (internetArchive) {
-    <a href="{{internetArchive}}" mat-icon-button>
+    <a href="{{internetArchive}}" mat-icon-button target="_blank" rel="noopener noreferrer">
         <mat-icon svgIcon="internet-archive"></mat-icon>
     </a>
     }

--- a/cultpodcasts/src/app/episode-podcast-links/episode-podcast-links.component.html
+++ b/cultpodcasts/src/app/episode-podcast-links/episode-podcast-links.component.html
@@ -1,5 +1,5 @@
 @if (_episode?.urls?.youtube) {
-<a href="{{_episode?.urls?.youtube}}" mat-icon-button>
+<a href="{{_episode?.urls?.youtube}}" mat-icon-button target="_blank" rel="noopener noreferrer">
     <mat-icon svgIcon="youtube"></mat-icon>
 </a>
 } @else if (_episode?.youTubePodcast) {
@@ -9,7 +9,7 @@
 }
 
 @if (_episode?.urls?.spotify) {
-<a href="{{_episode?.urls?.spotify}}" mat-icon-button>
+<a href="{{_episode?.urls?.spotify}}" mat-icon-button target="_blank" rel="noopener noreferrer">
     <mat-icon svgIcon="spotify"></mat-icon>
 </a>
 } @else if (_episode?.spotifyPodcast) {
@@ -19,7 +19,7 @@
 }
 
 @if (_episode?.urls?.apple) {
-<a href="{{_episode?.urls?.apple}}" mat-icon-button>
+<a href="{{_episode?.urls?.apple}}" mat-icon-button target="_blank" rel="noopener noreferrer">
     <mat-icon><app-apple-podcasts-svg></app-apple-podcasts-svg></mat-icon>
 </a>
 } @else if (_episode?.applePodcast) {
@@ -29,7 +29,7 @@
 }
 
 @if (this.isSounds() || this.isIplayer()) {
-<a href="{{_episode?.urls?.bbc}}" mat-icon-button>
+<a href="{{_episode?.urls?.bbc}}" mat-icon-button target="_blank" rel="noopener noreferrer">
 
     @if (this.isIplayer()) {
     <mat-icon svgIcon="bbc-iplayer"></mat-icon>
@@ -40,7 +40,7 @@
 }
 
 @if (_episode?.urls?.internetArchive) {
-<a href="{{_episode?.urls?.internetArchive}}" mat-icon-button>
+<a href="{{_episode?.urls?.internetArchive}}" mat-icon-button target="_blank" rel="noopener noreferrer">
     <mat-icon svgIcon="internet-archive"></mat-icon>
 </a>
 }

--- a/cultpodcasts/src/app/episode-poster/episode-poster.component.html
+++ b/cultpodcasts/src/app/episode-poster/episode-poster.component.html
@@ -42,12 +42,14 @@
   <button type="button" class="episode-poster__cta" (click)="onPlay($event)">
     {{ playLabel() }}
   </button>
+  @if (queueable()) {
   <button type="button" class="episode-poster__queue-btn" [class.is-queued]="queued()"
     [attr.aria-label]="queued() ? 'Remove from queue' : 'Add to queue'"
     [attr.title]="queued() ? 'Remove from queue' : 'Add to queue'"
     (click)="onToggleQueue($event)">
     <mat-icon>{{ queued() ? 'playlist_add_check' : 'playlist_add' }}</mat-icon>
   </button>
+  }
   }
   @if (languageBadge() || duration() || (showRelease() && releaseLabel())) {
   <div class="episode-poster__meta-badges">

--- a/cultpodcasts/src/app/episode-poster/episode-poster.component.ts
+++ b/cultpodcasts/src/app/episode-poster/episode-poster.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, computed, inject, input, output } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { MatIconModule } from '@angular/material/icon';
-import { canPlayEpisode, playActionLabel } from '../episode-embed';
+import { canEmbedEpisode, canPlayEpisode, playActionLabel, startEpisodePlayback } from '../episode-embed';
 import { languageFlagBadgeForEpisode, LanguageFlagBadge } from '../language-flag';
 import { SearchDisplayEpisode, episodeArtAspect, episodeImageUrl } from '../search-result-links';
 import { displayCatalogName } from '../display-catalog-name';
@@ -58,10 +58,13 @@ export class EpisodePosterComponent {
     episodeImageUrl(this.episode())?.toString()
   );
 
-  /** YouTube thumbnail → wide 16:9; Spotify/Apple/feed art → square. */
+  /** YouTube / external video → wide 16:9; Spotify/Apple/feed art → square. */
   protected readonly artAspect = computed(() => episodeArtAspect(this.episode()));
 
   protected readonly playable = computed(() => canPlayEpisode(this.episode()));
+
+  /** In-app queue only when we can embed; outbound Watch has nothing to enqueue. */
+  protected readonly queueable = computed(() => canEmbedEpisode(this.episode()));
 
   protected readonly playLabel = computed(() => playActionLabel(this.episode()));
 
@@ -87,15 +90,13 @@ export class EpisodePosterComponent {
   onPlay(event?: Event): void {
     event?.preventDefault();
     event?.stopPropagation();
-    if (this.playable()) {
-      this.play.emit(this.episode());
-    }
+    startEpisodePlayback(this.episode(), (ep) => this.play.emit(ep));
   }
 
   onToggleQueue(event?: Event): void {
     event?.preventDefault();
     event?.stopPropagation();
-    if (this.playable()) {
+    if (this.queueable()) {
       this.playerService.toggleQueue(this.episode());
     }
   }

--- a/cultpodcasts/src/app/homepage-api/homepage-api.component.ts
+++ b/cultpodcasts/src/app/homepage-api/homepage-api.component.ts
@@ -24,7 +24,7 @@ import { episodeImageUrl } from '../search-result-links';
 import { SearchDisplayEpisode } from '../search-result-links';
 import { pickObscureCults } from '../obscure-cults';
 import { SiteLoadingComponent } from '../site-loading/site-loading.component';
-import { episodeEmbedOptions } from '../episode-embed';
+import { startEpisodePlayback } from '../episode-embed';
 import { dateFromKey, dateKey } from '../homepage-date.util';
 import { displayCatalogName } from '../display-catalog-name';
 import { HeroCurationService } from '../hero-curation.service';
@@ -283,10 +283,7 @@ export class HomepageApiComponent {
   playEpisode(episode: HomepageEpisode | SearchDisplayEpisode, event?: Event): void {
     event?.preventDefault();
     event?.stopPropagation();
-    if (episodeEmbedOptions(episode).length === 0) {
-      return;
-    }
-    this.playerService.play(episode);
+    startEpisodePlayback(episode, (playable) => this.playerService.play(playable));
   }
 
   async togglePromote(episode: SearchDisplayEpisode): Promise<void> {

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.ts
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.ts
@@ -22,7 +22,7 @@ import { PlayerService } from '../player.service';
 import { episodeImageUrl, SearchDisplayEpisode } from '../search-result-links';
 import { languageFlagBadgeForEpisode, LanguageFlagBadge } from '../language-flag';
 import { SubjectChipComponent } from '../subject-chip/subject-chip.component';
-import { episodeEmbedOptions, playActionLabel } from '../episode-embed';
+import { canPlayEpisode, playActionLabel, startEpisodePlayback } from '../episode-embed';
 import { displayCatalogName } from '../display-catalog-name';
 
 @Component({
@@ -289,7 +289,7 @@ export class HomepageHeroComponent {
   }
 
   protected canPlay(episode: HomepageEpisode | SearchDisplayEpisode): boolean {
-    return episodeEmbedOptions(episode).length > 0;
+    return canPlayEpisode(episode);
   }
 
   protected playLabel(episode: HomepageEpisode | SearchDisplayEpisode): 'Watch' | 'Listen' {
@@ -303,11 +303,10 @@ export class HomepageHeroComponent {
   playEpisode(episode: HomepageEpisode | SearchDisplayEpisode, event?: Event): void {
     event?.preventDefault();
     event?.stopPropagation();
-    if (!this.canPlay(episode)) {
-      return;
-    }
-    this.heroPaused.set(true);
-    this.play.emit(episode);
+    startEpisodePlayback(episode, (playable) => {
+      this.heroPaused.set(true);
+      this.play.emit(playable);
+    });
   }
 
   onHeroPointerEnter(): void {

--- a/cultpodcasts/src/app/podcast-api/podcast-api.component.ts
+++ b/cultpodcasts/src/app/podcast-api/podcast-api.component.ts
@@ -33,7 +33,7 @@ import { EpisodePosterComponent } from '../episode-poster/episode-poster.compone
 import { SiteLoadingComponent } from '../site-loading/site-loading.component';
 import { BrowseLoadingSkeletonComponent } from '../browse-loading-skeleton/browse-loading-skeleton.component';
 import { SearchDisplayEpisode } from '../search-result-links';
-import { canPlayEpisode } from '../episode-embed';
+import { startEpisodePlayback } from '../episode-embed';
 import { PlayerService } from '../player.service';
 import { displayCatalogName } from '../display-catalog-name';
 
@@ -421,10 +421,7 @@ export class PodcastApiComponent {
   }
 
   playEpisode(episode: SearchDisplayEpisode): void {
-    if (!canPlayEpisode(episode)) {
-      return;
-    }
-    this.playerService.play(episode);
+    startEpisodePlayback(episode, (playable) => this.playerService.play(playable));
   }
 
   isPlayingId(id: string): boolean {

--- a/cultpodcasts/src/app/podcast-episode/podcast-episode.component.html
+++ b/cultpodcasts/src/app/podcast-episode/podcast-episode.component.html
@@ -67,11 +67,13 @@
         <mat-icon>play_arrow</mat-icon>
         {{ playLabel() }}
       </button>
+      @if (queueable()) {
       <button type="button" class="episode-hero__queue" [class.is-queued]="queued()"
         [attr.aria-label]="queued() ? 'Remove from queue' : 'Add to queue'" (click)="toggleQueue()">
         <mat-icon>{{ queued() ? 'playlist_add_check' : 'playlist_add' }}</mat-icon>
         {{ queued() ? 'Queued' : 'Add to Queue' }}
       </button>
+      }
       }
       <app-episode-links class="episode-hero__links" [episode]="episode"></app-episode-links>
     </div>

--- a/cultpodcasts/src/app/podcast-episode/podcast-episode.component.ts
+++ b/cultpodcasts/src/app/podcast-episode/podcast-episode.component.ts
@@ -25,7 +25,7 @@ import { SearchDescriptionPipe } from '../search-description.pipe';
 import { displayCatalogName } from '../display-catalog-name';
 import { releaseDateLabel } from '../release-label';
 import { SearchDisplayEpisode, episodeImageUrl } from '../search-result-links';
-import { canPlayEpisode, playActionLabel } from '../episode-embed';
+import { canEmbedEpisode, canPlayEpisode, playActionLabel, startEpisodePlayback } from '../episode-embed';
 import { PlayerService } from '../player.service';
 import { languageFlagBadgeForEpisode } from '../language-flag';
 import { Component, DestroyRef, inject, Input, ChangeDetectionStrategy, signal, computed, effect } from '@angular/core';
@@ -98,6 +98,11 @@ export class PodcastEpisodeComponent {
   protected readonly playable = computed(() => {
     const ep = this._episode();
     return ep ? canPlayEpisode(ep) : false;
+  });
+
+  protected readonly queueable = computed(() => {
+    const ep = this._episode();
+    return ep ? canEmbedEpisode(ep) : false;
   });
 
   protected readonly playLabel = computed(() => {
@@ -253,14 +258,14 @@ export class PodcastEpisodeComponent {
 
   playEpisode(episode?: SearchDisplayEpisode): void {
     const ep = episode ?? this._episode();
-    if (ep && canPlayEpisode(ep)) {
-      this.playerService.play(ep);
+    if (ep) {
+      startEpisodePlayback(ep, (playable) => this.playerService.play(playable));
     }
   }
 
   toggleQueue(): void {
     const ep = this._episode();
-    if (ep && canPlayEpisode(ep)) {
+    if (ep && canEmbedEpisode(ep)) {
       this.playerService.toggleQueue(ep);
     }
   }

--- a/cultpodcasts/src/app/search-api/search-api.component.ts
+++ b/cultpodcasts/src/app/search-api/search-api.component.ts
@@ -16,7 +16,7 @@ import { EpisodePosterComponent } from '../episode-poster/episode-poster.compone
 import { SiteLoadingComponent } from '../site-loading/site-loading.component';
 import { BrowseLoadingSkeletonComponent } from '../browse-loading-skeleton/browse-loading-skeleton.component';
 import { SearchDisplayEpisode } from '../search-result-links';
-import { canPlayEpisode } from '../episode-embed';
+import { startEpisodePlayback } from '../episode-embed';
 import { SearchResultsFacets } from '../search-results-facets.interface';
 import { FacetState } from '../facet-state.interface';
 import { displayCatalogName } from '../display-catalog-name';
@@ -334,10 +334,7 @@ export class SearchApiComponent {
   }
 
   playEpisode(episode: SearchDisplayEpisode): void {
-    if (!canPlayEpisode(episode)) {
-      return;
-    }
-    this.playerService.play(episode);
+    startEpisodePlayback(episode, (playable) => this.playerService.play(playable));
   }
 
   isPlayingId(id: string): boolean {

--- a/cultpodcasts/src/app/search-result-links.spec.ts
+++ b/cultpodcasts/src/app/search-result-links.spec.ts
@@ -68,6 +68,33 @@ describe("search-result-links", () => {
     expect(episodeArtAspect(homepageYt)).toBe("wide");
   });
 
+  it("uses wide rail art for BBC iPlayer and Internet Archive even with square feed covers", () => {
+    const iplayer: HomepageEpisode = {
+      id: "id",
+      podcastName: "BBC Three",
+      episodeTitle: "Title",
+      episodeDescription: "Description",
+      release: new Date("2026-07-17T00:00:00Z"),
+      duration: "00:57:00",
+      spotify: undefined,
+      apple: undefined,
+      youtube: undefined,
+      bbc: new URL("https://www.bbc.co.uk/iplayer/episode/p0abc123/jared-leto"),
+      internetArchive: undefined,
+      subjects: [],
+      image: new URL("https://ichef.bbci.co.uk/images/ic/640xn/p0square.jpg")
+    };
+    const archive: SearchResult = {
+      ...searchResult,
+      youtubeId: undefined,
+      image: "sab6765cover",
+      internetArchive: "https://archive.org/details/example-video"
+    };
+
+    expect(episodeArtAspect(iplayer)).toBe("wide");
+    expect(episodeArtAspect(archive)).toBe("wide");
+  });
+
   it("prefers a YouTube thumbnail when the index stored square cover but the episode is watchable", () => {
     const watchWithSpotifyArt: SearchResult = {
       ...searchResult,

--- a/cultpodcasts/src/app/search-result-links.ts
+++ b/cultpodcasts/src/app/search-result-links.ts
@@ -1,5 +1,6 @@
 import { HomepageEpisode } from "./homepage-episode.interface";
 import { SearchResult } from "./search-result.interface";
+import { BBCServiceResolver } from "./service-resolver";
 
 export type SearchDisplayEpisode = HomepageEpisode | SearchResult;
 
@@ -28,6 +29,24 @@ export function appleUrl(episode: SearchDisplayEpisode): URL | undefined {
   return episode.appleId && episode.podcastAppleId
     ? toUrl(`https://podcasts.apple.com/podcast/id${encodeURIComponent(episode.podcastAppleId)}?i=${encodeURIComponent(episode.appleId)}`)
     : undefined;
+}
+
+/** BBC iPlayer (video) page — not embeddable; used for outbound Watch CTAs. */
+export function bbcIplayerUrl(episode: SearchDisplayEpisode): URL | undefined {
+  const bbc = toUrl(episode.bbc);
+  return bbc && BBCServiceResolver.isIplayer(bbc) ? bbc : undefined;
+}
+
+export function internetArchiveUrl(episode: SearchDisplayEpisode): URL | undefined {
+  return toUrl(episode.internetArchive);
+}
+
+/**
+ * Non-embeddable video destinations. Prefer iPlayer when both exist.
+ * BBC Sounds is audio and is intentionally excluded.
+ */
+export function externalWatchUrl(episode: SearchDisplayEpisode): URL | undefined {
+  return bbcIplayerUrl(episode) ?? internetArchiveUrl(episode);
 }
 
 export function episodeImageUrl(episode: SearchDisplayEpisode): URL | undefined {
@@ -105,9 +124,18 @@ export function isYoutubeThumbnailUrl(image: URL | string | undefined): boolean 
 
 export type EpisodeArtAspect = "wide" | "square";
 
-/** Layout for cover art: YouTube thumbs → 16:9; Spotify/Apple/feed art → square. */
+/**
+ * Layout for cover art: YouTube thumbs → 16:9; BBC iPlayer / Internet Archive video
+ * episodes → 16:9 (feed art is often square and gets cover-cropped); else square.
+ */
 export function episodeArtAspect(episode: SearchDisplayEpisode): EpisodeArtAspect {
-  return isYoutubeThumbnailUrl(episodeImageUrl(episode)) ? "wide" : "square";
+  if (isYoutubeThumbnailUrl(episodeImageUrl(episode))) {
+    return "wide";
+  }
+  if (externalWatchUrl(episode)) {
+    return "wide";
+  }
+  return "square";
 }
 
 // Loss-less inverse of the search index's image compaction (RPP `SearchEpisodeImage`). `image` holds

--- a/cultpodcasts/src/app/search-result-links.ts
+++ b/cultpodcasts/src/app/search-result-links.ts
@@ -37,16 +37,32 @@ export function bbcIplayerUrl(episode: SearchDisplayEpisode): URL | undefined {
   return bbc && BBCServiceResolver.isIplayer(bbc) ? bbc : undefined;
 }
 
+/** BBC Sounds (audio) page — not embeddable; used for outbound Listen CTAs. */
+export function bbcSoundsUrl(episode: SearchDisplayEpisode): URL | undefined {
+  const bbc = toUrl(episode.bbc);
+  return bbc && BBCServiceResolver.isSounds(bbc) ? bbc : undefined;
+}
+
 export function internetArchiveUrl(episode: SearchDisplayEpisode): URL | undefined {
   return toUrl(episode.internetArchive);
 }
 
 /**
  * Non-embeddable video destinations. Prefer iPlayer when both exist.
- * BBC Sounds is audio and is intentionally excluded.
+ * BBC Sounds is audio — see `externalListenUrl`.
  */
 export function externalWatchUrl(episode: SearchDisplayEpisode): URL | undefined {
   return bbcIplayerUrl(episode) ?? internetArchiveUrl(episode);
+}
+
+/** Non-embeddable audio destinations (BBC Sounds). */
+export function externalListenUrl(episode: SearchDisplayEpisode): URL | undefined {
+  return bbcSoundsUrl(episode);
+}
+
+/** Outbound Watch or Listen destination when nothing embeds in-app. */
+export function externalPlaybackUrl(episode: SearchDisplayEpisode): URL | undefined {
+  return externalWatchUrl(episode) ?? externalListenUrl(episode);
 }
 
 export function episodeImageUrl(episode: SearchDisplayEpisode): URL | undefined {

--- a/cultpodcasts/src/app/subject-api/subject-api.component.ts
+++ b/cultpodcasts/src/app/subject-api/subject-api.component.ts
@@ -35,7 +35,7 @@ import { EpisodePosterComponent } from '../episode-poster/episode-poster.compone
 import { SiteLoadingComponent } from '../site-loading/site-loading.component';
 import { BrowseLoadingSkeletonComponent } from '../browse-loading-skeleton/browse-loading-skeleton.component';
 import { SearchDisplayEpisode } from '../search-result-links';
-import { canPlayEpisode } from '../episode-embed';
+import { startEpisodePlayback } from '../episode-embed';
 import { displayCatalogName } from '../display-catalog-name';
 import { PlayerService } from '../player.service';
 
@@ -471,10 +471,7 @@ export class SubjectApiComponent {
   }
 
   playEpisode(episode: SearchDisplayEpisode): void {
-    if (!canPlayEpisode(episode)) {
-      return;
-    }
-    this.playerService.play(episode);
+    startEpisodePlayback(episode, (playable) => this.playerService.play(playable));
   }
 
   isPlayingId(id: string): boolean {


### PR DESCRIPTION
## Summary
- Show a **Watch** button for BBC iPlayer and Internet Archive episodes even when they cannot be embedded (opens the destination in a new tab).
- Show a **Listen** button for BBC Sounds-only episodes the same way (outbound, no embed).
- Use **16:9** rail framing for iPlayer / Internet Archive video episodes so they match YouTube Watch cards (square feed art is cover-cropped). Sounds stays square.
- Keep the play queue for in-app embeds only; prefer Spotify/Apple **Listen** when an embed exists alongside iPlayer/Sounds.

## Test plan
- [ ] Homepage rail: Jared Leto / BBC Three card shows wide art + Watch; click opens iPlayer
- [ ] Episode page for that show shows Watch (no queue when not embeddable)
- [ ] Internet Archive-only episode: wide art + Watch opens archive.org
- [ ] BBC Sounds-only episode: square art + Listen opens Sounds
- [ ] YouTube episode still embeds in-player; Spotify-only still shows Listen
- [ ] Episode with Spotify + iPlayer/Sounds prefers in-app Listen