### PR TITLE
fix(ui): curator cards, docked search suggestions, ultrawide hero

### DIFF
--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.15",
+  "version": "1.10.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.10.15",
+      "version": "1.10.16",
       "dependencies": {
         "@angular/cdk": "^22.0.6",
         "@angular/common": "^22.0.8",

--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.14",
+  "version": "1.10.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.10.14",
+      "version": "1.10.15",
       "dependencies": {
         "@angular/cdk": "^22.0.6",
         "@angular/common": "^22.0.8",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.15",
+  "version": "1.10.16",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.14",
+  "version": "1.10.15",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/src/app/app.component.sass
+++ b/cultpodcasts/src/app/app.component.sass
@@ -130,12 +130,13 @@
     top: calc((var(--site-chrome-bar-h) - var(--nflx-search-h)) / 2)
     width: calc(100vw - 11rem)
     max-width: none
+    // Size the input row only — do not clip the typeahead listbox below.
     height: var(--nflx-search-h)
     margin: 0
     z-index: 110
     transform: none
     --nflx-search-h: 40px
-    overflow: hidden
+    overflow: visible
     ::ng-deep
         #searchbar
             gap: 8px
@@ -143,6 +144,9 @@
         #searchboxwrapper
             flex: 1 1 auto
             min-width: 0
+            // Listbox is position:absolute under the field; keep it above page content.
+            #search-suggestions-listbox
+                z-index: 120
         #searchbox
             min-width: 0
         #searchcta

--- a/cultpodcasts/src/app/discovery-item/discovery-item.component.sass
+++ b/cultpodcasts/src/app/discovery-item/discovery-item.component.sass
@@ -87,12 +87,21 @@ mat-card-content
     margin-top: 10px
 
 .curator-card__actions
+    display: flex !important
+    flex-direction: row !important
+    flex-wrap: wrap
+    align-items: center
+    gap: 8px
     padding-top: 4px
     .discovery-service-links
         display: flex
         flex-wrap: wrap
         align-items: center
         gap: 4px
+        a[mat-icon-button],
+        button[mat-icon-button]
+            margin: 0 !important
+            transform: none !important
         .youtubemeta
             flex-direction: column
             margin-left: 6px

--- a/cultpodcasts/src/app/episodes-api/episodes-api.component.html
+++ b/cultpodcasts/src/app/episodes-api/episodes-api.component.html
@@ -92,8 +92,13 @@
                             {{result.podcastName}}
                         </a>
                     </mat-card-subtitle>
-                    <mat-card-subtitle class="curator-card__meta">{{result.release | date:'d MMM yyyy H:mm'}}
-                        [{{result.duration.startsWith("0")?result.duration.split(".")[0].substring(1):result.duration.split(".")[0]}}]
+                    <mat-card-subtitle class="curator-card__meta">
+                        <span>{{result.release | date:'d MMM yyyy H:mm'}}
+                            [{{result.duration.startsWith("0")?result.duration.split(".")[0].substring(1):result.duration.split(".")[0]}}]</span>
+                        @if (languageBadge(result); as lang) {
+                        <span class="curator-card__lang" [attr.title]="lang.label"
+                            [attr.aria-label]="lang.label">{{lang.flag}}</span>
+                        }
                     </mat-card-subtitle>
                 </mat-card-header>
                 <mat-card-content class="resultdescription">
@@ -101,7 +106,8 @@
                     @if (result.subjects?.length) {
                     <div class="curator-card__subjects">
                         <app-subjects [subjects]="result.subjects!" [showHidden]="true" [editable]="true"
-                            [disabled]="isUpdating(result.id)" (removeSubject)="removeSubject(result, $event)"></app-subjects>
+                            [disabled]="isUpdating(result.id)" [loadingSubjectName]="loadingSubjectName(result.id)"
+                            (removeSubject)="removeSubject(result, $event)"></app-subjects>
                     </div>
                     }
                     @if ((result.guestPeople?.length ?? 0) > 0 || (result.guestSuggestions?.length ?? 0) > 0) {

--- a/cultpodcasts/src/app/episodes-api/episodes-api.component.sass
+++ b/cultpodcasts/src/app/episodes-api/episodes-api.component.sass
@@ -68,23 +68,53 @@
 mat-card-title
     margin-right: 40px
 
+.curator-card__meta
+    display: flex
+    flex-wrap: wrap
+    align-items: center
+    gap: 6px 10px
+
+.curator-card__lang
+    display: inline-flex
+    align-items: center
+    font-size: 1.1rem
+    line-height: 1
+
 .curator-card__subjects,
 .curator-card__guests
     margin-top: 10px
 
+// Stack platforms above status so labeled pills never collide with service icons.
+// Override global public-card row-reverse on .mdc-card__actions.
 .curator-card__actions
-    display: flex
-    flex-wrap: wrap
-    align-items: flex-start
-    gap: 12px 16px
+    display: flex !important
+    flex-direction: column !important
+    flex-wrap: nowrap
+    align-items: stretch
+    gap: 10px
     padding-top: 8px
 
-.curator-card__status,
 .curator-card__platforms
     display: flex
     flex-wrap: wrap
     align-items: center
+    gap: 4px
+    order: -1
+    ::ng-deep app-episode-podcast-links
+        flex-wrap: wrap
+        height: auto
+        gap: 4px
+    a[mat-icon-button],
+    button[mat-icon-button]
+        margin: 0 !important
+        transform: none !important
+
+.curator-card__status
+    display: flex
+    flex-wrap: wrap
+    align-items: center
     gap: 8px
+    order: 0
 
 button.selected
     span

--- a/cultpodcasts/src/app/episodes-api/episodes-api.component.ts
+++ b/cultpodcasts/src/app/episodes-api/episodes-api.component.ts
@@ -31,6 +31,7 @@ import { PodcastIndexComponent } from '../podcast-index/podcast-index.component'
 import { EpisodeUpdateService } from '../episode-update.service';
 import { ManualTweetEpisodeDialogComponent } from '../manual-tweet-episode-dialog/manual-tweet-episode-dialog.component';
 import { ClampableTextComponent } from '../clampable-text/clampable-text.component';
+import { languageFlagBadgeForEpisode, LanguageFlagBadge } from '../language-flag';
 
 const sortParamDateAsc: string = "date-asc";
 const sortParamDateDesc: string = "date-desc";
@@ -65,7 +66,8 @@ export class EpisodesApiComponent {
   protected isLoading = signal<boolean>(true);
   protected sortDirection = signal<string>(sortParamDateDesc);
   protected updatingEpisodeId = signal<string | null>(null);
-  protected updatingFlag = signal<'ignored' | 'removed' | 'tweeted' | 'bluesky' | null>(null);
+  protected updatingFlag = signal<'ignored' | 'removed' | 'tweeted' | 'bluesky' | 'subject' | null>(null);
+  protected updatingSubjectName = signal<string | null>(null);
   protected addingGuest = signal<Record<string, string>>({});
 
   private destroyRef = inject(DestroyRef);
@@ -215,6 +217,17 @@ export class EpisodesApiComponent {
       || this.isLoadingBluesky(episodeId);
   }
 
+  languageBadge(episode: ApiEpisode): LanguageFlagBadge | undefined {
+    return languageFlagBadgeForEpisode(episode);
+  }
+
+  loadingSubjectName(episodeId: string): string | null {
+    if (!this.isUpdating(episodeId) || this.updatingFlag() !== 'subject') {
+      return null;
+    }
+    return this.updatingSubjectName();
+  }
+
   async refreshEpisode(episodeId: string) {
     try {
       const updated = await this.episodeUpdate.fetchEpisode(episodeId);
@@ -231,7 +244,7 @@ export class EpisodesApiComponent {
   private async runEpisodeUpdate(
     episode: ApiEpisode,
     action: () => Promise<ApiEpisode>,
-    flag: 'ignored' | 'removed' | 'tweeted' | 'bluesky' | null = null
+    flag: 'ignored' | 'removed' | 'tweeted' | 'bluesky' | 'subject' | null = null
   ) {
     if (this.isUpdating(episode.id)) {
       return;
@@ -248,11 +261,16 @@ export class EpisodesApiComponent {
     } finally {
       this.updatingEpisodeId.set(null);
       this.updatingFlag.set(null);
+      this.updatingSubjectName.set(null);
     }
   }
 
   removeSubject(episode: ApiEpisode, subject: string) {
-    this.runEpisodeUpdate(episode, () => this.episodeUpdate.removeSubject(episode, subject));
+    if (this.isUpdating(episode.id)) {
+      return;
+    }
+    this.updatingSubjectName.set(subject);
+    this.runEpisodeUpdate(episode, () => this.episodeUpdate.removeSubject(episode, subject), 'subject');
   }
 
   removeGuest(episode: ApiEpisode, guestName: string) {

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.html
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.html
@@ -6,18 +6,38 @@
 
   <div class="billboard__stages" aria-hidden="true">
     <div class="billboard__stage" [class.is-active]="heroFrontLayer() === 'a'"
-      [class.is-kenburns]="heroKenBurnsA()">
-      <div class="billboard__stage-bleed"
-        [style.background-image]="heroLayerA() ? 'url(' + heroLayerA() + ')' : null"></div>
-      <div class="billboard__stage-focus"
-        [style.background-image]="heroLayerA() ? 'url(' + heroLayerA() + ')' : null"></div>
+      [class.is-kenburns]="heroKenBurnsA()"
+      [class.has-edge-extend]="heroAspectA() != null"
+      [style.--hero-art-aspect]="heroAspectA() ?? null">
+      <div class="billboard__stage-edge billboard__stage-edge--left">
+        <div class="billboard__stage-edge-strip"
+          [style.background-image]="heroLayerA() ? 'url(' + heroLayerA() + ')' : null"></div>
+      </div>
+      <div class="billboard__stage-edge billboard__stage-edge--right">
+        <div class="billboard__stage-edge-strip"
+          [style.background-image]="heroLayerA() ? 'url(' + heroLayerA() + ')' : null"></div>
+      </div>
+      <div class="billboard__stage-focus-slot">
+        <div class="billboard__stage-focus"
+          [style.background-image]="heroLayerA() ? 'url(' + heroLayerA() + ')' : null"></div>
+      </div>
     </div>
     <div class="billboard__stage" [class.is-active]="heroFrontLayer() === 'b'"
-      [class.is-kenburns]="heroKenBurnsB()">
-      <div class="billboard__stage-bleed"
-        [style.background-image]="heroLayerB() ? 'url(' + heroLayerB() + ')' : null"></div>
-      <div class="billboard__stage-focus"
-        [style.background-image]="heroLayerB() ? 'url(' + heroLayerB() + ')' : null"></div>
+      [class.is-kenburns]="heroKenBurnsB()"
+      [class.has-edge-extend]="heroAspectB() != null"
+      [style.--hero-art-aspect]="heroAspectB() ?? null">
+      <div class="billboard__stage-edge billboard__stage-edge--left">
+        <div class="billboard__stage-edge-strip"
+          [style.background-image]="heroLayerB() ? 'url(' + heroLayerB() + ')' : null"></div>
+      </div>
+      <div class="billboard__stage-edge billboard__stage-edge--right">
+        <div class="billboard__stage-edge-strip"
+          [style.background-image]="heroLayerB() ? 'url(' + heroLayerB() + ')' : null"></div>
+      </div>
+      <div class="billboard__stage-focus-slot">
+        <div class="billboard__stage-focus"
+          [style.background-image]="heroLayerB() ? 'url(' + heroLayerB() + ')' : null"></div>
+      </div>
     </div>
   </div>
   <div class="billboard__grain" aria-hidden="true"></div>

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.html
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.html
@@ -6,12 +6,18 @@
 
   <div class="billboard__stages" aria-hidden="true">
     <div class="billboard__stage" [class.is-active]="heroFrontLayer() === 'a'"
-      [class.is-kenburns]="heroKenBurnsA()"
-      [style.background-image]="heroLayerA() ? 'url(' + heroLayerA() + ')' : null">
+      [class.is-kenburns]="heroKenBurnsA()">
+      <div class="billboard__stage-bleed"
+        [style.background-image]="heroLayerA() ? 'url(' + heroLayerA() + ')' : null"></div>
+      <div class="billboard__stage-focus"
+        [style.background-image]="heroLayerA() ? 'url(' + heroLayerA() + ')' : null"></div>
     </div>
     <div class="billboard__stage" [class.is-active]="heroFrontLayer() === 'b'"
-      [class.is-kenburns]="heroKenBurnsB()"
-      [style.background-image]="heroLayerB() ? 'url(' + heroLayerB() + ')' : null">
+      [class.is-kenburns]="heroKenBurnsB()">
+      <div class="billboard__stage-bleed"
+        [style.background-image]="heroLayerB() ? 'url(' + heroLayerB() + ')' : null"></div>
+      <div class="billboard__stage-focus"
+        [style.background-image]="heroLayerB() ? 'url(' + heroLayerB() + ')' : null"></div>
     </div>
   </div>
   <div class="billboard__grain" aria-hidden="true"></div>

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
@@ -39,17 +39,47 @@
 
 .billboard__stage
     position: absolute
-    inset: -4%
+    inset: 0
     background-color: #121212
-    background-size: cover
-    background-position: center 20%
     opacity: 0
-    transform: scale(1.08)
+    overflow: hidden
     transition: opacity 1.15s cubic-bezier(0.33, 0.1, 0.25, 1)
     &.is-active
         opacity: 1
     &.is-kenburns
-        animation: nflx-ken-burns var(--hero-interval) ease-out forwards
+        .billboard__stage-bleed
+            animation: nflx-ken-burns-bleed var(--hero-interval) ease-out forwards
+        .billboard__stage-focus
+            animation: nflx-ken-burns var(--hero-interval) ease-out forwards
+
+// Full-bleed atmosphere — fills side gaps when the sharp layer is height-fit.
+.billboard__stage-bleed
+    position: absolute
+    inset: -8%
+    background-color: #121212
+    background-size: cover
+    background-position: center
+    background-repeat: no-repeat
+    filter: blur(48px) saturate(1.15) brightness(0.82)
+    transform: scale(1.12)
+    will-change: transform
+
+// Sharp art — cover on narrow; height-fit on wide so top/bottom are not cropped.
+.billboard__stage-focus
+    position: absolute
+    inset: 0
+    background-color: transparent
+    background-size: cover
+    background-position: center 20%
+    background-repeat: no-repeat
+    transform: scale(1.08)
+    will-change: transform
+
+@media screen and (min-width: 1280px)
+    .billboard__stage-focus
+        // Fill height; letterbox sides → bleed shows through with matching edge colour.
+        background-size: auto 100%
+        background-position: center center
 
 .billboard__content
     position: relative
@@ -312,7 +342,13 @@
     .billboard__grain
         display: none
     .billboard__stage.is-kenburns
-        animation: none
+        .billboard__stage-bleed,
+        .billboard__stage-focus
+            animation: none
+    .billboard__stage-bleed
+        transform: scale(1.12)
+        filter: blur(48px) saturate(1.15) brightness(0.82)
+    .billboard__stage-focus
         transform: scale(1.05)
     .billboard__stage
         transition: none
@@ -333,7 +369,13 @@
     .billboard__grain
         display: none
     .billboard__stage.is-kenburns
-        animation: none
+        .billboard__stage-bleed,
+        .billboard__stage-focus
+            animation: none
+    .billboard__stage-bleed
+        // Soft edge fill still helps; skip animated Ken Burns on touch.
+        transform: scale(1.12)
+    .billboard__stage-focus
         transform: scale(1.05)
     .billboard__live
         animation: none
@@ -342,7 +384,9 @@
 // While a Material dialog holds scroll-lock, freeze any leftover stage motion.
 :host-context(.cdk-global-scrollblock)
     .billboard__stage.is-kenburns
-        animation-play-state: paused
+        .billboard__stage-bleed,
+        .billboard__stage-focus
+            animation-play-state: paused
     .billboard__live
         animation-play-state: paused
 

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
@@ -43,28 +43,57 @@
     background-color: #121212
     opacity: 0
     overflow: hidden
+    container-type: size
+    // Width/height ratio of the sharp art (set from naturalWidth/naturalHeight).
+    --hero-art-aspect: 1.777
     transition: opacity 1.15s cubic-bezier(0.33, 0.1, 0.25, 1)
     &.is-active
         opacity: 1
     &.is-kenburns
-        .billboard__stage-bleed
-            animation: nflx-ken-burns-bleed var(--hero-interval) ease-out forwards
         .billboard__stage-focus
             animation: nflx-ken-burns var(--hero-interval) ease-out forwards
 
-// Full-bleed atmosphere — fills side gaps when the sharp layer is height-fit.
-.billboard__stage-bleed
+// Side fills: stretch a thin strip of the image's true left/right edge outward
+// (not a blurred cover of the whole frame — that looks wrong on square art).
+.billboard__stage-edge
+    display: none
     position: absolute
-    inset: -8%
-    background-color: #121212
-    background-size: cover
-    background-position: center
-    background-repeat: no-repeat
-    filter: blur(48px) saturate(1.15) brightness(0.82)
-    transform: scale(1.12)
-    will-change: transform
+    top: 0
+    bottom: 0
+    overflow: hidden
+    pointer-events: none
 
-// Sharp art — cover on narrow; height-fit on wide so top/bottom are not cropped.
+.billboard__stage-edge-strip
+    position: absolute
+    top: -6%
+    bottom: -6%
+    width: 14px
+    background-color: #121212
+    background-size: auto 100%
+    background-repeat: no-repeat
+    filter: blur(32px) saturate(1.12) brightness(0.88)
+
+.billboard__stage-edge--left
+    left: 0
+    .billboard__stage-edge-strip
+        right: 0
+        background-position: left center
+        transform-origin: right center
+        transform: scaleX(70)
+
+.billboard__stage-edge--right
+    right: 0
+    .billboard__stage-edge-strip
+        left: 0
+        background-position: right center
+        transform-origin: left center
+        transform: scaleX(70)
+
+// Slot sizes/positions the sharp art; Ken Burns scales the inner focus only.
+.billboard__stage-focus-slot
+    position: absolute
+    inset: 0
+
 .billboard__stage-focus
     position: absolute
     inset: 0
@@ -76,10 +105,21 @@
     will-change: transform
 
 @media screen and (min-width: 1280px)
-    .billboard__stage-focus
-        // Fill height; letterbox sides → bleed shows through with matching edge colour.
-        background-size: auto 100%
-        background-position: center center
+    .billboard__stage.has-edge-extend
+        .billboard__stage-edge
+            display: block
+            // Gap between viewport edge and the height-fit art box.
+            width: max(0px, calc((100% - min(100%, 100cqh * var(--hero-art-aspect))) / 2))
+        .billboard__stage-focus-slot
+            top: 0
+            bottom: 0
+            left: 50%
+            width: min(100%, calc(100cqh * var(--hero-art-aspect)))
+            transform: translateX(-50%)
+        .billboard__stage-focus
+            // Fill the aspect-correct slot exactly (no further cover crop).
+            background-size: 100% 100%
+            background-position: center center
 
 .billboard__content
     position: relative
@@ -342,12 +382,8 @@
     .billboard__grain
         display: none
     .billboard__stage.is-kenburns
-        .billboard__stage-bleed,
         .billboard__stage-focus
             animation: none
-    .billboard__stage-bleed
-        transform: scale(1.12)
-        filter: blur(48px) saturate(1.15) brightness(0.82)
     .billboard__stage-focus
         transform: scale(1.05)
     .billboard__stage
@@ -369,12 +405,8 @@
     .billboard__grain
         display: none
     .billboard__stage.is-kenburns
-        .billboard__stage-bleed,
         .billboard__stage-focus
             animation: none
-    .billboard__stage-bleed
-        // Soft edge fill still helps; skip animated Ken Burns on touch.
-        transform: scale(1.12)
     .billboard__stage-focus
         transform: scale(1.05)
     .billboard__live
@@ -384,7 +416,6 @@
 // While a Material dialog holds scroll-lock, freeze any leftover stage motion.
 :host-context(.cdk-global-scrollblock)
     .billboard__stage.is-kenburns
-        .billboard__stage-bleed,
         .billboard__stage-focus
             animation-play-state: paused
     .billboard__live

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.ts
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.ts
@@ -66,8 +66,13 @@ export class HomepageHeroComponent {
   protected readonly heroFrontLayer = signal<'a' | 'b'>('a');
   protected readonly heroLayerA = signal<string | undefined>(undefined);
   protected readonly heroLayerB = signal<string | undefined>(undefined);
+  /** naturalWidth/naturalHeight for edge-extend layout (no canvas / CORS). */
+  protected readonly heroAspectA = signal<number | undefined>(undefined);
+  protected readonly heroAspectB = signal<number | undefined>(undefined);
   protected readonly heroKenBurnsA = signal(false);
   protected readonly heroKenBurnsB = signal(false);
+  /** Aspect ratios keyed by image URL from preload (survives layer flips). */
+  private readonly heroAspectByUrl = new Map<string, number>();
   protected readonly heroDotsOverflowStart = signal(false);
   protected readonly heroDotsOverflowEnd = signal(false);
   private readonly heroDotsViewport = viewChild<ElementRef<HTMLElement>>('heroDotsViewport');
@@ -530,7 +535,9 @@ export class HomepageHeroComponent {
         this.heroKenBurnsClearTimer = undefined;
       }
       this.heroLayerA.set(url);
+      this.heroAspectA.set(this.aspectForUrl(url));
       this.heroLayerB.set(undefined);
+      this.heroAspectB.set(undefined);
       this.heroFrontLayer.set('a');
       this.heroKenBurnsA.set(!!url && this.kenBurnsAllowed());
       this.heroKenBurnsB.set(false);
@@ -540,6 +547,7 @@ export class HomepageHeroComponent {
     if (front === 'a') {
       this.heroKenBurnsB.set(false);
       this.heroLayerB.set(url);
+      this.heroAspectB.set(this.aspectForUrl(url));
       requestAnimationFrame(() => {
         requestAnimationFrame(() => {
           this.heroFrontLayer.set('b');
@@ -550,6 +558,7 @@ export class HomepageHeroComponent {
     } else {
       this.heroKenBurnsA.set(false);
       this.heroLayerA.set(url);
+      this.heroAspectA.set(this.aspectForUrl(url));
       requestAnimationFrame(() => {
         requestAnimationFrame(() => {
           this.heroFrontLayer.set('a');
@@ -558,6 +567,13 @@ export class HomepageHeroComponent {
         });
       });
     }
+  }
+
+  private aspectForUrl(url: string | undefined): number | undefined {
+    if (!url) {
+      return undefined;
+    }
+    return this.heroAspectByUrl.get(url);
   }
 
   private scheduleOutgoingKenBurnsClear(outgoing: 'a' | 'b'): void {
@@ -572,9 +588,11 @@ export class HomepageHeroComponent {
       if (outgoing === 'a') {
         this.heroKenBurnsA.set(false);
         this.heroLayerA.set(undefined);
+        this.heroAspectA.set(undefined);
       } else {
         this.heroKenBurnsB.set(false);
         this.heroLayerB.set(undefined);
+        this.heroAspectB.set(undefined);
       }
     }, HomepageHeroComponent.heroTransitionMs);
   }
@@ -612,6 +630,7 @@ export class HomepageHeroComponent {
   /**
    * Warm + decode the next backdrop. Used both for the initial image gate and
    * for slide transitions so copy never advances ahead of a painted image.
+   * Also records natural aspect for ultrawide edge-strip extension (no CORS).
    */
   private preloadHeroImage(url: string, token: number, onReady: () => void): void {
     const img = new Image();
@@ -619,10 +638,23 @@ export class HomepageHeroComponent {
     // (like the CSS background-image it warms the cache for) fetches at Low priority.
     img.fetchPriority = 'high';
     img.decoding = 'async';
+    const rememberAspect = () => {
+      if (img.naturalWidth > 0 && img.naturalHeight > 0) {
+        this.heroAspectByUrl.set(url, img.naturalWidth / img.naturalHeight);
+        // Layer may already be showing this URL (immediate sync / cache hit).
+        if (this.heroLayerA() === url) {
+          this.heroAspectA.set(this.heroAspectByUrl.get(url));
+        }
+        if (this.heroLayerB() === url) {
+          this.heroAspectB.set(this.heroAspectByUrl.get(url));
+        }
+      }
+    };
     const markReady = () => {
       if (token !== this.heroImageToken) {
         return;
       }
+      rememberAspect();
       onReady();
     };
     img.onload = () => {

--- a/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.html
+++ b/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.html
@@ -113,8 +113,13 @@
                             {{result.podcastName}}
                         </a>
                     </mat-card-subtitle>
-                    <mat-card-subtitle class="curator-card__meta">{{result.release | date:'d MMM yyyy H:mm'}}
-                        [{{result.duration.startsWith("0")?result.duration.split(".")[0].substring(1):result.duration.split(".")[0]}}]
+                    <mat-card-subtitle class="curator-card__meta">
+                        <span>{{result.release | date:'d MMM yyyy H:mm'}}
+                            [{{result.duration.startsWith("0")?result.duration.split(".")[0].substring(1):result.duration.split(".")[0]}}]</span>
+                        @if (languageBadge(result); as lang) {
+                        <span class="curator-card__lang" [attr.title]="lang.label"
+                            [attr.aria-label]="lang.label">{{lang.flag}}</span>
+                        }
                     </mat-card-subtitle>
                 </mat-card-header>
                 <mat-card-content class="resultdescription">
@@ -122,7 +127,8 @@
                     @if (result.subjects?.length) {
                     <div class="curator-card__subjects">
                         <app-subjects [subjects]="result.subjects!" [showHidden]="true" [editable]="true"
-                            [disabled]="isUpdating(result.id)" (removeSubject)="removeSubject(result, $event)"></app-subjects>
+                            [disabled]="isUpdating(result.id)" [loadingSubjectName]="loadingSubjectName(result.id)"
+                            (removeSubject)="removeSubject(result, $event)"></app-subjects>
                     </div>
                     }
                     @if ((result.guestPeople?.length ?? 0) > 0 || (result.guestSuggestions?.length ?? 0) > 0) {

--- a/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.sass
+++ b/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.sass
@@ -71,23 +71,53 @@
 mat-card-title
     margin-right: 40px
 
+.curator-card__meta
+    display: flex
+    flex-wrap: wrap
+    align-items: center
+    gap: 6px 10px
+
+.curator-card__lang
+    display: inline-flex
+    align-items: center
+    font-size: 1.1rem
+    line-height: 1
+
 .curator-card__subjects,
 .curator-card__guests
     margin-top: 10px
 
+// Stack platforms above status so labeled pills never collide with service icons.
+// Override global public-card row-reverse on .mdc-card__actions.
 .curator-card__actions
-    display: flex
-    flex-wrap: wrap
-    align-items: flex-start
-    gap: 12px 16px
+    display: flex !important
+    flex-direction: column !important
+    flex-wrap: nowrap
+    align-items: stretch
+    gap: 10px
     padding-top: 8px
 
-.curator-card__status,
 .curator-card__platforms
     display: flex
     flex-wrap: wrap
     align-items: center
+    gap: 4px
+    order: -1
+    ::ng-deep app-episode-podcast-links
+        flex-wrap: wrap
+        height: auto
+        gap: 4px
+    a[mat-icon-button],
+    button[mat-icon-button]
+        margin: 0 !important
+        transform: none !important
+
+.curator-card__status
+    display: flex
+    flex-wrap: wrap
+    align-items: center
     gap: 8px
+    order: 0
 
 button.selected
     span

--- a/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.ts
+++ b/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.ts
@@ -35,6 +35,7 @@ import { FeatureSwitch } from '../feature-switch.enum';
 import { FeatureSwitchService } from '../feature-switch-service';
 import { ManualTweetEpisodeDialogComponent } from '../manual-tweet-episode-dialog/manual-tweet-episode-dialog.component';
 import { ClampableTextComponent } from '../clampable-text/clampable-text.component';
+import { languageFlagBadgeForEpisode, LanguageFlagBadge } from '../language-flag';
 
 const sortParamDateAsc: string = "date-asc";
 const sortParamDateDesc: string = "date-desc";
@@ -80,7 +81,8 @@ export class OutgoingEpisodesApiComponent {
   blueskyPosted = signal<boolean | undefined>(true);
   token: string = "";
   protected updatingEpisodeId = signal<string | null>(null);
-  protected updatingFlag = signal<'ignored' | 'removed' | 'tweeted' | 'bluesky' | null>(null);
+  protected updatingFlag = signal<'ignored' | 'removed' | 'tweeted' | 'bluesky' | 'subject' | null>(null);
+  protected updatingSubjectName = signal<string | null>(null);
   protected addingGuest = signal<{ [episodeId: string]: string }>({});
 
   private destroyRef = inject(DestroyRef);
@@ -209,6 +211,17 @@ export class OutgoingEpisodesApiComponent {
       || this.isLoadingBluesky(episodeId);
   }
 
+  languageBadge(episode: ApiEpisode): LanguageFlagBadge | undefined {
+    return languageFlagBadgeForEpisode(episode);
+  }
+
+  loadingSubjectName(episodeId: string): string | null {
+    if (!this.isUpdating(episodeId) || this.updatingFlag() !== 'subject') {
+      return null;
+    }
+    return this.updatingSubjectName();
+  }
+
   private refreshEpisodesSignal() {
     const current = this.episodes();
     if (current) {
@@ -228,7 +241,7 @@ export class OutgoingEpisodesApiComponent {
   private async runEpisodeUpdate(
     episode: ApiEpisode,
     action: () => Promise<ApiEpisode>,
-    flag: 'ignored' | 'removed' | 'tweeted' | 'bluesky' | null = null
+    flag: 'ignored' | 'removed' | 'tweeted' | 'bluesky' | 'subject' | null = null
   ) {
     if (this.isUpdating(episode.id)) {
       return;
@@ -245,11 +258,16 @@ export class OutgoingEpisodesApiComponent {
     } finally {
       this.updatingEpisodeId.set(null);
       this.updatingFlag.set(null);
+      this.updatingSubjectName.set(null);
     }
   }
 
   removeSubject(episode: ApiEpisode, subject: string) {
-    this.runEpisodeUpdate(episode, () => this.episodeUpdate.removeSubject(episode, subject));
+    if (this.isUpdating(episode.id)) {
+      return;
+    }
+    this.updatingSubjectName.set(subject);
+    this.runEpisodeUpdate(episode, () => this.episodeUpdate.removeSubject(episode, subject), 'subject');
   }
 
   removeGuest(episode: ApiEpisode, guestName: string) {

--- a/cultpodcasts/src/app/subjects/subjects.component.html
+++ b/cultpodcasts/src/app/subjects/subjects.component.html
@@ -1,12 +1,17 @@
 @for (subject of subjects; track subject) {
 @if (!subject.startsWith("_") || showHidden) {
-<div class="subject" (click)="stopPropagate($event)">
+<div class="subject" [class.loading]="isSubjectLoading(subject)" (click)="stopPropagate($event)">
     <app-subject-chip [subject]="subject" />
     @if (editable) {
-    <button mat-icon-button type="button" class="remove-btn" [disabled]="disabled"
+    <button mat-icon-button type="button" class="remove-btn"
+        [disabled]="disabled || isSubjectLoading(subject)"
+        [attr.aria-busy]="isSubjectLoading(subject)"
         (click)="onRemove(subject, $event)" [attr.aria-label]="'Remove subject ' + subject">
         <mat-icon>close</mat-icon>
     </button>
+    }
+    @if (isSubjectLoading(subject)) {
+    <mat-spinner diameter="16"></mat-spinner>
     }
 </div>
 }

--- a/cultpodcasts/src/app/subjects/subjects.component.sass
+++ b/cultpodcasts/src/app/subjects/subjects.component.sass
@@ -10,6 +10,8 @@
         align-items: center
         gap: 2px
         max-width: 100%
+        &.loading
+            opacity: 0.85
         .remove-btn
             --mdc-icon-button-state-layer-size: 22px
             --mdc-icon-button-icon-size: 14px
@@ -30,3 +32,6 @@
                 width: 14px
                 height: 14px
                 line-height: 14px
+        mat-spinner
+            flex: 0 0 auto
+            margin: 0 2px

--- a/cultpodcasts/src/app/subjects/subjects.component.ts
+++ b/cultpodcasts/src/app/subjects/subjects.component.ts
@@ -1,6 +1,7 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { SubjectChipComponent } from '../subject-chip/subject-chip.component';
 
 @Component({
@@ -8,6 +9,7 @@ import { SubjectChipComponent } from '../subject-chip/subject-chip.component';
   imports: [
     MatButtonModule,
     MatIconModule,
+    MatProgressSpinnerModule,
     SubjectChipComponent,
   ],
   templateUrl: './subjects.component.html',
@@ -30,6 +32,10 @@ export class SubjectsComponent {
   @Input()
   disabled: boolean = false;
 
+  /** Subject name currently being removed (in-flight). */
+  @Input()
+  loadingSubjectName: string | null = null;
+
   @Output()
   removeSubject = new EventEmitter<string>();
 
@@ -37,6 +43,10 @@ export class SubjectsComponent {
     if (this.stopPropagation) {
       $event.stopPropagation();
     }
+  }
+
+  isSubjectLoading(subject: string): boolean {
+    return !!this.loadingSubjectName && this.loadingSubjectName === subject;
   }
 
   onRemove(subject: string, $event: Event) {

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -1519,12 +1519,6 @@ option {
   to { transform: scale(1.18); }
 }
 
-/* Subtler zoom on the blurred side-fill so it stays in sync with the sharp layer. */
-@keyframes nflx-ken-burns-bleed {
-  from { transform: scale(1.12); }
-  to { transform: scale(1.22); }
-}
-
 @keyframes nflx-pulse-live {
   0% { box-shadow: 0 0 0 0 rgba(232, 162, 58, 0.65); }
   70% { box-shadow: 0 0 0 10px rgba(232, 162, 58, 0); }

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -487,18 +487,20 @@ mat-card.error {
   border-width: 2px !important;
 }
 
-mat-card-actions {
+// Public browse cards only — curator cards manage their own action spacing
+// (status pills + platform icons) and must not inherit the 25px/scale treatment.
+mat-card-actions:not(.curator-card__actions) {
   a[mat-icon-button]:not(.remove-btn):not(.add-btn),
-  button[mat-icon-button]:not(.remove-btn):not(.add-btn) {
+  button[mat-icon-button]:not(.remove-btn):not(.add-btn):not(.flag-toggle) {
     margin-right: 25px;
     transform: scale(1.15);
   }
 }
 
 @media screen and (max-width: 600px) {
-  mat-card-actions {
+  mat-card-actions:not(.curator-card__actions) {
     a[mat-icon-button]:not(.remove-btn):not(.add-btn),
-    button[mat-icon-button]:not(.remove-btn):not(.add-btn) {
+    button[mat-icon-button]:not(.remove-btn):not(.add-btn):not(.flag-toggle) {
       margin-right: 18px;
     }
   }
@@ -511,9 +513,9 @@ mat-card-actions {
 }
 
 @media screen and (max-width: 400px) {
-  mat-card-actions {
+  mat-card-actions:not(.curator-card__actions) {
     a[mat-icon-button]:not(.remove-btn):not(.add-btn),
-    button[mat-icon-button]:not(.remove-btn):not(.add-btn) {
+    button[mat-icon-button]:not(.remove-btn):not(.add-btn):not(.flag-toggle) {
       margin-right: 12px;
     }
   }
@@ -1515,6 +1517,12 @@ option {
 @keyframes nflx-ken-burns {
   from { transform: scale(1.08); }
   to { transform: scale(1.18); }
+}
+
+/* Subtler zoom on the blurred side-fill so it stays in sync with the sharp layer. */
+@keyframes nflx-ken-burns-bleed {
+  from { transform: scale(1.12); }
+  to { transform: scale(1.22); }
 }
 
 @keyframes nflx-pulse-live {


### PR DESCRIPTION
## Summary
- Stop docked sticky search from clipping typeahead (`overflow: visible` + listbox z-index)
- Curator Outgoing/Episodes/Discovery cards: stack platforms above status pills, language flag on meta, spinner when removing a subject
- Ultrawide hero: height-fit sharp art with blurred same-image side bleed (1280px+)

## Test plan
- [ ] Home: scroll until search docks; type a query — suggestions list visible below the field
- [ ] Outgoing/Episodes: non-English episode shows flag; status pills no longer collide with YouTube/Spotify/Apple icons
- [ ] Remove a subject chip — spinner appears on that chip until refresh
- [ ] Ultrawide viewport (≥1280): hero faces not heavily top/bottom cropped; side fill is soft blur of the art
- [ ] Narrow viewport: hero still uses cover as before
