### PR TITLE
feat(seo): use shortener KV share image for episode OG/Twitter cards

### DIFF
--- a/cultpodcasts/AGENTS.md
+++ b/cultpodcasts/AGENTS.md
@@ -36,3 +36,7 @@ Auth0 requires hostname **`local.cultpodcasts.com`** (hosts → `127.0.0.1`). De
 | `npm run dev` | `https://local.cultpodcasts.com:4200` |
 
 Build: `ng build`. Mobile/TWA notes: `MOBILE_BUILDS.md`.
+
+## Version bumps (HARD for PRs)
+
+Every website PR that changes shipped client code **MUST** bump `cultpodcasts/package.json` (and `package-lock.json` to match) — patch unless the change warrants minor/major. Do this in the same PR before opening or as the last commit before ready-for-review.

--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.10.3",
+      "version": "1.10.4",
       "dependencies": {
         "@angular/cdk": "^22.0.6",
         "@angular/common": "^22.0.8",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/src/app/page-details.interface.ts
+++ b/cultpodcasts/src/app/page-details.interface.ts
@@ -1,6 +1,12 @@
+export type PageDetailsImageAspect = "wide" | "square";
+
 export interface IPageDetails {
     title?: string,
     description?: string,
     releaseDate?: string,
-    duration?: string
+    duration?: string,
+    /** Absolute HTTPS episode art for og:image / twitter:image. */
+    image?: string,
+    /** YouTube / BBC iPlayer / Internet Archive → wide; Spotify/Apple/BBC Sounds → square. */
+    imageAspect?: PageDetailsImageAspect
 }

--- a/cultpodcasts/src/app/page-details.interface.ts
+++ b/cultpodcasts/src/app/page-details.interface.ts
@@ -5,7 +5,7 @@ export interface IPageDetails {
     description?: string,
     releaseDate?: string,
     duration?: string,
-    /** Absolute HTTPS episode art for og:image / twitter:image. */
+    /** Absolute HTTPS URL for og:image (Api `/og-image` with logo overlay when share art exists). */
     image?: string,
     /** YouTube / BBC iPlayer / Internet Archive → wide; Spotify/Apple/BBC Sounds → square. */
     imageAspect?: PageDetailsImageAspect

--- a/cultpodcasts/src/app/podcast/podcast.component.ts
+++ b/cultpodcasts/src/app/podcast/podcast.component.ts
@@ -12,6 +12,7 @@ import { SearchResult } from '../search-result.interface';
 import { PodcastEpisodeComponent } from '../podcast-episode/podcast-episode.component';
 import { SiteLoadingComponent } from '../site-loading/site-loading.component';
 import { EpisodeLoadingSkeletonComponent } from '../episode-loading-skeleton/episode-loading-skeleton.component';
+import { bbcIplayerUrl, episodeImageUrl, isYoutubeThumbnailUrl } from '../search-result-links';
 
 @Component({
   selector: 'app-podcast',
@@ -97,11 +98,22 @@ export class PodcastComponent {
             .then(episode => {
               this.episode.set(episode);
               if (episode) {
+                const shareImage = episodeImageUrl(episode)?.toString();
                 pageDetails = {
                   description: this.podcastName,
                   title: `${episode.episodeTitle} | ${this.podcastName}`,
                   releaseDate: episode.release.toString(),
-                  duration: episode.duration
+                  duration: episode.duration,
+                  image: shareImage,
+                  // YouTube / BBC iPlayer / Internet Archive → wide; Spotify/Apple/BBC Sounds → square.
+                  imageAspect: shareImage
+                    ? (isYoutubeThumbnailUrl(shareImage)
+                      || !!episode.youtubeId
+                      || !!bbcIplayerUrl(episode)
+                      || !!episode.internetArchive
+                      ? "wide"
+                      : "square")
+                    : undefined
                 };
               }
             })

--- a/cultpodcasts/src/app/seo.service.spec.ts
+++ b/cultpodcasts/src/app/seo.service.spec.ts
@@ -1,0 +1,58 @@
+import { TestBed } from '@angular/core/testing';
+import { Meta } from '@angular/platform-browser';
+import { PLATFORM_ID } from '@angular/core';
+import { SeoService } from './seo.service';
+
+describe('SeoService share images', () => {
+  let meta: Meta;
+  let seo: SeoService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        SeoService,
+        { provide: PLATFORM_ID, useValue: 'server' },
+        { provide: 'url', useValue: new URL('https://cultpodcasts.com/podcast/Show/ep') }
+      ]
+    });
+    meta = TestBed.inject(Meta);
+    seo = TestBed.inject(SeoService);
+    seo.AddRequiredMetaTags();
+  });
+
+  it('keeps site icon and summary card when page has no episode image', () => {
+    seo.AddMetaTags({ title: 'Ep | Show', description: 'Show' });
+
+    expect(meta.getTag('property="og:image"')?.content)
+      .toBe('https://cultpodcasts.com/assets/sq-image.png');
+    expect(meta.getTag('name="twitter:card"')?.content).toBe('summary');
+  });
+
+  it('uses episode art with summary for square covers', () => {
+    seo.AddMetaTags({
+      title: 'Ep | Show',
+      description: 'Show',
+      image: 'https://i.scdn.co/image/ab6765cover',
+      imageAspect: 'square'
+    });
+
+    expect(meta.getTag('property="og:image"')?.content)
+      .toBe('https://i.scdn.co/image/ab6765cover');
+    expect(meta.getTag('name="twitter:image"')?.content)
+      .toBe('https://i.scdn.co/image/ab6765cover');
+    expect(meta.getTag('name="twitter:card"')?.content).toBe('summary');
+  });
+
+  it('uses summary_large_image for wide YouTube art', () => {
+    seo.AddMetaTags({
+      title: 'Ep | Show',
+      description: 'Show',
+      image: 'https://i.ytimg.com/vi/griffinsong42/hqdefault.jpg',
+      imageAspect: 'wide'
+    });
+
+    expect(meta.getTag('property="og:image"')?.content)
+      .toBe('https://i.ytimg.com/vi/griffinsong42/hqdefault.jpg');
+    expect(meta.getTag('name="twitter:card"')?.content).toBe('summary_large_image');
+  });
+});

