### PR TITLE
feat(ui): sticky header with collapsing search

### DIFF
--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.10.3",
+      "version": "1.10.4",
       "dependencies": {
         "@angular/cdk": "^22.0.6",
         "@angular/common": "^22.0.8",

--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.4",
+  "version": "1.10.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.10.4",
+      "version": "1.10.5",
       "dependencies": {
         "@angular/cdk": "^22.0.6",
         "@angular/common": "^22.0.8",

--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.7",
+  "version": "1.10.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.10.7",
+      "version": "1.10.8",
       "dependencies": {
         "@angular/cdk": "^22.0.6",
         "@angular/common": "^22.0.8",

--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.8",
+  "version": "1.10.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.10.8",
+      "version": "1.10.9",
       "dependencies": {
         "@angular/cdk": "^22.0.6",
         "@angular/common": "^22.0.8",

--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.9",
+  "version": "1.10.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.10.9",
+      "version": "1.10.10",
       "dependencies": {
         "@angular/cdk": "^22.0.6",
         "@angular/common": "^22.0.8",

--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.6",
+  "version": "1.10.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.10.6",
+      "version": "1.10.7",
       "dependencies": {
         "@angular/cdk": "^22.0.6",
         "@angular/common": "^22.0.8",

--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.5",
+  "version": "1.10.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.10.5",
+      "version": "1.10.6",
       "dependencies": {
         "@angular/cdk": "^22.0.6",
         "@angular/common": "^22.0.8",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.8",
+  "version": "1.10.9",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.4",
+  "version": "1.10.5",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.6",
+  "version": "1.10.7",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.5",
+  "version": "1.10.6",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.9",
+  "version": "1.10.10",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.7",
+  "version": "1.10.8",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/src/app/app.component.html
+++ b/cultpodcasts/src/app/app.component.html
@@ -41,6 +41,8 @@
     <div class="site-chrome__bar" #chromeBar>
       <app-toolbar></app-toolbar>
     </div>
+    <!-- Keeps document flow under the fixed logo bar (0 on home — hero pulls under). -->
+    <div class="site-chrome__bar-spacer" aria-hidden="true"></div>
     <div class="chrome-search" #chromeSearch [class.chrome-search--docked]="chromeStuck()">
       <app-search-bar></app-search-bar>
     </div>

--- a/cultpodcasts/src/app/app.component.html
+++ b/cultpodcasts/src/app/app.component.html
@@ -34,18 +34,15 @@
 <section id="body"
   [class.home-shell]="isHomePage()"
   [class.browse-shell]="!isHomePage()"
-  [class.chrome-compact]="chromeCompact()"
+  [class.chrome-stuck]="chromeStuck()"
   (dragover)="onDragOver($event)"
   (drop)="onDrop($event)">
   <div class="site-chrome">
-    <app-toolbar>
-      <div chromeSearch class="chrome-search">
-        <app-search-bar></app-search-bar>
-      </div>
-    </app-toolbar>
+    <app-toolbar></app-toolbar>
+    <div class="chrome-search">
+      <app-search-bar></app-search-bar>
+    </div>
   </div>
-  <!-- Reserves vertical room for the dropped search on browse; collapsed when compact / home overlay. -->
-  <div class="chrome-search-spacer" aria-hidden="true"></div>
   <router-outlet></router-outlet>
 
   <footer class="site-footer">

--- a/cultpodcasts/src/app/app.component.html
+++ b/cultpodcasts/src/app/app.component.html
@@ -34,13 +34,18 @@
 <section id="body"
   [class.home-shell]="isHomePage()"
   [class.browse-shell]="!isHomePage()"
+  [class.chrome-compact]="chromeCompact()"
   (dragover)="onDragOver($event)"
   (drop)="onDrop($event)">
-  <app-toolbar></app-toolbar>
-  <!-- Always in DOM (CSS-hide on home) so browse-route hydration matches SSR. -->
-  <div class="chrome-search" [class.browse-chrome-search]="!isHomePage()">
-    <app-search-bar></app-search-bar>
+  <div class="site-chrome">
+    <app-toolbar>
+      <div chromeSearch class="chrome-search">
+        <app-search-bar></app-search-bar>
+      </div>
+    </app-toolbar>
   </div>
+  <!-- Reserves vertical room for the dropped search on browse; collapsed when compact / home overlay. -->
+  <div class="chrome-search-spacer" aria-hidden="true"></div>
   <router-outlet></router-outlet>
 
   <footer class="site-footer">

--- a/cultpodcasts/src/app/app.component.html
+++ b/cultpodcasts/src/app/app.component.html
@@ -38,8 +38,10 @@
   (dragover)="onDragOver($event)"
   (drop)="onDrop($event)">
   <div class="site-chrome">
-    <app-toolbar></app-toolbar>
-    <div class="chrome-search">
+    <div class="site-chrome__bar" #chromeBar>
+      <app-toolbar></app-toolbar>
+    </div>
+    <div class="chrome-search" #chromeSearch [class.chrome-search--docked]="chromeStuck()">
       <app-search-bar></app-search-bar>
     </div>
   </div>

--- a/cultpodcasts/src/app/app.component.sass
+++ b/cultpodcasts/src/app/app.component.sass
@@ -6,26 +6,28 @@
     padding-bottom: calc(24px + env(safe-area-inset-bottom))
     scroll-snap-align: start
     scroll-snap-stop: always
-    // Toolbar + gap + search + chrome padding — used for home hero pull-under.
+    // Expanded chrome: sticky logo bar + dropped search (hero pull-under on home).
     --nflx-search-h: 48px
-    --site-chrome-pad-bottom: 12px
-    --site-chrome-h: calc(58px + 12px + var(--nflx-search-h) + var(--site-chrome-pad-bottom))
+    --site-chrome-bar-h: 58px
+    --site-chrome-search-gap: 12px
+    --site-chrome-h: calc(var(--site-chrome-bar-h) + var(--site-chrome-search-gap) + var(--nflx-search-h) + 12px)
     --nflx-hero-search-clearance: calc(var(--site-chrome-h) + 8px)
     --search-bar-control-h: var(--nflx-search-h)
 
 @media screen and (max-width: 700px)
     #body
-        --site-chrome-h: calc(52px + 10px + var(--nflx-search-h) + var(--site-chrome-pad-bottom))
+        --site-chrome-bar-h: 52px
+        --site-chrome-search-gap: 10px
 
-// Sticky band: logo row + centered search with CTA. Sticks when it reaches the viewport top.
+// Logo / actions bar — sticky on its own. Search scrolls up into it, then docks.
 .site-chrome
+    position: relative
+    z-index: 100
+
+.site-chrome__bar
     position: sticky
     top: 0
-    z-index: 100
-    display: flex
-    flex-direction: column
-    align-items: stretch
-    padding-bottom: var(--site-chrome-pad-bottom)
+    z-index: 102
     transition: background-color 0.22s ease, box-shadow 0.22s ease, border-color 0.22s ease, backdrop-filter 0.22s ease
 
 .home-shell
@@ -34,8 +36,8 @@
 .browse-shell
     background: var(--nflx-bg, #0b0b0b)
 
-// Home at top: cinematic transparent overlay.
-.home-shell > .site-chrome
+// Home at top: cinematic transparent overlay on the logo bar.
+.home-shell > .site-chrome > .site-chrome__bar
     background: transparent
     border-bottom: 1px solid transparent
     backdrop-filter: none
@@ -58,8 +60,8 @@
         button#menu
             color: #fff !important
 
-// Once the sticky chrome has left the page top, frost it so content doesn't show through.
-.home-shell.chrome-stuck > .site-chrome
+// After search docks into the bar, frost the single sticky row.
+.home-shell.chrome-stuck > .site-chrome > .site-chrome__bar
     background: color-mix(in srgb, var(--nflx-panel, #141414) 88%, transparent)
     backdrop-filter: blur(14px)
     -webkit-backdrop-filter: blur(14px)
@@ -70,23 +72,25 @@
             background: transparent !important
             border-bottom-color: transparent !important
 
-.browse-shell > .site-chrome
+.browse-shell > .site-chrome > .site-chrome__bar
     background: color-mix(in srgb, var(--nflx-panel, var(--cp-ink-elevated)) 78%, transparent)
     backdrop-filter: blur(14px)
     -webkit-backdrop-filter: blur(14px)
     border-bottom: 1px solid var(--nflx-border, color-mix(in srgb, var(--mat-sys-outline-variant) 45%, transparent))
 
-.browse-shell.chrome-stuck > .site-chrome
+.browse-shell.chrome-stuck > .site-chrome > .site-chrome__bar
     background: color-mix(in srgb, var(--nflx-panel, var(--cp-ink-elevated)) 92%, transparent)
     box-shadow: 0 6px 18px rgba(0, 0, 0, 0.28)
 
-// Always centered under the logo row, homepage width, with Search CTA.
+// Dropped search (in flow) — scrolls with the page until it meets the sticky bar.
 .chrome-search
     --search-bar-control-h: var(--nflx-search-h)
     --mat-form-field-container-height: var(--nflx-search-h)
     --mat-form-field-container-vertical-padding: 0px
+    position: relative
+    z-index: 101
     width: min(640px, calc(100% - 2.5rem))
-    margin: 12px auto 0
+    margin: var(--site-chrome-search-gap) auto 12px
     box-sizing: border-box
     ::ng-deep
         #searchcontainer
@@ -101,7 +105,21 @@
 @media screen and (max-width: 700px)
     .chrome-search
         width: min(640px, calc(100% - 1.5rem))
-        margin-top: 10px
+
+// Docked into the sticky header: single row, still centered, Search button kept.
+.chrome-search--docked
+    position: fixed
+    top: calc((var(--site-chrome-bar-h) - var(--nflx-search-h)) / 2)
+    left: 50%
+    transform: translateX(-50%)
+    width: min(520px, calc(100vw - 11rem))
+    height: var(--nflx-search-h)
+    margin: 0
+    z-index: 110
+
+@media screen and (max-width: 599.9px)
+    .chrome-search--docked
+        width: min(520px, calc(100vw - 7.5rem))
 
 // Homepage at top: dark glass over the billboard.
 .home-shell:not(.chrome-stuck) .chrome-search

--- a/cultpodcasts/src/app/app.component.sass
+++ b/cultpodcasts/src/app/app.component.sass
@@ -19,19 +19,29 @@
         --site-chrome-bar-h: 52px
         --site-chrome-search-gap: 10px
 
-// Logo / actions bar — sticky on its own. Search scrolls up into it, then docks.
+// Logo / actions bar is fixed so it never leaves the viewport once the page scrolls.
+// (Sticky inside a short .site-chrome parent fails after search docks and leaves flow.)
 .site-chrome
     position: relative
     z-index: 100
 
 .site-chrome__bar
-    position: sticky
+    position: fixed
     top: 0
+    left: 0
+    right: 0
     z-index: 102
     transition: background-color 0.22s ease, box-shadow 0.22s ease, border-color 0.22s ease, backdrop-filter 0.22s ease
 
+.site-chrome__bar-spacer
+    height: var(--site-chrome-bar-h)
+    pointer-events: none
+
 .home-shell
     background: var(--nflx-bg, #0b0b0b)
+    // Billboard pulls under the fixed transparent bar + dropped search.
+    .site-chrome__bar-spacer
+        height: 0
 
 .browse-shell
     background: var(--nflx-bg, #0b0b0b)

--- a/cultpodcasts/src/app/app.component.sass
+++ b/cultpodcasts/src/app/app.component.sass
@@ -6,29 +6,52 @@
     padding-bottom: calc(24px + env(safe-area-inset-bottom))
     scroll-snap-align: start
     scroll-snap-stop: always
+    // Shared search geometry (homepage overlay + browse drop + compact bar).
+    // Clearance ≈ toolbar (~58px) + drop gap (12px) + search + breathing room.
+    --nflx-search-h: 48px
+    --nflx-hero-search-clearance: calc(58px + 12px + var(--nflx-search-h) + 20px)
+    --search-bar-control-h: var(--nflx-search-h)
 
-.chrome-search
-    padding-top: 8px
-    padding-bottom: 4px
+@media screen and (max-width: 700px)
+    #body
+        --nflx-hero-search-clearance: calc(52px + 12px + var(--nflx-search-h) + 16px)
+
+// Sticky site chrome: toolbar + projected search (collapsed into the bar when .chrome-compact).
+.site-chrome
+    position: sticky
+    top: 0
+    z-index: 100
+    overflow: visible
+    transition: background-color 0.22s ease, box-shadow 0.22s ease, border-color 0.22s ease
+
+.chrome-search-spacer
+    height: calc(var(--nflx-search-h) + 24px)
+    transition: height 0.22s ease
+    pointer-events: none
+
+.chrome-compact .chrome-search-spacer
+    height: 0
 
 .home-shell
     background: var(--nflx-bg, #0b0b0b)
-    // Keep <app-search-bar> in the DOM for stable hydration; hide visually on home.
-    .chrome-search
-        display: none !important
+    // Overlay chrome on the hero when at the top (not in document flow).
+    &:not(.chrome-compact) > .site-chrome
+        position: absolute
+        top: 0
+        left: 0
+        right: 0
+        background: transparent
+        box-shadow: none
+    &:not(.chrome-compact) > .chrome-search-spacer
+        height: 0
 
 .browse-shell
     background: var(--nflx-bg, #0b0b0b)
 
-// Home toolbar: keep cinematic dark overlay (host-context can lose to light Material).
-.home-shell > app-toolbar
+// Home toolbar: cinematic dark overlay at top; frosted sticky bar when compact.
+.home-shell > .site-chrome
     ::ng-deep
         .app-toolbar
-            position: absolute
-            top: 0
-            left: 0
-            right: 0
-            z-index: 20
             background: linear-gradient(to bottom, rgba(0, 0, 0, 0.8), transparent) !important
             border-bottom-color: transparent !important
             backdrop-filter: none !important
@@ -45,28 +68,120 @@
         button#menu
             color: #fff !important
 
-.browse-chrome-search
-    // Match the horizontal rhythm of .browse-filters / .browse-grid (both use
-    // width: 100% + 4vw padding, uncapped) so the box lines up with the pill
-    // filters directly beneath it instead of the unrelated .page-rail (920px) grid.
-    --nflx-search-h: 48px
+.home-shell.chrome-compact > .site-chrome
+    background: color-mix(in srgb, var(--nflx-panel, #141414) 88%, transparent)
+    backdrop-filter: blur(14px)
+    -webkit-backdrop-filter: blur(14px)
+    border-bottom: 1px solid color-mix(in srgb, #fff 18%, transparent)
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35)
+    ::ng-deep
+        .app-toolbar
+            background: transparent !important
+            border-bottom-color: transparent !important
+
+.browse-shell > .site-chrome
+    background: color-mix(in srgb, var(--nflx-panel, var(--cp-ink-elevated)) 78%, transparent)
+    backdrop-filter: blur(14px)
+    -webkit-backdrop-filter: blur(14px)
+    border-bottom: 1px solid var(--nflx-border, color-mix(in srgb, var(--mat-sys-outline-variant) 45%, transparent))
+
+.browse-shell.chrome-compact > .site-chrome
+    background: color-mix(in srgb, var(--nflx-panel, var(--cp-ink-elevated)) 92%, transparent)
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.28)
+
+// Projected search field styling (geometry of .toolbar-search lives in toolbar.sass).
+.chrome-search
     --search-bar-control-h: var(--nflx-search-h)
-    // Angular Material hardcodes `.mdc-text-field--outlined { height: 56px }`
-    // with the same specificity as a plain `.mdc-text-field` override, so the
-    // token below is belt-and-braces — the !important heights further down on
-    // the library's own selectors are what actually win the cascade.
     --mat-form-field-container-height: var(--nflx-search-h)
     --mat-form-field-container-vertical-padding: 0px
     width: 100%
-    margin: 0 auto
     box-sizing: border-box
-    padding-left: 4vw
-    padding-right: 4vw
     ::ng-deep
         #searchcontainer
+            --search-bar-control-h: var(--nflx-search-h)
             margin: 0
         #searchbar
             gap: 12px
+        #searchcta
+            background: var(--nflx-accent, #e8a23a) !important
+            color: #111 !important
+            transition: opacity 0.18s ease, max-width 0.22s ease, padding 0.22s ease, margin 0.22s ease
+
+// Compact: hide the Search CTA so the field fits between logo and actions.
+.chrome-compact
+    --nflx-search-h: 40px
+    .chrome-search
+        ::ng-deep
+            #searchcta
+                opacity: 0
+                max-width: 0
+                min-width: 0
+                padding-left: 0
+                padding-right: 0
+                margin: 0
+                overflow: hidden
+                pointer-events: none
+            #searchbar
+                gap: 0
+            #searchbox
+                input.mat-mdc-chip-input,
+                #searchtext
+                    font-size: 0.95rem
+
+// Homepage expanded search: always dark glass over the billboard.
+.home-shell:not(.chrome-compact) .chrome-search
+    ::ng-deep
+        #searchbox
+            .mat-mdc-text-field-wrapper,
+            .mdc-text-field,
+            .mdc-text-field--outlined,
+            .mdc-text-field--no-label
+                background: rgba(12, 12, 12, 0.88) !important
+                backdrop-filter: blur(10px)
+                color: #fff !important
+            .mdc-notched-outline__leading,
+            .mdc-notched-outline__notch,
+            .mdc-notched-outline__trailing
+                border-color: rgba(255, 255, 255, 0.45) !important
+            .mat-mdc-form-field:hover .mdc-notched-outline__leading,
+            .mat-mdc-form-field:hover .mdc-notched-outline__notch,
+            .mat-mdc-form-field:hover .mdc-notched-outline__trailing,
+            .mdc-text-field--focused .mdc-notched-outline__leading,
+            .mdc-text-field--focused .mdc-notched-outline__notch,
+            .mdc-text-field--focused .mdc-notched-outline__trailing
+                border-color: rgba(255, 255, 255, 0.7) !important
+            input.mat-mdc-chip-input,
+            #searchtext
+                font-size: 1.05rem
+                color: #fff !important
+                caret-color: #fff !important
+                &::placeholder
+                    color: rgba(255, 255, 255, 0.65) !important
+                    opacity: 1 !important
+            .mat-mdc-chip
+                --mdc-chip-label-text-color: #fff
+                --mdc-chip-outline-color: rgba(255, 255, 255, 0.4)
+                --mdc-chip-elevated-container-color: rgba(255, 255, 255, 0.12)
+                color: #fff !important
+                background: rgba(255, 255, 255, 0.12) !important
+            .mat-mdc-chip-remove,
+            .mat-icon
+                color: rgba(255, 255, 255, 0.8) !important
+
+@media screen and (max-width: 900px), (hover: none) and (pointer: coarse)
+    .home-shell:not(.chrome-compact) .chrome-search
+        ::ng-deep
+            #searchbox
+                .mat-mdc-text-field-wrapper,
+                .mdc-text-field,
+                .mdc-text-field--outlined,
+                .mdc-text-field--no-label
+                    backdrop-filter: none !important
+
+// Browse + compact (any shell): tokenized glass matching browse chrome.
+.browse-shell .chrome-search,
+.chrome-compact .chrome-search
+    ::ng-deep
         #searchbox
             .mat-mdc-text-field-wrapper,
             .mdc-text-field,
@@ -107,9 +222,6 @@
             .mat-mdc-chip .mat-icon,
             .mat-mdc-chip mat-icon
                 color: var(--nflx-muted, #5c564c) !important
-        #searchcta
-            background: var(--nflx-accent, #e8a23a) !important
-            color: #111 !important
 
 .drop-overlay
     position: fixed

--- a/cultpodcasts/src/app/app.component.sass
+++ b/cultpodcasts/src/app/app.component.sass
@@ -106,20 +106,29 @@
     .chrome-search
         width: min(640px, calc(100% - 1.5rem))
 
-// Docked into the sticky header: single row, still centered, Search button kept.
+// Docked into the sticky header between logo (left) and add/profile (right).
+// Left/width/top are set in AppComponent.layoutDockedSearch() from those anchors.
 .chrome-search--docked
     position: fixed
+    // Fallback before the first measure — wide header gap, not viewport-centred.
+    left: 72px
     top: calc((var(--site-chrome-bar-h) - var(--nflx-search-h)) / 2)
-    left: 50%
-    transform: translateX(-50%)
-    width: min(520px, calc(100vw - 11rem))
+    width: calc(100vw - 11rem)
+    max-width: none
     height: var(--nflx-search-h)
     margin: 0
     z-index: 110
+    transform: none
+    --nflx-search-h: 40px
 
 @media screen and (max-width: 599.9px)
     .chrome-search--docked
-        width: min(520px, calc(100vw - 7.5rem))
+        // Narrow: between logo and overflow menu; hide CTA so the field fits.
+        ::ng-deep
+            #searchcta
+                display: none
+            #searchbar
+                gap: 0
 
 // Homepage at top: dark glass over the billboard.
 .home-shell:not(.chrome-stuck) .chrome-search

--- a/cultpodcasts/src/app/app.component.sass
+++ b/cultpodcasts/src/app/app.component.sass
@@ -125,8 +125,8 @@
 // Left/width/top are set in AppComponent.layoutDockedSearch() from those anchors.
 .chrome-search--docked
     position: fixed
-    // Fallback before the first measure — wide header gap, not viewport-centred.
-    left: 72px
+    // Fallback before the first measure — icon-only logo + actions.
+    left: 70px
     top: calc((var(--site-chrome-bar-h) - var(--nflx-search-h)) / 2)
     width: calc(100vw - 11rem)
     max-width: none
@@ -135,15 +135,30 @@
     z-index: 110
     transform: none
     --nflx-search-h: 40px
+    overflow: hidden
+    ::ng-deep
+        // CTA does not fit in the header slot on narrow/mid widths; Enter still searches.
+        #searchcta
+            display: none !important
+        #searchbar
+            gap: 0
+            min-width: 0
+        #searchbox
+            min-width: 0
+        .chiptext
+            max-width: 5.5rem
+
+@media screen and (max-width: 700px)
+    .chrome-search--docked
+        ::ng-deep
+            .chiptext
+                max-width: 3.5rem
 
 @media screen and (max-width: 599.9px)
     .chrome-search--docked
-        // Narrow: between logo and overflow menu; hide CTA so the field fits.
-        ::ng-deep
-            #searchcta
-                display: none
-            #searchbar
-                gap: 0
+        // Between logo icon and overflow menu.
+        left: 58px
+        width: calc(100vw - 7rem)
 
 // Homepage at top: dark glass over the billboard.
 .home-shell:not(.chrome-stuck) .chrome-search

--- a/cultpodcasts/src/app/app.component.sass
+++ b/cultpodcasts/src/app/app.component.sass
@@ -92,7 +92,7 @@
     background: color-mix(in srgb, var(--nflx-panel, var(--cp-ink-elevated)) 92%, transparent)
     box-shadow: 0 6px 18px rgba(0, 0, 0, 0.28)
 
-// Dropped search (in flow) — scrolls with the page until it meets the sticky bar.
+// Dropped search (in flow) — scrolls with the page until it meets the fixed logo bar.
 .chrome-search
     --search-bar-control-h: var(--nflx-search-h)
     --mat-form-field-container-height: var(--nflx-search-h)
@@ -111,6 +111,11 @@
         #searchcta
             background: var(--nflx-accent, #e8a23a) !important
             color: #111 !important
+
+// Home overlay: spacer is 0 so the billboard can sit under the bar — push search
+// down explicitly so it starts dropped (not already inside the fixed header).
+.home-shell:not(.chrome-stuck) .chrome-search
+    margin-top: calc(var(--site-chrome-bar-h) + var(--site-chrome-search-gap))
 
 @media screen and (max-width: 700px)
     .chrome-search

--- a/cultpodcasts/src/app/app.component.sass
+++ b/cultpodcasts/src/app/app.component.sass
@@ -6,50 +6,40 @@
     padding-bottom: calc(24px + env(safe-area-inset-bottom))
     scroll-snap-align: start
     scroll-snap-stop: always
-    // Shared search geometry (homepage overlay + browse drop + compact bar).
-    // Clearance ≈ toolbar (~58px) + drop gap (12px) + search + breathing room.
+    // Toolbar + gap + search + chrome padding — used for home hero pull-under.
     --nflx-search-h: 48px
-    --nflx-hero-search-clearance: calc(58px + 12px + var(--nflx-search-h) + 20px)
+    --site-chrome-pad-bottom: 12px
+    --site-chrome-h: calc(58px + 12px + var(--nflx-search-h) + var(--site-chrome-pad-bottom))
+    --nflx-hero-search-clearance: calc(var(--site-chrome-h) + 8px)
     --search-bar-control-h: var(--nflx-search-h)
 
 @media screen and (max-width: 700px)
     #body
-        --nflx-hero-search-clearance: calc(52px + 12px + var(--nflx-search-h) + 16px)
+        --site-chrome-h: calc(52px + 10px + var(--nflx-search-h) + var(--site-chrome-pad-bottom))
 
-// Sticky site chrome: toolbar + projected search (collapsed into the bar when .chrome-compact).
+// Sticky band: logo row + centered search with CTA. Sticks when it reaches the viewport top.
 .site-chrome
     position: sticky
     top: 0
     z-index: 100
-    overflow: visible
-    transition: background-color 0.22s ease, box-shadow 0.22s ease, border-color 0.22s ease
-
-.chrome-search-spacer
-    height: calc(var(--nflx-search-h) + 24px)
-    transition: height 0.22s ease
-    pointer-events: none
-
-.chrome-compact .chrome-search-spacer
-    height: 0
+    display: flex
+    flex-direction: column
+    align-items: stretch
+    padding-bottom: var(--site-chrome-pad-bottom)
+    transition: background-color 0.22s ease, box-shadow 0.22s ease, border-color 0.22s ease, backdrop-filter 0.22s ease
 
 .home-shell
     background: var(--nflx-bg, #0b0b0b)
-    // Overlay chrome on the hero when at the top (not in document flow).
-    &:not(.chrome-compact) > .site-chrome
-        position: absolute
-        top: 0
-        left: 0
-        right: 0
-        background: transparent
-        box-shadow: none
-    &:not(.chrome-compact) > .chrome-search-spacer
-        height: 0
 
 .browse-shell
     background: var(--nflx-bg, #0b0b0b)
 
-// Home toolbar: cinematic dark overlay at top; frosted sticky bar when compact.
+// Home at top: cinematic transparent overlay.
 .home-shell > .site-chrome
+    background: transparent
+    border-bottom: 1px solid transparent
+    backdrop-filter: none
+    -webkit-backdrop-filter: none
     ::ng-deep
         .app-toolbar
             background: linear-gradient(to bottom, rgba(0, 0, 0, 0.8), transparent) !important
@@ -68,11 +58,12 @@
         button#menu
             color: #fff !important
 
-.home-shell.chrome-compact > .site-chrome
+// Once the sticky chrome has left the page top, frost it so content doesn't show through.
+.home-shell.chrome-stuck > .site-chrome
     background: color-mix(in srgb, var(--nflx-panel, #141414) 88%, transparent)
     backdrop-filter: blur(14px)
     -webkit-backdrop-filter: blur(14px)
-    border-bottom: 1px solid color-mix(in srgb, #fff 18%, transparent)
+    border-bottom-color: color-mix(in srgb, #fff 18%, transparent)
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35)
     ::ng-deep
         .app-toolbar
@@ -85,16 +76,17 @@
     -webkit-backdrop-filter: blur(14px)
     border-bottom: 1px solid var(--nflx-border, color-mix(in srgb, var(--mat-sys-outline-variant) 45%, transparent))
 
-.browse-shell.chrome-compact > .site-chrome
+.browse-shell.chrome-stuck > .site-chrome
     background: color-mix(in srgb, var(--nflx-panel, var(--cp-ink-elevated)) 92%, transparent)
     box-shadow: 0 6px 18px rgba(0, 0, 0, 0.28)
 
-// Projected search field styling (geometry of .toolbar-search lives in toolbar.sass).
+// Always centered under the logo row, homepage width, with Search CTA.
 .chrome-search
     --search-bar-control-h: var(--nflx-search-h)
     --mat-form-field-container-height: var(--nflx-search-h)
     --mat-form-field-container-vertical-padding: 0px
-    width: 100%
+    width: min(640px, calc(100% - 2.5rem))
+    margin: 12px auto 0
     box-sizing: border-box
     ::ng-deep
         #searchcontainer
@@ -105,31 +97,14 @@
         #searchcta
             background: var(--nflx-accent, #e8a23a) !important
             color: #111 !important
-            transition: opacity 0.18s ease, max-width 0.22s ease, padding 0.22s ease, margin 0.22s ease
 
-// Compact: hide the Search CTA so the field fits between logo and actions.
-.chrome-compact
-    --nflx-search-h: 40px
+@media screen and (max-width: 700px)
     .chrome-search
-        ::ng-deep
-            #searchcta
-                opacity: 0
-                max-width: 0
-                min-width: 0
-                padding-left: 0
-                padding-right: 0
-                margin: 0
-                overflow: hidden
-                pointer-events: none
-            #searchbar
-                gap: 0
-            #searchbox
-                input.mat-mdc-chip-input,
-                #searchtext
-                    font-size: 0.95rem
+        width: min(640px, calc(100% - 1.5rem))
+        margin-top: 10px
 
-// Homepage expanded search: always dark glass over the billboard.
-.home-shell:not(.chrome-compact) .chrome-search
+// Homepage at top: dark glass over the billboard.
+.home-shell:not(.chrome-stuck) .chrome-search
     ::ng-deep
         #searchbox
             .mat-mdc-text-field-wrapper,
@@ -169,7 +144,7 @@
                 color: rgba(255, 255, 255, 0.8) !important
 
 @media screen and (max-width: 900px), (hover: none) and (pointer: coarse)
-    .home-shell:not(.chrome-compact) .chrome-search
+    .home-shell:not(.chrome-stuck) .chrome-search
         ::ng-deep
             #searchbox
                 .mat-mdc-text-field-wrapper,
@@ -178,9 +153,9 @@
                 .mdc-text-field--no-label
                     backdrop-filter: none !important
 
-// Browse + compact (any shell): tokenized glass matching browse chrome.
+// Browse + stuck home: tokenized glass.
 .browse-shell .chrome-search,
-.chrome-compact .chrome-search
+.home-shell.chrome-stuck .chrome-search
     ::ng-deep
         #searchbox
             .mat-mdc-text-field-wrapper,

--- a/cultpodcasts/src/app/app.component.ts
+++ b/cultpodcasts/src/app/app.component.ts
@@ -288,7 +288,7 @@ export class AppComponent implements OnDestroy {
       return;
     }
 
-    // Dock when the scrolling search meets the sticky logo bar.
+    // Dock when the scrolling search meets the fixed logo bar.
     const barBottom = bar.getBoundingClientRect().bottom;
     const searchTop = search.getBoundingClientRect().top;
     if (searchTop <= barBottom + 2) {

--- a/cultpodcasts/src/app/app.component.ts
+++ b/cultpodcasts/src/app/app.component.ts
@@ -74,10 +74,10 @@ export class AppComponent implements OnDestroy {
 
   /** Shows the floating "back to top" control once the user has scrolled well past the fold. */
   private static readonly BACK_TO_TOP_THRESHOLD_PX = 480;
-  /** Collapse the dropped search into the sticky header after a short scroll. */
-  private static readonly CHROME_COMPACT_THRESHOLD_PX = 48;
+  /** Frost the sticky chrome once it has left the page top (home overlay → solid bar). */
+  private static readonly CHROME_STUCK_THRESHOLD_PX = 8;
   protected readonly showBackToTop = signal(false);
-  protected readonly chromeCompact = signal(false);
+  protected readonly chromeStuck = signal(false);
   private scrollRaf = 0;
 
   @ViewChild(ToolbarComponent)
@@ -253,7 +253,7 @@ export class AppComponent implements OnDestroy {
   private syncChromeFromScroll(): void {
     const y = window.scrollY;
     this.showBackToTop.set(y > AppComponent.BACK_TO_TOP_THRESHOLD_PX);
-    this.chromeCompact.set(y > AppComponent.CHROME_COMPACT_THRESHOLD_PX);
+    this.chromeStuck.set(y > AppComponent.CHROME_STUCK_THRESHOLD_PX);
   }
 
   private readonly onDocumentDragEnter = (event: DragEvent) => {

--- a/cultpodcasts/src/app/app.component.ts
+++ b/cultpodcasts/src/app/app.component.ts
@@ -2,6 +2,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   DestroyRef,
+  ElementRef,
   Inject,
   OnDestroy,
   PLATFORM_ID,
@@ -74,14 +75,21 @@ export class AppComponent implements OnDestroy {
 
   /** Shows the floating "back to top" control once the user has scrolled well past the fold. */
   private static readonly BACK_TO_TOP_THRESHOLD_PX = 480;
-  /** Frost the sticky chrome once it has left the page top (home overlay → solid bar). */
-  private static readonly CHROME_STUCK_THRESHOLD_PX = 8;
   protected readonly showBackToTop = signal(false);
+  /** Search has scrolled up into the sticky logo bar (single-row chrome). */
   protected readonly chromeStuck = signal(false);
   private scrollRaf = 0;
+  /** scrollY when search last docked — used to undock without flicker. */
+  private dockAtScrollY = 0;
 
   @ViewChild(ToolbarComponent)
   private toolbar!: ToolbarComponent;
+
+  @ViewChild('chromeBar')
+  private chromeBar?: ElementRef<HTMLElement>;
+
+  @ViewChild('chromeSearch')
+  private chromeSearch?: ElementRef<HTMLElement>;
 
   private readonly destroyRef = inject(DestroyRef);
   private readonly webPushService = inject(WebPushService);
@@ -253,7 +261,28 @@ export class AppComponent implements OnDestroy {
   private syncChromeFromScroll(): void {
     const y = window.scrollY;
     this.showBackToTop.set(y > AppComponent.BACK_TO_TOP_THRESHOLD_PX);
-    this.chromeStuck.set(y > AppComponent.CHROME_STUCK_THRESHOLD_PX);
+
+    const bar = this.chromeBar?.nativeElement;
+    const search = this.chromeSearch?.nativeElement;
+    if (!bar || !search) {
+      return;
+    }
+
+    if (this.chromeStuck()) {
+      // Release back to the dropped layout near the top of the page.
+      if (y < Math.max(8, this.dockAtScrollY - 12)) {
+        this.chromeStuck.set(false);
+      }
+      return;
+    }
+
+    // Dock when the scrolling search meets the sticky logo bar.
+    const barBottom = bar.getBoundingClientRect().bottom;
+    const searchTop = search.getBoundingClientRect().top;
+    if (searchTop <= barBottom + 2) {
+      this.dockAtScrollY = y;
+      this.chromeStuck.set(true);
+    }
   }
 
   private readonly onDocumentDragEnter = (event: DragEvent) => {

--- a/cultpodcasts/src/app/app.component.ts
+++ b/cultpodcasts/src/app/app.component.ts
@@ -74,7 +74,10 @@ export class AppComponent implements OnDestroy {
 
   /** Shows the floating "back to top" control once the user has scrolled well past the fold. */
   private static readonly BACK_TO_TOP_THRESHOLD_PX = 480;
+  /** Collapse the dropped search into the sticky header after a short scroll. */
+  private static readonly CHROME_COMPACT_THRESHOLD_PX = 48;
   protected readonly showBackToTop = signal(false);
+  protected readonly chromeCompact = signal(false);
   private scrollRaf = 0;
 
   @ViewChild(ToolbarComponent)
@@ -114,6 +117,15 @@ export class AppComponent implements OnDestroy {
   initialiseBrowser() {
     this.addDragListeners();
     this.addScrollListener();
+    this.router.events
+      .pipe(
+        filter((event): event is NavigationEnd => event instanceof NavigationEnd),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe(() => {
+        // scrollPositionRestoration may settle after NavigationEnd; re-measure next frame.
+        requestAnimationFrame(() => this.syncChromeFromScroll());
+      });
     navigator.serviceWorker.addEventListener('message', this.onSwMessage.bind(this));
     this.profileService.roles
       .pipe(takeUntilDestroyed(this.destroyRef))
@@ -234,9 +246,15 @@ export class AppComponent implements OnDestroy {
     }
     this.scrollRaf = window.requestAnimationFrame(() => {
       this.scrollRaf = 0;
-      this.showBackToTop.set(window.scrollY > AppComponent.BACK_TO_TOP_THRESHOLD_PX);
+      this.syncChromeFromScroll();
     });
   };
+
+  private syncChromeFromScroll(): void {
+    const y = window.scrollY;
+    this.showBackToTop.set(y > AppComponent.BACK_TO_TOP_THRESHOLD_PX);
+    this.chromeCompact.set(y > AppComponent.CHROME_COMPACT_THRESHOLD_PX);
+  }
 
   private readonly onDocumentDragEnter = (event: DragEvent) => {
     if (this.ignoreDragUntilEnd || !this.hasDroppableUrl(event)) {

--- a/cultpodcasts/src/app/app.component.ts
+++ b/cultpodcasts/src/app/app.component.ts
@@ -281,12 +281,17 @@ export class AppComponent implements OnDestroy {
 
     if (this.chromeStuck()) {
       // Release back to the dropped layout near the top of the page.
-      if (y < Math.max(8, this.dockAtScrollY - 12)) {
+      if (y < AppComponent.MIN_SCROLL_TO_DOCK_PX) {
         this.chromeStuck.set(false);
         this.clearDockedSearchLayout(search);
       } else {
         this.layoutDockedSearch();
       }
+      return;
+    }
+
+    // Keep search dropped at the top of the page (esp. homepage overlay).
+    if (y < AppComponent.MIN_SCROLL_TO_DOCK_PX) {
       return;
     }
 
@@ -296,13 +301,13 @@ export class AppComponent implements OnDestroy {
     if (searchTop <= barBottom + 2) {
       this.dockAtScrollY = y;
       this.chromeStuck.set(true);
-      // Layout after the docked class applies.
-      requestAnimationFrame(() => this.layoutDockedSearch());
+      // Wait for chrome-stuck styles (icon-only logo) before measuring the header gap.
+      requestAnimationFrame(() => requestAnimationFrame(() => this.layoutDockedSearch()));
     }
   }
 
   /**
-   * Pin the search field between the logo (#site) and add/profile (#socialbuttons)
+   * Pin the search field between the logo mark and add/profile (#socialbuttons)
    * — or the overflow menu on narrow viewports — inside the sticky header row.
    */
   private layoutDockedSearch(): void {
@@ -313,21 +318,25 @@ export class AppComponent implements OnDestroy {
     }
 
     const site = bar.querySelector('#site') as HTMLElement | null;
-    const end = (bar.querySelector('#socialbuttons') as HTMLElement | null)
-      ?? (bar.querySelector('button#menu') as HTMLElement | null);
+    // Prefer the visible end control: social cluster when shown, else overflow menu.
+    const social = bar.querySelector('#socialbuttons') as HTMLElement | null;
+    const menu = bar.querySelector('button#menu') as HTMLElement | null;
+    const socialVisible = !!social && social.getClientRects().length > 0;
+    const end = socialVisible ? social : menu;
     if (!site || !end) {
       return;
     }
 
+    // Anchor to the logo image so a still-visible title span cannot steal the gap.
+    const siteAnchor = (site.querySelector('img') as HTMLElement | null) ?? site;
     const gap = AppComponent.DOCK_INLINE_GAP_PX;
-    const siteRect = site.getBoundingClientRect();
+    const siteRect = siteAnchor.getBoundingClientRect();
     const endRect = end.getBoundingClientRect();
-    // Logo bar is position:fixed at top:0 — never use a negative barRect.top for docking.
     const barHeight = Math.max(bar.getBoundingClientRect().height, 52);
-    const left = Math.max(gap, siteRect.right + gap);
-    const right = Math.min(window.innerWidth - gap, endRect.left - gap);
-    const width = Math.max(140, right - left);
-    const searchHeight = search.offsetHeight || 40;
+    const left = Math.max(gap, Math.round(siteRect.right + gap));
+    const right = Math.min(window.innerWidth - gap, Math.round(endRect.left - gap));
+    const width = Math.max(120, right - left);
+    const searchHeight = Math.min(search.offsetHeight || 40, barHeight - 8);
     const top = Math.max(0, (barHeight - searchHeight) / 2);
 
     search.style.left = `${left}px`;

--- a/cultpodcasts/src/app/app.component.ts
+++ b/cultpodcasts/src/app/app.component.ts
@@ -76,6 +76,8 @@ export class AppComponent implements OnDestroy {
   /** Shows the floating "back to top" control once the user has scrolled well past the fold. */
   private static readonly BACK_TO_TOP_THRESHOLD_PX = 480;
   private static readonly DOCK_INLINE_GAP_PX = 12;
+  /** Don't dock at rest — homepage search must start dropped below the fixed bar. */
+  private static readonly MIN_SCROLL_TO_DOCK_PX = 40;
   protected readonly showBackToTop = signal(false);
   /** Search has scrolled up into the sticky logo bar (single-row chrome). */
   protected readonly chromeStuck = signal(false);

--- a/cultpodcasts/src/app/app.component.ts
+++ b/cultpodcasts/src/app/app.component.ts
@@ -320,12 +320,13 @@ export class AppComponent implements OnDestroy {
     const gap = AppComponent.DOCK_INLINE_GAP_PX;
     const siteRect = site.getBoundingClientRect();
     const endRect = end.getBoundingClientRect();
-    const barRect = bar.getBoundingClientRect();
+    // Logo bar is position:fixed at top:0 — never use a negative barRect.top for docking.
+    const barHeight = Math.max(bar.getBoundingClientRect().height, 52);
     const left = Math.max(gap, siteRect.right + gap);
     const right = Math.min(window.innerWidth - gap, endRect.left - gap);
     const width = Math.max(140, right - left);
-    const searchHeight = search.getBoundingClientRect().height || 40;
-    const top = barRect.top + Math.max(0, (barRect.height - searchHeight) / 2);
+    const searchHeight = search.offsetHeight || 40;
+    const top = Math.max(0, (barHeight - searchHeight) / 2);
 
     search.style.left = `${left}px`;
     search.style.width = `${width}px`;

--- a/cultpodcasts/src/app/app.component.ts
+++ b/cultpodcasts/src/app/app.component.ts
@@ -75,6 +75,7 @@ export class AppComponent implements OnDestroy {
 
   /** Shows the floating "back to top" control once the user has scrolled well past the fold. */
   private static readonly BACK_TO_TOP_THRESHOLD_PX = 480;
+  private static readonly DOCK_INLINE_GAP_PX = 12;
   protected readonly showBackToTop = signal(false);
   /** Search has scrolled up into the sticky logo bar (single-row chrome). */
   protected readonly chromeStuck = signal(false);
@@ -119,12 +120,14 @@ export class AppComponent implements OnDestroy {
     if (this.isBrowser) {
       this.removeDragListeners();
       this.removeScrollListener();
+      window.removeEventListener('resize', this.onWindowResize);
     }
   }
 
   initialiseBrowser() {
     this.addDragListeners();
     this.addScrollListener();
+    window.addEventListener('resize', this.onWindowResize, { passive: true });
     this.router.events
       .pipe(
         filter((event): event is NavigationEnd => event instanceof NavigationEnd),
@@ -258,6 +261,12 @@ export class AppComponent implements OnDestroy {
     });
   };
 
+  private readonly onWindowResize = () => {
+    if (this.chromeStuck()) {
+      this.layoutDockedSearch();
+    }
+  };
+
   private syncChromeFromScroll(): void {
     const y = window.scrollY;
     this.showBackToTop.set(y > AppComponent.BACK_TO_TOP_THRESHOLD_PX);
@@ -272,6 +281,9 @@ export class AppComponent implements OnDestroy {
       // Release back to the dropped layout near the top of the page.
       if (y < Math.max(8, this.dockAtScrollY - 12)) {
         this.chromeStuck.set(false);
+        this.clearDockedSearchLayout(search);
+      } else {
+        this.layoutDockedSearch();
       }
       return;
     }
@@ -282,7 +294,50 @@ export class AppComponent implements OnDestroy {
     if (searchTop <= barBottom + 2) {
       this.dockAtScrollY = y;
       this.chromeStuck.set(true);
+      // Layout after the docked class applies.
+      requestAnimationFrame(() => this.layoutDockedSearch());
     }
+  }
+
+  /**
+   * Pin the search field between the logo (#site) and add/profile (#socialbuttons)
+   * — or the overflow menu on narrow viewports — inside the sticky header row.
+   */
+  private layoutDockedSearch(): void {
+    const bar = this.chromeBar?.nativeElement;
+    const search = this.chromeSearch?.nativeElement;
+    if (!bar || !search || !this.chromeStuck()) {
+      return;
+    }
+
+    const site = bar.querySelector('#site') as HTMLElement | null;
+    const end = (bar.querySelector('#socialbuttons') as HTMLElement | null)
+      ?? (bar.querySelector('button#menu') as HTMLElement | null);
+    if (!site || !end) {
+      return;
+    }
+
+    const gap = AppComponent.DOCK_INLINE_GAP_PX;
+    const siteRect = site.getBoundingClientRect();
+    const endRect = end.getBoundingClientRect();
+    const barRect = bar.getBoundingClientRect();
+    const left = Math.max(gap, siteRect.right + gap);
+    const right = Math.min(window.innerWidth - gap, endRect.left - gap);
+    const width = Math.max(140, right - left);
+    const searchHeight = search.getBoundingClientRect().height || 40;
+    const top = barRect.top + Math.max(0, (barRect.height - searchHeight) / 2);
+
+    search.style.left = `${left}px`;
+    search.style.width = `${width}px`;
+    search.style.top = `${top}px`;
+    search.style.transform = 'none';
+  }
+
+  private clearDockedSearchLayout(search: HTMLElement): void {
+    search.style.left = '';
+    search.style.width = '';
+    search.style.top = '';
+    search.style.transform = '';
   }
 
   private readonly onDocumentDragEnter = (event: DragEvent) => {

--- a/cultpodcasts/src/app/homepage-api/homepage-api.component.html
+++ b/cultpodcasts/src/app/homepage-api/homepage-api.component.html
@@ -2,10 +2,6 @@
   [class.nflx--playing]="!!playerService.episode() && playerService.mode() === 'dock'">
   <app-site-loading [active]="isLoading()" label="Loading homepage" />
 
-  <div class="nflx-search">
-    <app-search-bar></app-search-bar>
-  </div>
-
   @if (isLoading()) {
   <div class="nflx-loading" aria-hidden="true">
     <div class="nflx-loading__billboard">

--- a/cultpodcasts/src/app/homepage-api/homepage-api.component.sass
+++ b/cultpodcasts/src/app/homepage-api/homepage-api.component.sass
@@ -11,6 +11,8 @@
     background: var(--nflx-bg)
     min-height: 100vh
     padding-bottom: 48px
+    // Pull under sticky chrome so the billboard sits behind the transparent header/search.
+    margin-top: calc(-1 * var(--site-chrome-h, 130px))
 
 .nflx--playing
     padding-bottom: min(52vh, 420px)

--- a/cultpodcasts/src/app/homepage-api/homepage-api.component.sass
+++ b/cultpodcasts/src/app/homepage-api/homepage-api.component.sass
@@ -1,15 +1,11 @@
 // Netflix-style browse shell — children own billboard / catalogue / discover / rails.
 // --nflx-* tokens live on :root (styles.scss); layout-only tokens stay here.
+// Search chrome lives in app.component (.site-chrome); hero clearance comes from #body.
 .nflx
     --rail-poster-w: min(42vw, 220px)
     --rail-poster-sq: min(32vw, 160px)
     --obscure-card-w: min(42vw, 168px)
     --obscure-yt-w: min(55vw, 240px)
-    // Absolute .nflx-search overlays the hero; homepage-hero reads this to keep
-    // titles/actions below the search hit box (esp. short mobile viewports).
-    --nflx-search-top: 72px
-    --nflx-search-h: 48px
-    --nflx-hero-search-clearance: calc(var(--nflx-search-top) + var(--nflx-search-h) + 20px)
     position: relative
     color: var(--nflx-text)
     background: var(--nflx-bg)
@@ -18,72 +14,6 @@
 
 .nflx--playing
     padding-bottom: min(52vh, 420px)
-
-.nflx-search
-    --search-bar-control-h: var(--nflx-search-h)
-    --mat-form-field-container-height: var(--nflx-search-h)
-    --mat-form-field-container-vertical-padding: 0px
-    position: absolute
-    top: var(--nflx-search-top)
-    left: 50%
-    z-index: 15
-    transform: translateX(-50%)
-    width: min(640px, calc(100% - 2.5rem))
-    #searchcontainer
-        margin: 0
-    ::ng-deep
-        #searchbar
-            gap: 12px
-        #searchbox
-            // Always dark panel on the billboard (ignore light --nflx-search-glass).
-            .mat-mdc-text-field-wrapper,
-            .mdc-text-field,
-            .mdc-text-field--outlined,
-            .mdc-text-field--no-label
-                background: rgba(12, 12, 12, 0.88) !important
-                backdrop-filter: blur(10px)
-                color: #fff !important
-            .mdc-notched-outline__leading,
-            .mdc-notched-outline__notch,
-            .mdc-notched-outline__trailing
-                border-color: rgba(255, 255, 255, 0.45) !important
-            .mat-mdc-form-field:hover .mdc-notched-outline__leading,
-            .mat-mdc-form-field:hover .mdc-notched-outline__notch,
-            .mat-mdc-form-field:hover .mdc-notched-outline__trailing,
-            .mdc-text-field--focused .mdc-notched-outline__leading,
-            .mdc-text-field--focused .mdc-notched-outline__notch,
-            .mdc-text-field--focused .mdc-notched-outline__trailing
-                border-color: rgba(255, 255, 255, 0.7) !important
-            input.mat-mdc-chip-input,
-            #searchtext
-                font-size: 1.05rem
-                color: #fff !important
-                caret-color: #fff !important
-                &::placeholder
-                    color: rgba(255, 255, 255, 0.65) !important
-                    opacity: 1 !important
-            .mat-mdc-chip
-                --mdc-chip-label-text-color: #fff
-                --mdc-chip-outline-color: rgba(255, 255, 255, 0.4)
-                --mdc-chip-elevated-container-color: rgba(255, 255, 255, 0.12)
-                color: #fff !important
-                background: rgba(255, 255, 255, 0.12) !important
-            .mat-mdc-chip-remove,
-            .mat-icon
-                color: rgba(255, 255, 255, 0.8) !important
-        #searchcta
-            background: var(--nflx-accent, #e8a23a) !important
-            color: #111 !important
-
-@media screen and (max-width: 900px), (hover: none) and (pointer: coarse)
-    .nflx-search
-        ::ng-deep
-            #searchbox
-                .mat-mdc-text-field-wrapper,
-                .mdc-text-field,
-                .mdc-text-field--outlined,
-                .mdc-text-field--no-label
-                    backdrop-filter: none !important
 
 .nflx-error
     padding: 160px 16px
@@ -107,9 +37,6 @@
     .nflx
         --obscure-card-w: 42vw
         --obscure-yt-w: 55vw
-        --nflx-search-top: 64px
-    .nflx-search
-        width: min(640px, calc(100% - 1.5rem))
 
 @media screen and (max-width: 600px)
     .nflx

--- a/cultpodcasts/src/app/homepage-api/homepage-api.component.spec.ts
+++ b/cultpodcasts/src/app/homepage-api/homepage-api.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { Component, PLATFORM_ID, provideZonelessChangeDetection } from '@angular/core';
+import { PLATFORM_ID, provideZonelessChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { ActivatedRoute } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
@@ -13,10 +13,6 @@ import { PlayerService } from '../player.service';
 import { Homepage } from '../homepage.interface';
 import { HomepageEpisode } from '../homepage-episode.interface';
 import { RAIL_DISPLAY_SIZE, SUBJECT_RAIL_MIN_EPISODES } from '../rail-subjects';
-import { SearchBarComponent } from '../search-bar/search-bar.component';
-
-@Component({ selector: 'app-search-bar', template: '', standalone: true })
-class StubSearchBarComponent {}
 
 function dayOffset(daysAgo: number): Date {
   const d = new Date();
@@ -144,12 +140,7 @@ describe('HomepageApiComponent', () => {
           },
         },
       ],
-    })
-      .overrideComponent(HomepageApiComponent, {
-        remove: { imports: [SearchBarComponent] },
-        add: { imports: [StubSearchBarComponent] },
-      })
-      .compileComponents();
+    }).compileComponents();
 
     fixture = TestBed.createComponent(HomepageApiComponent);
     component = fixture.componentInstance;

--- a/cultpodcasts/src/app/homepage-api/homepage-api.component.ts
+++ b/cultpodcasts/src/app/homepage-api/homepage-api.component.ts
@@ -18,7 +18,6 @@ import { MatDialog } from '@angular/material/dialog';
 import { HomepageService } from '../homepage.service';
 import { HomepageEpisode } from '../homepage-episode.interface';
 import { AuthServiceWrapper } from '../auth-service-wrapper.class';
-import { SearchBarComponent } from '../search-bar/search-bar.component';
 import { PlayerService } from '../player.service';
 import { episodeImageUrl } from '../search-result-links';
 import { SearchDisplayEpisode } from '../search-result-links';
@@ -61,7 +60,6 @@ export interface EpisodeRail {
   selector: 'app-homepage-api',
   imports: [
     MatButtonModule,
-    SearchBarComponent,
     SiteLoadingComponent,
     HomepageHeroComponent,
     HomepageCatalogueComponent,

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
@@ -8,7 +8,7 @@
     min-height: min(88vh, 720px)
     display: flex
     align-items: flex-end
-    // Keep feature copy below the absolute homepage search overlay.
+    // Keep feature copy below the dropped chrome search overlay.
     padding: var(--nflx-hero-search-clearance, 140px) 4vw 48px
     box-sizing: border-box
     overflow: hidden

--- a/cultpodcasts/src/app/search-bar/search-bar.component.ts
+++ b/cultpodcasts/src/app/search-bar/search-bar.component.ts
@@ -108,8 +108,7 @@ export class SearchBarComponent {
     if (!el) {
       return;
     }
-    // Chrome search stays in DOM but is display:none on home; skip so the
-    // homepage instance (which is visible) can take the same focus request.
+    // Skip zero-rect instances so a visible search field can take focus.
     if (!el.getClientRects().length) {
       return;
     }

--- a/cultpodcasts/src/app/toolbar/toolbar.component.html
+++ b/cultpodcasts/src/app/toolbar/toolbar.component.html
@@ -2,9 +2,6 @@
   <mat-toolbar class="app-toolbar">
     <a routerLink="/" id="site" (click)="onSiteClick()"><img src="/assets/cultpodcasts.svg"
         alt="image"><span>Cult Podcasts</span></a>
-    <div class="toolbar-search">
-      <ng-content select="[chromeSearch]"></ng-content>
-    </div>
     <div id="socialbuttons">
       <img src="/assets/add-podcast.svg" alt="Add Podcast" class="socialbutton button" (click)="openSubmitPodcast()">
       @if (featureSwitchService.IsEnabled(FeatureSwitch.auth0)) {

--- a/cultpodcasts/src/app/toolbar/toolbar.component.html
+++ b/cultpodcasts/src/app/toolbar/toolbar.component.html
@@ -2,6 +2,9 @@
   <mat-toolbar class="app-toolbar">
     <a routerLink="/" id="site" (click)="onSiteClick()"><img src="/assets/cultpodcasts.svg"
         alt="image"><span>Cult Podcasts</span></a>
+    <div class="toolbar-search">
+      <ng-content select="[chromeSearch]"></ng-content>
+    </div>
     <div id="socialbuttons">
       <img src="/assets/add-podcast.svg" alt="Add Podcast" class="socialbutton button" (click)="openSubmitPodcast()">
       @if (featureSwitchService.IsEnabled(FeatureSwitch.auth0)) {

--- a/cultpodcasts/src/app/toolbar/toolbar.component.sass
+++ b/cultpodcasts/src/app/toolbar/toolbar.component.sass
@@ -41,40 +41,6 @@
     .mat-toolbar-single-row
         overflow: visible
 
-.toolbar-search
-    display: flex
-    align-items: center
-    min-width: 0
-    // Default (expanded): drop below the bar, centered at homepage width.
-    position: absolute
-    left: 50%
-    top: calc(100% + 12px)
-    transform: translateX(-50%)
-    width: min(640px, calc(100vw - 2.5rem))
-    max-width: min(640px, calc(100% - 2.5rem))
-    z-index: 15
-    flex: none
-    margin: 0
-    pointer-events: auto
-
-@media screen and (max-width: 700px)
-    .toolbar-search
-        width: min(640px, calc(100vw - 1.5rem))
-        max-width: min(640px, calc(100% - 1.5rem))
-
-:host-context(.chrome-compact)
-    .toolbar-search
-        position: relative
-        left: auto
-        top: auto
-        transform: none
-        flex: 1 1 auto
-        min-width: 0
-        width: auto
-        max-width: min(480px, 100%)
-        margin: 0 10px
-        z-index: auto
-
 .beta
     color: #aaa
 
@@ -132,7 +98,7 @@ button#menu
     border: none
     background-color: transparent
 
-// Home overlay colors — absolute/sticky placement lives on .site-chrome in app.
+// Home overlay colors — sticky frosted placement lives on .site-chrome in app.
 :host-context(.home-shell)
     .app-toolbar
         background: linear-gradient(to bottom, rgba(0, 0, 0, 0.75), transparent) !important

--- a/cultpodcasts/src/app/toolbar/toolbar.component.sass
+++ b/cultpodcasts/src/app/toolbar/toolbar.component.sass
@@ -128,3 +128,15 @@ button#menu
         color: var(--nflx-text, var(--mat-sys-on-surface))
     button#menu
         color: var(--nflx-text, var(--mat-sys-on-surface))
+
+// When search is docked into the bar, keep logo icon-only so the field fits
+// between mark and add/profile (esp. browse + narrow widths).
+:host-context(.chrome-stuck)
+    #site span
+        position: absolute
+        width: 1px
+        height: 1px
+        overflow: hidden
+        clip: rect(0, 0, 0, 0)
+    #site
+        gap: 0

--- a/cultpodcasts/src/app/toolbar/toolbar.component.sass
+++ b/cultpodcasts/src/app/toolbar/toolbar.component.sass
@@ -8,6 +8,9 @@
     .mat-toolbar-single-row
         padding-right: 0
 
+#header
+    overflow: visible
+
 @media screen and (min-width: 600px)
     #menu
         display: none
@@ -23,6 +26,7 @@
         padding-right: 4px
 
 .app-toolbar
+    position: relative
     background: color-mix(in srgb, var(--cp-ink-elevated, var(--mat-sys-surface-container)) 72%, transparent) !important
     backdrop-filter: blur(14px)
     -webkit-backdrop-filter: blur(14px)
@@ -37,6 +41,40 @@
     .mat-toolbar-single-row
         overflow: visible
 
+.toolbar-search
+    display: flex
+    align-items: center
+    min-width: 0
+    // Default (expanded): drop below the bar, centered at homepage width.
+    position: absolute
+    left: 50%
+    top: calc(100% + 12px)
+    transform: translateX(-50%)
+    width: min(640px, calc(100vw - 2.5rem))
+    max-width: min(640px, calc(100% - 2.5rem))
+    z-index: 15
+    flex: none
+    margin: 0
+    pointer-events: auto
+
+@media screen and (max-width: 700px)
+    .toolbar-search
+        width: min(640px, calc(100vw - 1.5rem))
+        max-width: min(640px, calc(100% - 1.5rem))
+
+:host-context(.chrome-compact)
+    .toolbar-search
+        position: relative
+        left: auto
+        top: auto
+        transform: none
+        flex: 1 1 auto
+        min-width: 0
+        width: auto
+        max-width: min(480px, 100%)
+        margin: 0 10px
+        z-index: auto
+
 .beta
     color: #aaa
 
@@ -46,6 +84,7 @@
     display: inline-flex
     align-items: center
     gap: 12px
+    flex-shrink: 0
     img
         vertical-align: middle
         width: 42px
@@ -72,6 +111,7 @@
         opacity: 0
 
 #socialbuttons
+    flex-shrink: 0
     .button:hover
         cursor: pointer
     // Signed-in chrome wraps the avatar + matBadge. Do not overflow:hidden here —
@@ -88,16 +128,13 @@
         box-shadow: 0 0 0 2px color-mix(in srgb, var(--cp-amber, #e8a23a) 40%, transparent)
 
 button#menu
+    flex-shrink: 0
     border: none
     background-color: transparent
 
+// Home overlay colors — absolute/sticky placement lives on .site-chrome in app.
 :host-context(.home-shell)
     .app-toolbar
-        position: absolute
-        top: 0
-        left: 0
-        right: 0
-        z-index: 20
         background: linear-gradient(to bottom, rgba(0, 0, 0, 0.75), transparent) !important
         border-bottom-color: transparent
         backdrop-filter: none
@@ -114,13 +151,13 @@ button#menu
     button#menu
         color: var(--nflx-on-media, #fff)
 
-// Browse routes use the same frosted bar as Material chrome, but tinted with
-// Flix tokens so light OS theme does not sit cream-on-black.
 :host-context(.browse-shell)
     .app-toolbar
-        background: color-mix(in srgb, var(--nflx-panel, var(--cp-ink-elevated)) 78%, transparent) !important
+        background: transparent !important
         color: var(--nflx-text, var(--mat-sys-on-surface))
-        border-bottom: 1px solid var(--nflx-border, color-mix(in srgb, var(--mat-sys-outline-variant) 45%, transparent))
+        border-bottom: none
+        backdrop-filter: none
+        -webkit-backdrop-filter: none
     #site
         color: var(--nflx-text, var(--mat-sys-on-surface))
     button#menu


### PR DESCRIPTION
## Summary
- Sticky site chrome with search projected into the toolbar (logo | search | add/profile)
- At page top, search drops below the header at homepage width; after a short scroll it collapses into the sticky bar
- Homepage and browse share the same behaviour (no duplicate homepage search overlay)

## Test plan
- [ ] Homepage: search overlays hero at top; scroll → frosted sticky bar with inline search
- [ ] Browse/search/podcast pages: same dropped → collapsed behaviour; search not full-bleed
- [ ] Mobile: search fits between logo and menu when compact; Search CTA hides when collapsed
- [ ] Search still navigates / suggestions still work after collapse
- [ ] Cloudflare Pages preview deploys and loads