### PR TITLE
fix(auth): recover Missing Refresh Token without manual re-login

### DIFF
--- a/cultpodcasts/docs/auth0-preview-hosts.md
+++ b/cultpodcasts/docs/auth0-preview-hosts.md
@@ -6,8 +6,8 @@ Preview hosts change every deploy (`https://<id-or-branch>.website-83e.pages.dev
 
 - Login `redirect_uri` and logout `returnTo` use `window.location.origin` ([`auth-redirect-uri.ts`](../src/app/auth-redirect-uri.ts)).
 - MatIcon SVGs are inlined via `addSvgIconLiteral` ([`register-svg-icons.ts`](../src/app/register-svg-icons.ts)); plain assets use same-origin `/assets/...`.
-- Auth0 SPA uses **refresh tokens** + `localstorage` (`useRefreshTokens`, `cacheLocation`) so `getAccessTokenSilently` does not rely on a cross-site iframe. Preview hosts (`*.pages.dev`) are third-party to `auth-staging.cultpodcasts.com`; Firefox blocks that iframe and surfaces `Error: Login required`.
-- After deploying this config, **log out and log in once** so Auth0 issues a refresh token covering `openid profile email offline_access curate admin submit`. Refresh tokens cannot add scopes later; a session minted without those API scopes will throw `Missing Refresh Token` on silent renew.
+- Auth0 SPA uses **refresh tokens** + `localstorage` (`useRefreshTokens`, `cacheLocation`), with `useRefreshTokensFallback` for when an Auth0 session cookie can still silent-renew. Preview hosts (`*.pages.dev`) are third-party to `auth-staging.cultpodcasts.com`; Firefox often blocks that iframe.
+- If silent renew still fails with `missing_refresh_token` / `invalid_grant`, [`AuthServiceWrapper`](../src/app/auth-service-wrapper.class.ts) calls `loginWithRedirect` once (SSO bounce when the Auth0 cookie is alive). Refresh tokens cannot add scopes later — a session minted without `openid profile email offline_access curate admin submit` needs that interactive login.
 - The Auth0 **API** (`https://api.cultpodcasts.com/`) must have **Allow Offline Access** enabled, or Auth0 never returns a refresh token even when the SPA requests `offline_access`.
 
 ## Auth0 Application (staging SPA)

--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.10",
+  "version": "1.10.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.10.10",
+      "version": "1.10.11",
       "dependencies": {
         "@angular/cdk": "^22.0.6",
         "@angular/common": "^22.0.8",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.10",
+  "version": "1.10.11",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/src/app/app.config.ts
+++ b/cultpodcasts/src/app/app.config.ts
@@ -25,11 +25,12 @@ export const appConfig: ApplicationConfig = {
     provideAuth0({
       domain: environment.auth0.domain,
       clientId: environment.auth0.clientId,
-      // Firefox (and Safari) block Auth0 silent auth iframes when the app host
-      // (e.g. *.pages.dev) is cross-site to the Auth0 custom domain. Refresh
-      // tokens + localStorage avoid that path for getAccessTokenSilently.
+      // Prefer refresh tokens in localStorage. If the RT is missing, fall back to
+      // the Auth0 iframe when the custom domain session cookie is still valid
+      // (prod/staging apex). Preview hosts (*.pages.dev) often block that iframe;
+      // AuthServiceWrapper then loginWithRedirects once on missing_refresh_token.
       useRefreshTokens: true,
-      useRefreshTokensFallback: false,
+      useRefreshTokensFallback: true,
       cacheLocation: 'localstorage',
       authorizationParams: {
         redirect_uri: authRedirectUri(environment.assetHost),

--- a/cultpodcasts/src/app/auth-service-wrapper.class.spec.ts
+++ b/cultpodcasts/src/app/auth-service-wrapper.class.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { PLATFORM_ID, provideZonelessChangeDetection } from '@angular/core';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, Subject, of } from 'rxjs';
 import { AuthService } from '@auth0/auth0-angular';
 import {
   AUTH_AVATAR_STORAGE_KEY,
@@ -12,6 +12,8 @@ describe('AuthServiceWrapper avatar cache', () => {
   let isLoading$: BehaviorSubject<boolean>;
   let isAuthenticated$: BehaviorSubject<boolean>;
   let user$: BehaviorSubject<Record<string, unknown> | null>;
+  let error$: Subject<Error>;
+  let loginWithRedirect: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     localStorage.removeItem(AUTH_AVATAR_STORAGE_KEY);
@@ -19,6 +21,8 @@ describe('AuthServiceWrapper avatar cache', () => {
     isLoading$ = new BehaviorSubject(true);
     isAuthenticated$ = new BehaviorSubject(false);
     user$ = new BehaviorSubject<Record<string, unknown> | null>(null);
+    error$ = new Subject<Error>();
+    loginWithRedirect = vi.fn().mockName('loginWithRedirect').mockReturnValue(of(void 0));
 
     TestBed.configureTestingModule({
       providers: [
@@ -30,6 +34,8 @@ describe('AuthServiceWrapper avatar cache', () => {
             isLoading$,
             isAuthenticated$,
             user$,
+            error$,
+            loginWithRedirect,
           },
         },
         AuthServiceWrapper,
@@ -113,5 +119,33 @@ describe('AuthServiceWrapper avatar cache', () => {
     expect(wrapper.avatarUrl()).toBeNull();
     expect(localStorage.getItem(AUTH_AVATAR_STORAGE_KEY)).toBeNull();
     expect(document.documentElement.classList.contains('has-cached-avatar')).toBe(false);
+  });
+
+  it('loginWithRedirects once on missing_refresh_token', () => {
+    TestBed.inject(AuthServiceWrapper);
+
+    error$.next(
+      Object.assign(new Error("Missing Refresh Token (audience: 'https://api.cultpodcasts.com/')"), {
+        error: 'missing_refresh_token',
+      })
+    );
+    error$.next(
+      Object.assign(new Error("Missing Refresh Token (audience: 'https://api.cultpodcasts.com/')"), {
+        error: 'missing_refresh_token',
+      })
+    );
+
+    expect(loginWithRedirect).toHaveBeenCalledTimes(1);
+    expect(loginWithRedirect).toHaveBeenCalledWith({
+      appState: { target: expect.stringMatching(/^\//) },
+    });
+  });
+
+  it('does not loginWithRedirect for unrelated Auth0 errors', () => {
+    TestBed.inject(AuthServiceWrapper);
+
+    error$.next(Object.assign(new Error('Login required'), { error: 'login_required' }));
+
+    expect(loginWithRedirect).not.toHaveBeenCalled();
   });
 });

--- a/cultpodcasts/src/app/auth-service-wrapper.class.ts
+++ b/cultpodcasts/src/app/auth-service-wrapper.class.ts
@@ -1,7 +1,8 @@
 import { Injectable, PLATFORM_ID, inject, signal } from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
 import { AuthService } from '@auth0/auth0-angular';
-import { combineLatest, filter, of, ReplaySubject, take } from 'rxjs';
+import { combineLatest, EMPTY, filter, of, ReplaySubject, take } from 'rxjs';
+import { currentAppPath, isSessionRecoveryError } from './auth-session-recovery';
 
 /**
  * Playwright sets `globalThis.__E2E_CURATOR__` via addInitScript so curator
@@ -26,6 +27,9 @@ export class AuthServiceWrapper {
     private readonly _avatarUrl = signal<string | null>(null);
     readonly avatarUrl = this._avatarUrl.asReadonly();
 
+    /** One interactive re-login per page lifetime — avoids redirect storms from concurrent token calls. */
+    private sessionRecoveryStarted = false;
+
     constructor(public authService: AuthService) {
         // Re-seed on the browser only — SSR/prerender has no localStorage, and a null
         // server value must not stick around after client bootstrap.
@@ -47,7 +51,9 @@ export class AuthServiceWrapper {
                 user$: of(curatorUser),
                 isAuthenticated$: of(true),
                 isLoading$: of(false),
-                getAccessTokenSilently: () => of('e2e-test-token')
+                error$: EMPTY,
+                getAccessTokenSilently: () => of('e2e-test-token'),
+                loginWithRedirect: () => of(void 0)
             } as unknown as AuthService;
         }
 
@@ -94,7 +100,33 @@ export class AuthServiceWrapper {
                         }
                     });
             }
+
+            this.watchSessionRecovery();
         }
+    }
+
+    /**
+     * When the refresh token is missing or revoked, bounce through Auth0 login once.
+     * With an active Auth0 SSO cookie this is usually a silent round-trip (no password).
+     */
+    private watchSessionRecovery(): void {
+        if (!isPlatformBrowser(this.platformId) || !this.authService.error$) {
+            return;
+        }
+        this.authService.error$.subscribe(error => {
+            if (!isSessionRecoveryError(error) || this.sessionRecoveryStarted) {
+                return;
+            }
+            this.sessionRecoveryStarted = true;
+            this.authService.loginWithRedirect({
+                appState: { target: currentAppPath() }
+            }).subscribe({
+                error: () => {
+                    // Allow a later retry if the redirect itself failed to start.
+                    this.sessionRecoveryStarted = false;
+                }
+            });
+        });
     }
 
     /** Call on explicit logout so the toolbar flips immediately before Auth0 redirects. */

--- a/cultpodcasts/src/app/auth-session-recovery.spec.ts
+++ b/cultpodcasts/src/app/auth-session-recovery.spec.ts
@@ -1,0 +1,36 @@
+import { currentAppPath, isSessionRecoveryError } from './auth-session-recovery';
+
+describe('isSessionRecoveryError', () => {
+  it('matches Auth0 missing_refresh_token errors', () => {
+    expect(
+      isSessionRecoveryError({
+        error: 'missing_refresh_token',
+        message: "Missing Refresh Token (audience: 'https://api.cultpodcasts.com/', scope: 'openid')"
+      })
+    ).toBe(true);
+  });
+
+  it('matches invalid_grant refresh failures', () => {
+    expect(isSessionRecoveryError({ error: 'invalid_grant', message: 'Unknown or invalid refresh token.' })).toBe(true);
+  });
+
+  it('matches Missing Refresh Token message without an error code', () => {
+    expect(
+      isSessionRecoveryError(
+        new Error("Missing Refresh Token (audience: 'https://api.cultpodcasts.com/', scope: 'openid')")
+      )
+    ).toBe(true);
+  });
+
+  it('ignores login_required and other auth noise', () => {
+    expect(isSessionRecoveryError({ error: 'login_required', message: 'Login required' })).toBe(false);
+    expect(isSessionRecoveryError(new Error('network_error'))).toBe(false);
+    expect(isSessionRecoveryError(null)).toBe(false);
+  });
+});
+
+describe('currentAppPath', () => {
+  it('returns path, query, and hash from window.location', () => {
+    expect(currentAppPath()).toMatch(/^\//);
+  });
+});

--- a/cultpodcasts/src/app/auth-session-recovery.ts
+++ b/cultpodcasts/src/app/auth-session-recovery.ts
@@ -1,0 +1,24 @@
+/**
+ * Auth0 SPA errors that mean the local session cannot be renewed silently
+ * and need an interactive login (usually SSO bounce, not a full password entry).
+ */
+export function isSessionRecoveryError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+  const code = 'error' in error ? String((error as { error?: unknown }).error ?? '') : '';
+  const message = 'message' in error ? String((error as { message?: unknown }).message ?? '') : '';
+  return (
+    code === 'missing_refresh_token' ||
+    code === 'invalid_grant' ||
+    message.startsWith('Missing Refresh Token')
+  );
+}
+
+/** Prefer returning the user to the page they were on after Auth0 callback. */
+export function currentAppPath(): string {
+  if (typeof window === 'undefined') {
+    return '/';
+  }
+  return `${window.location.pathname}${window.location.search}${window.location.hash}` || '/';
+}

--- a/cultpodcasts/src/app/discovery-api/discovery-api.component.html
+++ b/cultpodcasts/src/app/discovery-api/discovery-api.component.html
@@ -35,8 +35,8 @@
       <button matButton="tonal" (click)="selectLikelyMatches()">Select likely</button>
       }
       @if (displaySave()) {
-      <button matButton="tonal" (click)="close()" [disabled]="closeDisabled()">Close</button>
-      <button matButton="tonal" (click)="save()" [disabled]="saveDisabled()" [matBadge]="selectedIds().length"
+      <button matButton="tonal" class="curator-toolbar__close" (click)="close()" [disabled]="closeDisabled()">Close</button>
+      <button matButton="tonal" class="curator-toolbar__save" (click)="save()" [disabled]="saveDisabled()" [matBadge]="selectedIds().length"
         [matBadgeHidden]="saveDisabled()">Save</button>
       }
     </div>

--- a/cultpodcasts/src/app/discovery-api/discovery-api.component.sass
+++ b/cultpodcasts/src/app/discovery-api/discovery-api.component.sass
@@ -48,6 +48,14 @@
     gap: 10px
     margin-left: auto
 
+// On phones the Close/Save pair wraps onto a second row; hide the disabled one
+// (they are mutually exclusive) so only the actionable control takes space.
+@media screen and (max-width: 600px)
+    .curator-toolbar__actions
+        .curator-toolbar__close[disabled],
+        .curator-toolbar__save[disabled]
+            display: none
+
 :host ::ng-deep .curator-toolbar__actions
     .mat-button-toggle-group
         overflow: hidden

--- a/cultpodcasts/src/app/fake-auth-service-wrapper.ts
+++ b/cultpodcasts/src/app/fake-auth-service-wrapper.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { of } from 'rxjs';
+import { EMPTY, of } from 'rxjs';
 import { AuthServiceWrapper } from './auth-service-wrapper.class';
 
 @Injectable({ providedIn: 'root' })
@@ -13,7 +13,8 @@ export class FakeAuthServiceWrapper extends AuthServiceWrapper {
       getAccessTokenSilently: () => of(),
       isAuthenticated$: of(false),
       isLoading$: of(false),
-      user$: of(null)
+      user$: of(null),
+      error$: EMPTY
     } as any);
   }
 }


### PR DESCRIPTION
## Summary
- Enable Auth0 `useRefreshTokensFallback` so a still-valid custom-domain session can silent-renew when the local refresh token is gone.
- On `missing_refresh_token` / `invalid_grant`, `AuthServiceWrapper` calls `loginWithRedirect` once (SSO bounce) and returns to the current path.
- On discovery (≤600px), hide disabled Close/Save so only the actionable button shows and Save does not wrap to a second row.
- Bump client to 1.10.11.

## Test plan
- [ ] Unit tests: `auth-session-recovery` + AuthServiceWrapper redirect-once coverage
- [ ] Signed-in curator: Missing Refresh Token triggers an automatic Auth0 bounce that restores API calls without manual sign-out/in
- [ ] Unrelated Auth0 errors (e.g. `login_required` alone) do not force a redirect storm
- [ ] Discovery on a phone-width viewport: with no selection only Close shows; with selection only Save shows
- [ ] Discovery on desktop: both Close and Save remain visible (disabled state unchanged)