### PR TITLE
fix(ui): show Search button in sticky docked search

### DIFF
--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.12",
+  "version": "1.10.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.10.12",
+      "version": "1.10.13",
       "dependencies": {
         "@angular/cdk": "^22.0.6",
         "@angular/common": "^22.0.8",

--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.11",
+  "version": "1.10.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.10.11",
+      "version": "1.10.12",
       "dependencies": {
         "@angular/cdk": "^22.0.6",
         "@angular/common": "^22.0.8",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.11",
+  "version": "1.10.12",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.12",
+  "version": "1.10.13",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/src/app/app.component.sass
+++ b/cultpodcasts/src/app/app.component.sass
@@ -148,12 +148,14 @@
         #searchcta
             display: inline-flex !important
             flex: 0 0 auto
-            min-width: 0
+            min-width: 0 !important
+            width: auto
             height: var(--nflx-search-h)
             min-height: var(--nflx-search-h)
-            padding-left: 14px
-            padding-right: 14px
-            font-size: 0.875rem
+            padding-left: 12px
+            padding-right: 12px
+            font-size: 0.8125rem
+            letter-spacing: 0
             background: var(--nflx-accent, #e8a23a) !important
             color: #111 !important
         .chiptext
@@ -163,8 +165,9 @@
     .chrome-search--docked
         ::ng-deep
             #searchcta
-                padding-left: 12px
-                padding-right: 12px
+                padding-left: 8px
+                padding-right: 8px
+                font-size: 0.75rem
             .chiptext
                 max-width: 3.5rem
 
@@ -174,9 +177,12 @@
         left: 58px
         width: calc(100vw - 7rem)
         ::ng-deep
+            #searchbar
+                gap: 6px
             #searchcta
-                padding-left: 10px
-                padding-right: 10px
+                padding-left: 6px
+                padding-right: 6px
+                font-size: 0.7rem
             .chiptext
                 max-width: 2.75rem
 

--- a/cultpodcasts/src/app/app.component.sass
+++ b/cultpodcasts/src/app/app.component.sass
@@ -137,20 +137,34 @@
     --nflx-search-h: 40px
     overflow: hidden
     ::ng-deep
-        // CTA does not fit in the header slot on narrow/mid widths; Enter still searches.
-        #searchcta
-            display: none !important
         #searchbar
-            gap: 0
+            gap: 8px
+            min-width: 0
+        #searchboxwrapper
+            flex: 1 1 auto
             min-width: 0
         #searchbox
             min-width: 0
+        #searchcta
+            display: inline-flex !important
+            flex: 0 0 auto
+            min-width: 0
+            height: var(--nflx-search-h)
+            min-height: var(--nflx-search-h)
+            padding-left: 14px
+            padding-right: 14px
+            font-size: 0.875rem
+            background: var(--nflx-accent, #e8a23a) !important
+            color: #111 !important
         .chiptext
             max-width: 5.5rem
 
 @media screen and (max-width: 700px)
     .chrome-search--docked
         ::ng-deep
+            #searchcta
+                padding-left: 12px
+                padding-right: 12px
             .chiptext
                 max-width: 3.5rem
 
@@ -159,6 +173,12 @@
         // Between logo icon and overflow menu.
         left: 58px
         width: calc(100vw - 7rem)
+        ::ng-deep
+            #searchcta
+                padding-left: 10px
+                padding-right: 10px
+            .chiptext
+                max-width: 2.75rem
 
 // Homepage at top: dark glass over the billboard.
 .home-shell:not(.chrome-stuck) .chrome-search


### PR DESCRIPTION
## Summary
- Restore the Search CTA when search is docked into the sticky header (it was hidden for space)
- Compact padding / flex so the field + button still fit between logo and add/profile on narrow screens

## Test plan
- [ ] Homepage: scroll until search docks — Search button visible beside the field
- [ ] Narrow viewport (~400–700px): docked search shows field + button without overlapping logo/actions
- [ ] Browse/subject with chip: docked search still usable; Enter and Search button both work