### PR TITLE
fix(ui): curator card spacing and two-pane layout

### DIFF
--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.16",
+  "version": "1.10.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.10.16",
+      "version": "1.10.17",
       "dependencies": {
         "@angular/cdk": "^22.0.6",
         "@angular/common": "^22.0.8",

--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.17",
+  "version": "1.10.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.10.17",
+      "version": "1.10.18",
       "dependencies": {
         "@angular/cdk": "^22.0.6",
         "@angular/common": "^22.0.8",

--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.19",
+  "version": "1.10.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.10.19",
+      "version": "1.10.20",
       "dependencies": {
         "@angular/cdk": "^22.0.6",
         "@angular/common": "^22.0.8",

--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.18",
+  "version": "1.10.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.10.18",
+      "version": "1.10.19",
       "dependencies": {
         "@angular/cdk": "^22.0.6",
         "@angular/common": "^22.0.8",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.16",
+  "version": "1.10.17",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.18",
+  "version": "1.10.19",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.19",
+  "version": "1.10.20",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.17",
+  "version": "1.10.18",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/src/app/discovery-api/discovery-api.component.sass
+++ b/cultpodcasts/src/app/discovery-api/discovery-api.component.sass
@@ -12,8 +12,9 @@
 
 .curator-toolbar
     position: sticky
-    top: 0
-    z-index: 8
+    // Sit under the fixed logo/search bar; top: 0 hides Save/Close under chrome.
+    top: var(--site-chrome-bar-h, 58px)
+    z-index: 90
     display: flex
     flex-wrap: wrap
     align-items: center

--- a/cultpodcasts/src/app/discovery-api/discovery-api.component.sass
+++ b/cultpodcasts/src/app/discovery-api/discovery-api.component.sass
@@ -17,9 +17,9 @@
     top: calc(var(--site-chrome-bar-h, 58px) + 4px)
     z-index: 90
     display: flex
-    flex-wrap: wrap
+    flex-wrap: nowrap
     align-items: center
-    gap: 12px 16px
+    gap: 8px 12px
     margin: 0 0 14px
     padding: 10px 12px
     border-radius: var(--cp-radius, 14px)
@@ -31,12 +31,14 @@
     display: flex
     flex-wrap: wrap
     align-items: baseline
-    gap: 8px 12px
+    gap: 4px 10px
+    flex: 1 1 auto
     min-width: 0
     h2
         margin: 0
         font-size: 1.25rem
         font-weight: 700
+        line-height: 1.2
 
 .curator-toolbar__count,
 .curator-toolbar__meta
@@ -47,13 +49,22 @@
     display: flex
     flex-wrap: wrap
     align-items: center
-    gap: 10px
+    justify-content: flex-end
+    gap: 8px
+    flex: 0 1 auto
     margin-left: auto
+    max-width: min(100%, 28rem)
 
 // On phones the Close/Save pair wraps onto a second row; hide the disabled one
 // (they are mutually exclusive) so only the actionable control takes space.
 @media screen and (max-width: 600px)
+    .curator-toolbar
+        gap: 8px
+        padding: 8px 10px
+    .curator-toolbar__title h2
+        font-size: 1.05rem
     .curator-toolbar__actions
+        gap: 6px
         .curator-toolbar__close[disabled],
         .curator-toolbar__save[disabled]
             display: none

--- a/cultpodcasts/src/app/discovery-api/discovery-api.component.sass
+++ b/cultpodcasts/src/app/discovery-api/discovery-api.component.sass
@@ -13,7 +13,8 @@
 .curator-toolbar
     position: sticky
     // Sit under the fixed logo/search bar; top: 0 hides Save/Close under chrome.
-    top: var(--site-chrome-bar-h, 58px)
+    // +4px covers border/box so the bar does not tuck under the measured chrome (~61px).
+    top: calc(var(--site-chrome-bar-h, 58px) + 4px)
     z-index: 90
     display: flex
     flex-wrap: wrap

--- a/cultpodcasts/src/app/discovery-api/discovery-api.component.ts
+++ b/cultpodcasts/src/app/discovery-api/discovery-api.component.ts
@@ -138,8 +138,8 @@ export class DiscoveryApiComponent implements AfterViewInit {
     const chromeH = parseFloat(
       getComputedStyle(chromeSource).getPropertyValue('--site-chrome-bar-h')
     ) || 58;
-    // Gap so the card title isn't flush against the sticky Discovery toolbar.
-    const offset = Math.ceil(toolbar.getBoundingClientRect().height) + Math.ceil(chromeH) + 8;
+    // Match sticky top: calc(var(--site-chrome-bar-h) + 4px) plus toolbar + gap.
+    const offset = Math.ceil(toolbar.getBoundingClientRect().height) + Math.ceil(chromeH) + 4 + 8;
     document.documentElement.style.setProperty('--discovery-snap-offset', `${offset}px`);
   }
 

--- a/cultpodcasts/src/app/discovery-api/discovery-api.component.ts
+++ b/cultpodcasts/src/app/discovery-api/discovery-api.component.ts
@@ -110,9 +110,9 @@ export class DiscoveryApiComponent implements AfterViewInit {
   }
 
   /**
-   * Cards snap to the viewport top; the sticky Discovery toolbar covers that
-   * band. Keep scroll-padding-top equal to the live toolbar height (it grows
-   * when filter/actions wrap).
+   * Cards snap below the fixed site chrome + sticky Discovery toolbar.
+   * Keep scroll-padding-top equal to that stacked height (toolbar grows when
+   * filter/actions wrap).
    */
   private setupSnapOffsetObserver() {
     const toolbar = this.curatorToolbar?.nativeElement;
@@ -134,8 +134,12 @@ export class DiscoveryApiComponent implements AfterViewInit {
     if (!toolbar) {
       return;
     }
-    // Small gap so the card title isn't flush against the sticky chrome.
-    const offset = Math.ceil(toolbar.getBoundingClientRect().height) + 8;
+    const chromeSource = document.getElementById('body') ?? document.documentElement;
+    const chromeH = parseFloat(
+      getComputedStyle(chromeSource).getPropertyValue('--site-chrome-bar-h')
+    ) || 58;
+    // Gap so the card title isn't flush against the sticky Discovery toolbar.
+    const offset = Math.ceil(toolbar.getBoundingClientRect().height) + Math.ceil(chromeH) + 8;
     document.documentElement.style.setProperty('--discovery-snap-offset', `${offset}px`);
   }
 

--- a/cultpodcasts/src/app/discovery-item/discovery-item.component.html
+++ b/cultpodcasts/src/app/discovery-item/discovery-item.component.html
@@ -54,14 +54,18 @@
                     </span>
                 </mat-card-subtitle>
             </mat-card-header>
-            <mat-card-content>
-                @if (item.showDescription && (item.matchingPodcasts === null || item.matchingPodcasts.length==0)) {
-                <app-clampable-text class="showDescription" [maxLines]="3" [html]="item.showDescription"></app-clampable-text>
-                }
-                <app-clampable-text class="resultdescription" [maxLines]="3" [html]="item.episodeDescription"></app-clampable-text>
+            <mat-card-content class="curator-card__content">
+                <div class="curator-card__desc">
+                    @if (item.showDescription && (item.matchingPodcasts === null || item.matchingPodcasts.length==0)) {
+                    <app-clampable-text class="showDescription" [maxLines]="3" [html]="item.showDescription"></app-clampable-text>
+                    }
+                    <app-clampable-text class="resultdescription" [maxLines]="3" [html]="item.episodeDescription"></app-clampable-text>
+                </div>
                 @if (item.subjects?.length) {
-                <div class="curator-card__subjects">
-                    <app-subjects [subjects]="item.subjects!" [showHidden]="true" [stopPropagation]="true"></app-subjects>
+                <div class="curator-card__side">
+                    <div class="curator-card__subjects">
+                        <app-subjects [subjects]="item.subjects!" [showHidden]="true" [stopPropagation]="true"></app-subjects>
+                    </div>
                 </div>
                 }
             </mat-card-content>

--- a/cultpodcasts/src/app/discovery-item/discovery-item.component.sass
+++ b/cultpodcasts/src/app/discovery-item/discovery-item.component.sass
@@ -1,27 +1,11 @@
 mat-card.curator-card
-    margin-bottom: 12px
-    padding: 12px
-    border: 1px solid color-mix(in srgb, var(--mat-sys-outline-variant, #fff) 65%, transparent)
-    border-radius: var(--cp-radius, 14px)
-    background: var(--mat-sys-surface-container, color-mix(in srgb, var(--cp-ink-elevated, #141821) 92%, #1c2433))
     h3
         font-weight: bold
         margin-bottom: 2px
 
-.curator-card__body
-    display: flex
-    gap: 14px
-    align-items: flex-start
-
 .curator-card__art
-    flex: 0 0 112px
-    width: 112px
     app-episode-image
         display: block
-
-.curator-card__main
-    flex: 1 1 auto
-    min-width: 0
 
 .score-row
     margin-top: 4px
@@ -74,41 +58,21 @@ mat-card-subtitle
         color: var(--cp-warn, #f44336)
         font-weight: 600
 
-mat-card-content
-    padding-top: 4px
-    overflow: hidden
+.curator-card__desc
     .showDescription,
     .resultdescription
         display: block
     .resultdescription
         padding-top: 4px
 
-.curator-card__subjects
-    margin-top: 10px
-
-.curator-card__actions
-    display: flex !important
-    flex-direction: row !important
-    flex-wrap: wrap
-    align-items: center
-    gap: 8px
-    padding-top: 4px
-    .discovery-service-links
+.curator-card__platforms.discovery-service-links
+    .youtubemeta
+        flex-direction: column
+        margin-left: 6px
         display: flex
-        flex-wrap: wrap
-        align-items: center
-        gap: 4px
-        a[mat-icon-button],
-        button[mat-icon-button]
-            margin: 0 !important
-            transform: none !important
-        .youtubemeta
-            flex-direction: column
-            margin-left: 6px
-            display: flex
-            min-width: 120px
-            font-size: 0.78rem
-            color: color-mix(in srgb, var(--mat-sys-on-surface, #e8e8e8) 60%, transparent)
+        min-width: 120px
+        font-size: 0.78rem
+        color: color-mix(in srgb, var(--mat-sys-on-surface, #e8e8e8) 60%, transparent)
 
 // State chrome (border / background) lives in styles.scss — global mat-card rules use
 // !important and would otherwise hide any local selected / warning treatment.
@@ -118,10 +82,3 @@ mat-card.selected
 
 mat-card.auto-hidden
     opacity: 0.78
-
-@media screen and (max-width: 560px)
-    .curator-card__body
-        gap: 10px
-    .curator-card__art
-        flex-basis: 88px
-        width: 88px

--- a/cultpodcasts/src/app/episodes-api/episodes-api.component.html
+++ b/cultpodcasts/src/app/episodes-api/episodes-api.component.html
@@ -101,21 +101,27 @@
                         }
                     </mat-card-subtitle>
                 </mat-card-header>
-                <mat-card-content class="resultdescription">
-                    <app-clampable-text [maxLines]="3" [html]="result.displayDescription"></app-clampable-text>
-                    @if (result.subjects?.length) {
-                    <div class="curator-card__subjects">
-                        <app-subjects [subjects]="result.subjects!" [showHidden]="true" [editable]="true"
-                            [disabled]="isUpdating(result.id)" [loadingSubjectName]="loadingSubjectName(result.id)"
-                            (removeSubject)="removeSubject(result, $event)"></app-subjects>
+                <mat-card-content class="curator-card__content resultdescription">
+                    <div class="curator-card__desc">
+                        <app-clampable-text [maxLines]="3" [html]="result.displayDescription"></app-clampable-text>
                     </div>
-                    }
-                    @if ((result.guestPeople?.length ?? 0) > 0 || (result.guestSuggestions?.length ?? 0) > 0) {
-                    <div class="curator-card__guests">
-                        <app-episode-guests [guestPeople]="result.guestPeople" [guestSuggestions]="result.guestSuggestions"
-                            [editable]="true" [disabled]="isUpdating(result.id)" [loadingGuestName]="loadingGuestName(result.id)"
-                            (removeGuest)="removeGuest(result, $event)"
-                            (addSuggestedGuest)="addSuggestedGuest(result, $event)"></app-episode-guests>
+                    @if (result.subjects?.length || (result.guestPeople?.length ?? 0) > 0 || (result.guestSuggestions?.length ?? 0) > 0) {
+                    <div class="curator-card__side">
+                        @if (result.subjects?.length) {
+                        <div class="curator-card__subjects">
+                            <app-subjects [subjects]="result.subjects!" [showHidden]="true" [editable]="true"
+                                [disabled]="isUpdating(result.id)" [loadingSubjectName]="loadingSubjectName(result.id)"
+                                (removeSubject)="removeSubject(result, $event)"></app-subjects>
+                        </div>
+                        }
+                        @if ((result.guestPeople?.length ?? 0) > 0 || (result.guestSuggestions?.length ?? 0) > 0) {
+                        <div class="curator-card__guests">
+                            <app-episode-guests [guestPeople]="result.guestPeople" [guestSuggestions]="result.guestSuggestions"
+                                [editable]="true" [disabled]="isUpdating(result.id)" [loadingGuestName]="loadingGuestName(result.id)"
+                                (removeGuest)="removeGuest(result, $event)"
+                                (addSuggestedGuest)="addSuggestedGuest(result, $event)"></app-episode-guests>
+                        </div>
+                        }
                     </div>
                     }
                 </mat-card-content>

--- a/cultpodcasts/src/app/episodes-api/episodes-api.component.sass
+++ b/cultpodcasts/src/app/episodes-api/episodes-api.component.sass
@@ -7,9 +7,9 @@
     top: calc(var(--site-chrome-bar-h, 58px) + 4px)
     z-index: 90
     display: flex
-    flex-wrap: wrap
+    flex-wrap: nowrap
     align-items: center
-    gap: 12px 16px
+    gap: 8px 12px
     margin: 0 0 14px
     padding: 10px 12px
     border-radius: var(--cp-radius, 14px)
@@ -21,12 +21,14 @@
     display: flex
     flex-wrap: wrap
     align-items: baseline
-    gap: 8px 12px
+    gap: 4px 10px
+    flex: 1 1 auto
     min-width: 0
     h2
         margin: 0
         font-size: 1.25rem
         font-weight: 700
+        line-height: 1.2
 
 .curator-toolbar__count
     font-size: 0.85rem
@@ -34,10 +36,20 @@
 
 .curator-toolbar__actions
     display: flex
-    flex-wrap: wrap
+    flex-wrap: nowrap
     align-items: center
-    gap: 10px
+    gap: 8px
+    flex: 0 0 auto
     margin-left: auto
+
+@media screen and (max-width: 600px)
+    .curator-toolbar
+        gap: 8px
+        padding: 8px 10px
+    .curator-toolbar__title h2
+        font-size: 1.05rem
+    .curator-toolbar__actions
+        gap: 6px
 
 .curator-card__meta
     display: flex

--- a/cultpodcasts/src/app/episodes-api/episodes-api.component.sass
+++ b/cultpodcasts/src/app/episodes-api/episodes-api.component.sass
@@ -39,35 +39,6 @@
     gap: 10px
     margin-left: auto
 
-.curator-card
-    margin-bottom: 12px
-    padding: 12px
-    border: 1px solid color-mix(in srgb, var(--mat-sys-outline-variant, #fff) 65%, transparent)
-    border-radius: var(--cp-radius, 14px)
-    background: var(--mat-sys-surface-container, color-mix(in srgb, var(--cp-ink-elevated, #141821) 92%, #1c2433))
-
-.curator-card__body
-    display: flex
-    gap: 14px
-    align-items: flex-start
-
-.curator-card__art
-    flex: 0 0 112px
-    width: 112px
-
-.curator-card__main
-    flex: 1 1 auto
-    min-width: 0
-    position: relative
-
-.curator-card__overflow
-    position: absolute
-    top: 0
-    right: 0
-
-mat-card-title
-    margin-right: 40px
-
 .curator-card__meta
     display: flex
     flex-wrap: wrap
@@ -80,42 +51,6 @@ mat-card-title
     font-size: 1.1rem
     line-height: 1
 
-.curator-card__subjects,
-.curator-card__guests
-    margin-top: 10px
-
-// Stack platforms above status so labeled pills never collide with service icons.
-// Override global public-card row-reverse on .mdc-card__actions.
-.curator-card__actions
-    display: flex !important
-    flex-direction: column !important
-    flex-wrap: nowrap
-    align-items: stretch
-    gap: 10px
-    padding-top: 8px
-
-.curator-card__platforms
-    display: flex
-    flex-wrap: wrap
-    align-items: center
-    gap: 4px
-    order: -1
-    ::ng-deep app-episode-podcast-links
-        flex-wrap: wrap
-        height: auto
-        gap: 4px
-    a[mat-icon-button],
-    button[mat-icon-button]
-        margin: 0 !important
-        transform: none !important
-
-.curator-card__status
-    display: flex
-    flex-wrap: wrap
-    align-items: center
-    gap: 8px
-    order: 0
-
 button.selected
     span
         font-weight: bold
@@ -125,8 +60,3 @@ button.selected
 
 #cta-button
     margin: 10px 8px
-
-@media screen and (max-width: 560px)
-    .curator-card__art
-        flex-basis: 88px
-        width: 88px

--- a/cultpodcasts/src/app/episodes-api/episodes-api.component.sass
+++ b/cultpodcasts/src/app/episodes-api/episodes-api.component.sass
@@ -4,7 +4,7 @@
 
 .curator-toolbar
     position: sticky
-    top: var(--site-chrome-bar-h, 58px)
+    top: calc(var(--site-chrome-bar-h, 58px) + 4px)
     z-index: 90
     display: flex
     flex-wrap: wrap

--- a/cultpodcasts/src/app/episodes-api/episodes-api.component.sass
+++ b/cultpodcasts/src/app/episodes-api/episodes-api.component.sass
@@ -4,8 +4,8 @@
 
 .curator-toolbar
     position: sticky
-    top: 0
-    z-index: 8
+    top: var(--site-chrome-bar-h, 58px)
+    z-index: 90
     display: flex
     flex-wrap: wrap
     align-items: center

--- a/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.html
+++ b/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.html
@@ -122,21 +122,27 @@
                         }
                     </mat-card-subtitle>
                 </mat-card-header>
-                <mat-card-content class="resultdescription">
-                    <app-clampable-text [maxLines]="3" [html]="result.displayDescription"></app-clampable-text>
-                    @if (result.subjects?.length) {
-                    <div class="curator-card__subjects">
-                        <app-subjects [subjects]="result.subjects!" [showHidden]="true" [editable]="true"
-                            [disabled]="isUpdating(result.id)" [loadingSubjectName]="loadingSubjectName(result.id)"
-                            (removeSubject)="removeSubject(result, $event)"></app-subjects>
+                <mat-card-content class="curator-card__content resultdescription">
+                    <div class="curator-card__desc">
+                        <app-clampable-text [maxLines]="3" [html]="result.displayDescription"></app-clampable-text>
                     </div>
-                    }
-                    @if ((result.guestPeople?.length ?? 0) > 0 || (result.guestSuggestions?.length ?? 0) > 0) {
-                    <div class="curator-card__guests">
-                        <app-episode-guests [guestPeople]="result.guestPeople" [guestSuggestions]="result.guestSuggestions"
-                            [editable]="true" [disabled]="isUpdating(result.id)" [loadingGuestName]="loadingGuestName(result.id)"
-                            (removeGuest)="removeGuest(result, $event)"
-                            (addSuggestedGuest)="addSuggestedGuest(result, $event)"></app-episode-guests>
+                    @if (result.subjects?.length || (result.guestPeople?.length ?? 0) > 0 || (result.guestSuggestions?.length ?? 0) > 0) {
+                    <div class="curator-card__side">
+                        @if (result.subjects?.length) {
+                        <div class="curator-card__subjects">
+                            <app-subjects [subjects]="result.subjects!" [showHidden]="true" [editable]="true"
+                                [disabled]="isUpdating(result.id)" [loadingSubjectName]="loadingSubjectName(result.id)"
+                                (removeSubject)="removeSubject(result, $event)"></app-subjects>
+                        </div>
+                        }
+                        @if ((result.guestPeople?.length ?? 0) > 0 || (result.guestSuggestions?.length ?? 0) > 0) {
+                        <div class="curator-card__guests">
+                            <app-episode-guests [guestPeople]="result.guestPeople" [guestSuggestions]="result.guestSuggestions"
+                                [editable]="true" [disabled]="isUpdating(result.id)" [loadingGuestName]="loadingGuestName(result.id)"
+                                (removeGuest)="removeGuest(result, $event)"
+                                (addSuggestedGuest)="addSuggestedGuest(result, $event)"></app-episode-guests>
+                        </div>
+                        }
                     </div>
                     }
                 </mat-card-content>

--- a/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.sass
+++ b/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.sass
@@ -7,9 +7,9 @@
     top: calc(var(--site-chrome-bar-h, 58px) + 4px)
     z-index: 90
     display: flex
-    flex-wrap: wrap
+    flex-wrap: nowrap
     align-items: center
-    gap: 12px 16px
+    gap: 8px 12px
     margin: 0 0 14px
     padding: 10px 12px
     border-radius: var(--cp-radius, 14px)
@@ -21,12 +21,14 @@
     display: flex
     flex-wrap: wrap
     align-items: baseline
-    gap: 8px 12px
+    gap: 4px 10px
+    flex: 1 1 auto
     min-width: 0
     h2
         margin: 0
         font-size: 1.25rem
         font-weight: 700
+        line-height: 1.2
 
 .curator-toolbar__count
     font-size: 0.85rem
@@ -34,10 +36,20 @@
 
 .curator-toolbar__actions
     display: flex
-    flex-wrap: wrap
+    flex-wrap: nowrap
     align-items: center
-    gap: 10px
+    gap: 8px
+    flex: 0 0 auto
     margin-left: auto
+
+@media screen and (max-width: 600px)
+    .curator-toolbar
+        gap: 8px
+        padding: 8px 10px
+    .curator-toolbar__title h2
+        font-size: 1.05rem
+    .curator-toolbar__actions
+        gap: 6px
 
 .curator-empty
     margin: 12px 8px

--- a/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.sass
+++ b/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.sass
@@ -4,7 +4,7 @@
 
 .curator-toolbar
     position: sticky
-    top: var(--site-chrome-bar-h, 58px)
+    top: calc(var(--site-chrome-bar-h, 58px) + 4px)
     z-index: 90
     display: flex
     flex-wrap: wrap

--- a/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.sass
+++ b/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.sass
@@ -4,8 +4,8 @@
 
 .curator-toolbar
     position: sticky
-    top: 0
-    z-index: 8
+    top: var(--site-chrome-bar-h, 58px)
+    z-index: 90
     display: flex
     flex-wrap: wrap
     align-items: center

--- a/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.sass
+++ b/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.sass
@@ -42,35 +42,6 @@
 .curator-empty
     margin: 12px 8px
 
-.curator-card
-    margin-bottom: 12px
-    padding: 12px
-    border: 1px solid color-mix(in srgb, var(--mat-sys-outline-variant, #fff) 65%, transparent)
-    border-radius: var(--cp-radius, 14px)
-    background: var(--mat-sys-surface-container, color-mix(in srgb, var(--cp-ink-elevated, #141821) 92%, #1c2433))
-
-.curator-card__body
-    display: flex
-    gap: 14px
-    align-items: flex-start
-
-.curator-card__art
-    flex: 0 0 112px
-    width: 112px
-
-.curator-card__main
-    flex: 1 1 auto
-    min-width: 0
-    position: relative
-
-.curator-card__overflow
-    position: absolute
-    top: 0
-    right: 0
-
-mat-card-title
-    margin-right: 40px
-
 .curator-card__meta
     display: flex
     flex-wrap: wrap
@@ -83,42 +54,6 @@ mat-card-title
     font-size: 1.1rem
     line-height: 1
 
-.curator-card__subjects,
-.curator-card__guests
-    margin-top: 10px
-
-// Stack platforms above status so labeled pills never collide with service icons.
-// Override global public-card row-reverse on .mdc-card__actions.
-.curator-card__actions
-    display: flex !important
-    flex-direction: column !important
-    flex-wrap: nowrap
-    align-items: stretch
-    gap: 10px
-    padding-top: 8px
-
-.curator-card__platforms
-    display: flex
-    flex-wrap: wrap
-    align-items: center
-    gap: 4px
-    order: -1
-    ::ng-deep app-episode-podcast-links
-        flex-wrap: wrap
-        height: auto
-        gap: 4px
-    a[mat-icon-button],
-    button[mat-icon-button]
-        margin: 0 !important
-        transform: none !important
-
-.curator-card__status
-    display: flex
-    flex-wrap: wrap
-    align-items: center
-    gap: 8px
-    order: 0
-
 button.selected
     span
         font-weight: bold
@@ -128,8 +63,3 @@ button.selected
 
 #cta-button
     margin: 10px 8px
-
-@media screen and (max-width: 560px)
-    .curator-card__art
-        flex-basis: 88px
-        width: 88px

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -546,8 +546,9 @@ mat-card.curator-card {
   margin-right: 40px;
 }
 
-.curator-card__content {
-  display: grid;
+mat-card.curator-card mat-card-content.curator-card__content,
+mat-card.curator-card .curator-card__content {
+  display: grid !important;
   grid-template-columns: 1fr;
   gap: 16px;
   min-width: 0;
@@ -618,7 +619,8 @@ mat-card-actions.curator-card__actions {
 }
 
 @media screen and (min-width: 900px) {
-  .curator-card__content {
+  mat-card.curator-card mat-card-content.curator-card__content,
+  mat-card.curator-card .curator-card__content {
     grid-template-columns: 1fr minmax(220px, 0.9fr);
     column-gap: 24px;
     row-gap: 0;

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -72,13 +72,15 @@ mat-card-actions.review-actions {
   margin-top: 14px;
 }
 
-// Public result cards footer layout (preserved)
-mat-card:has(> .mdc-card__actions:not(.review-actions)) {
+// Public result cards footer layout (preserved).
+// Curator Episodes/Outgoing/Discovery use .curator-card__actions and manage their
+// own platform + status stack — do not apply the public icon-island layout there.
+mat-card:has(> .mdc-card__actions:not(.review-actions):not(.curator-card__actions)) {
   --public-card-footer-clearance: 12px;
   padding-bottom: var(--public-card-footer-clearance);
 }
 
-mat-card .mdc-card__actions:not(.review-actions) {
+mat-card .mdc-card__actions:not(.review-actions):not(.curator-card__actions) {
   display: flex !important;
   flex-wrap: wrap;
   flex-direction: row-reverse;
@@ -485,6 +487,163 @@ mat-card.unknownDuration {
 mat-card.error {
   border-color: var(--cp-warn) !important;
   border-width: 2px !important;
+}
+
+/* Shared curator card layout (Discovery / Episodes / Outgoing). */
+mat-card.curator-card {
+  margin-bottom: 12px;
+  padding: 18px !important;
+  box-sizing: border-box;
+
+  .mat-mdc-card-header,
+  .mat-mdc-card-content,
+  .mdc-card__actions {
+    padding-left: 0;
+    padding-right: 0;
+  }
+
+  .mat-mdc-card-header {
+    padding-top: 0;
+    padding-bottom: 0;
+  }
+
+  .mat-mdc-card-content {
+    padding-top: 8px;
+    padding-bottom: 0;
+  }
+
+  .mdc-card__actions {
+    padding-left: 0;
+    align-items: stretch;
+  }
+}
+
+.curator-card__body {
+  display: flex;
+  gap: 14px;
+  align-items: flex-start;
+}
+
+.curator-card__art {
+  flex: 0 0 112px;
+  width: 112px;
+}
+
+.curator-card__main {
+  flex: 1 1 auto;
+  min-width: 0;
+  position: relative;
+}
+
+.curator-card__overflow {
+  position: absolute;
+  top: 0;
+  right: 0;
+}
+
+.curator-card__main > .mat-mdc-card-header mat-card-title,
+.curator-card__main > mat-card-header mat-card-title {
+  margin-right: 40px;
+}
+
+.curator-card__content {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 16px;
+  min-width: 0;
+}
+
+.curator-card__desc {
+  min-width: 0;
+}
+
+.curator-card__side {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding-top: 16px;
+  border-top: 1px solid color-mix(in srgb, var(--mat-sys-outline-variant, #fff) 55%, transparent);
+}
+
+.curator-card__subjects,
+.curator-card__guests {
+  margin-top: 0;
+}
+
+/* Platforms above status; clear gap so icons never share a baseline with pills. */
+mat-card-actions.curator-card__actions {
+  display: flex !important;
+  flex-direction: column !important;
+  flex-wrap: nowrap;
+  align-items: stretch;
+  gap: 14px;
+  margin: 0;
+  padding-top: 16px !important;
+  padding-bottom: 0 !important;
+  padding-left: 0 !important;
+  padding-right: 0 !important;
+}
+
+.curator-card__platforms,
+.curator-card__platforms.discovery-service-links {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px;
+  order: -1;
+
+  app-episode-podcast-links {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    height: auto;
+    gap: 4px;
+  }
+
+  a[mat-icon-button],
+  button[mat-icon-button] {
+    margin: 0 !important;
+    transform: none !important;
+  }
+}
+
+.curator-card__status {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  order: 0;
+}
+
+@media screen and (min-width: 900px) {
+  .curator-card__content {
+    grid-template-columns: 1fr minmax(220px, 0.9fr);
+    column-gap: 24px;
+    row-gap: 0;
+    align-items: start;
+  }
+
+  .curator-card__side {
+    padding-top: 0;
+    border-top: none;
+  }
+
+  .curator-card__status {
+    justify-content: flex-end;
+  }
+}
+
+@media screen and (max-width: 560px) {
+  .curator-card__body {
+    gap: 10px;
+  }
+
+  .curator-card__art {
+    flex-basis: 88px;
+    width: 88px;
+  }
 }
 
 // Public browse cards only — curator cards manage their own action spacing


### PR DESCRIPTION
## Summary
- Exclude Discovery/Episodes/Outgoing `.curator-card__actions` from public browse footer CSS so platform icons no longer collide with status pills
- Shared curator card padding (18px), subject separation, and platforms-above-status stack with a clear gap
- Wide viewports (≥900px): description left, subjects/guests right; narrow stays stacked
- Bump to 1.10.17

## Test plan
- [ ] Episodes: card content inset from edges; subjects not flush under description
- [ ] Episodes/Outgoing: YouTube/Spotify/Apple on their own row above Ignored/Removed/Tweeted/Bluesky
- [ ] ≥900px width: description and subjects sit side by side
- [ ] Narrow width: description → subjects → platforms → status stacked
- [ ] Discovery cards match the same spacing/two-pane behaviour
- [ ] Public search/podcast cards: icon island footer unchanged

Made with [Cursor](https://cursor.com)