--- a/cultpodcasts/src/app/seo.service.ts
+++ b/cultpodcasts/src/app/seo.service.ts
@@ -4,6 +4,7 @@ import { Meta, Title } from '@angular/platform-browser';
 import { IPageDetails } from './page-details.interface';
 
 const siteName: string = "Cult Podcasts";
+const defaultShareImagePath: string = "/assets/sq-image.png";
 
 @Injectable({
   providedIn: 'root'
@@ -54,6 +55,7 @@ export class SeoService {
         this.meta.updateTag({ property: "og:description", content: description });
       }
       this.meta.updateTag({ property: "og:title", content: htmlTItle });
+      this.applyShareImage(pageDetails);
     }
   }
 
@@ -74,10 +76,25 @@ export class SeoService {
       if (this.url) {
         const domain: string = this.url.hostname;
         const url: string = this.url.toString();
+        const shareImage = new URL(defaultShareImagePath, this.url).toString();
         this.meta.addTag({ property: "twitter:domain", content: domain });
         this.meta.addTag({ property: "og:url", content: url });
-        this.meta.addTag({ property: "og:image", content: new URL("/assets/sq-image.png", this.url).toString() })
+        this.meta.addTag({ property: "og:image", content: shareImage });
       };
     }
+  }
+
+  private applyShareImage(pageDetails: IPageDetails): void {
+    const image = pageDetails.image
+      ?? (this.url ? new URL(defaultShareImagePath, this.url).toString() : undefined);
+    if (!image) {
+      return;
+    }
+    this.meta.updateTag({ property: "og:image", content: image });
+    this.meta.updateTag({ name: "twitter:image", content: image });
+    const card = pageDetails.image && pageDetails.imageAspect === "wide"
+      ? "summary_large_image"
+      : "summary";
+    this.meta.updateTag({ name: "twitter:card", content: card });
   }
 }


### PR DESCRIPTION
## Summary
- Episode SEO uses `image` / `imageAspect` from page-details (shortener KV) for `og:image` / `twitter:image` when present; otherwise keeps the site icon.
- Bumps client to **1.10.4**. Documents the version-bump PR rule in AGENTS.md.

## Test plan
- [ ] Episode with shortener KV `image` → OG/Twitter meta show episode art
- [ ] Episode without KV image → site icon unchanged
- [ ] Preview/staging SSR smoke on an episode page
