### PR TITLE
feat(ui): reorder locked day rails as n / n−1 / …

### DIFF
--- a/cultpodcasts/docs/flix-prototype.md
+++ b/cultpodcasts/docs/flix-prototype.md
@@ -32,7 +32,7 @@ Stored in the API worker `Curated` KV via `GET`/`PUT /hero-curation`:
 | Field | UI |
 |-------|----|
 | `episodeIds` | Star on any rail card; **Manage hero** panel (reorder / remove) |
-| `railSubjects` | Pin on subject rail headings; **Manage rails** panel (reorder / pin more) |
+| `railSubjects` | Pin on subject rail headings; **Manage rails** panel (reorder subjects + relative day slots `n` / `n−1` / …; days cannot be removed) |
 
 Pinned rails that drop below the week's episode threshold fall out. Only pinned subjects appear as rails — there is no popularity autofill. Hero picks that leave the current week prune the same way.
 

--- a/cultpodcasts/src/app/episodes-api/episodes-api.component.html
+++ b/cultpodcasts/src/app/episodes-api/episodes-api.component.html
@@ -47,6 +47,12 @@
     <div class="curator-card-grid">
     @for (result of episodes(); track result.id) {
     <mat-card class="result curator-card">
+        @if (showHeroPromote(result)) {
+        <div class="curator-card__promote">
+            <app-hero-promote-button [promoted]="curatedIdSet().has(result.id)"
+                (promoteToggle)="togglePromote(result)" />
+        </div>
+        }
         <button mat-icon-button type="button" class="curator-card__overflow" [matMenuTriggerFor]="menu"
             aria-label="Episode actions">
             <mat-icon>more_vert</mat-icon>
@@ -81,10 +87,6 @@
         <div class="curator-card__body">
             <div class="curator-card__art">
                 <app-episode-image [apiEpisode]="result" layout="tile"></app-episode-image>
-                @if (showHeroPromote(result)) {
-                <app-hero-promote-button [promoted]="curatedIdSet().has(result.id)"
-                    (promoteToggle)="togglePromote(result)" />
-                }
             </div>
             <div class="curator-card__main">
                 <mat-card-header>

--- a/cultpodcasts/src/app/episodes-api/episodes-api.component.html
+++ b/cultpodcasts/src/app/episodes-api/episodes-api.component.html
@@ -81,6 +81,10 @@
         <div class="curator-card__body">
             <div class="curator-card__art">
                 <app-episode-image [apiEpisode]="result" layout="tile"></app-episode-image>
+                @if (showHeroPromote(result)) {
+                <app-hero-promote-button [promoted]="curatedIdSet().has(result.id)"
+                    (promoteToggle)="togglePromote(result)" />
+                }
             </div>
             <div class="curator-card__main">
                 <mat-card-header>

--- a/cultpodcasts/src/app/episodes-api/episodes-api.component.ts
+++ b/cultpodcasts/src/app/episodes-api/episodes-api.component.ts
@@ -265,34 +265,32 @@ export class EpisodesApiComponent implements AfterViewInit {
     if (!this.showHeroPromote(episode)) {
       return;
     }
-    const ids = [...this.curatedEpisodeIds()];
-    const idx = ids.indexOf(episode.id);
-    if (idx >= 0) {
-      ids.splice(idx, 1);
-    } else {
-      ids.unshift(episode.id);
-    }
-    await this.persistHeroCuration(ids);
-  }
-
-  private async fetchHeroCuration(): Promise<void> {
-    const curation = await this.heroCuration.getHeroCuration();
-    this.curatedEpisodeIds.set(curation.episodeIds ?? []);
-    this.curatedUpdatedAt.set(curation.updatedAt ?? null);
-  }
-
-  private async persistHeroCuration(ids: string[]): Promise<void> {
     const previous = this.curatedEpisodeIds();
     const previousUpdatedAt = this.curatedUpdatedAt();
-    this.curatedEpisodeIds.set(ids);
+    const wantPromoted = !previous.includes(episode.id);
+    this.curatedEpisodeIds.set(
+      wantPromoted
+        ? [episode.id, ...previous.filter((id) => id !== episode.id)]
+        : previous.filter((id) => id !== episode.id)
+    );
     try {
-      const saved = await this.heroCuration.setHeroCuration(ids, previousUpdatedAt);
+      const saved = await this.heroCuration.toggleEpisode(
+        episode.id,
+        previous,
+        previousUpdatedAt
+      );
       this.curatedEpisodeIds.set(saved.episodeIds);
       this.curatedUpdatedAt.set(saved.updatedAt);
     } catch {
       this.curatedEpisodeIds.set(previous);
       this.curatedUpdatedAt.set(previousUpdatedAt);
     }
+  }
+
+  private async fetchHeroCuration(): Promise<void> {
+    const curation = await this.heroCuration.getHeroCuration();
+    this.curatedEpisodeIds.set(curation.episodeIds ?? []);
+    this.curatedUpdatedAt.set(curation.updatedAt ?? null);
   }
 
   loadingSubjectName(episodeId: string): string | null {

--- a/cultpodcasts/src/app/episodes-api/episodes-api.component.ts
+++ b/cultpodcasts/src/app/episodes-api/episodes-api.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, ChangeDetectionStrategy, Component, DestroyRef, ElementRef, PLATFORM_ID, ViewChild, inject, signal } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, DestroyRef, ElementRef, PLATFORM_ID, ViewChild, computed, inject, signal } from '@angular/core';
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { AuthServiceWrapper } from '../auth-service-wrapper.class';
@@ -38,6 +38,9 @@ import {
   syncCuratorSnapOffset,
   toggleCuratorSnapClass
 } from '../curator-snap';
+import { HeroCurationService } from '../hero-curation.service';
+import { HeroPromoteButtonComponent } from '../hero-promote-button/hero-promote-button.component';
+import { isWithinHeroWeek } from '../hero-slides';
 
 const sortParamDateAsc: string = "date-asc";
 const sortParamDateDesc: string = "date-desc";
@@ -57,7 +60,8 @@ const sortParamDateDesc: string = "date-desc";
     EpisodeImageComponent,
     SubjectsComponent,
     EpisodeGuestsComponent,
-    ClampableTextComponent
+    ClampableTextComponent,
+    HeroPromoteButtonComponent
   ],
   templateUrl: './episodes-api.component.html',
   styleUrl: './episodes-api.component.sass',
@@ -77,12 +81,16 @@ export class EpisodesApiComponent implements AfterViewInit {
   protected updatingFlag = signal<'ignored' | 'removed' | 'tweeted' | 'bluesky' | 'subject' | null>(null);
   protected updatingSubjectName = signal<string | null>(null);
   protected addingGuest = signal<Record<string, string>>({});
+  protected readonly curatedEpisodeIds = signal<string[]>([]);
+  protected readonly curatedUpdatedAt = signal<string | null>(null);
+  protected readonly curatedIdSet = computed(() => new Set(this.curatedEpisodeIds()));
 
   private destroyRef = inject(DestroyRef);
   private route = inject(ActivatedRoute);
   protected auth = inject(AuthServiceWrapper);
   protected authRoles = toSignal(this.auth.roles, { initialValue: [] as string[] });
   private readonly platformId = inject(PLATFORM_ID);
+  private readonly heroCuration = inject(HeroCurationService);
   private snapOffsetObserver: ResizeObserver | undefined;
 
   constructor(
@@ -108,6 +116,8 @@ export class EpisodesApiComponent implements AfterViewInit {
     if (!isPlatformBrowser(this.platformId)) {
       return;
     }
+
+    void this.fetchHeroCuration();
 
     this.isLoading.set(true);
     this.error.set(false);
@@ -242,6 +252,47 @@ export class EpisodesApiComponent implements AfterViewInit {
 
   languageBadge(episode: ApiEpisode): LanguageFlagBadge | undefined {
     return languageFlagBadgeForEpisode(episode);
+  }
+
+  showHeroPromote(episode: ApiEpisode): boolean {
+    return (
+      this.authRoles().includes('Curator') &&
+      (this.curatedIdSet().has(episode.id) || isWithinHeroWeek(episode.release))
+    );
+  }
+
+  async togglePromote(episode: ApiEpisode): Promise<void> {
+    if (!this.showHeroPromote(episode)) {
+      return;
+    }
+    const ids = [...this.curatedEpisodeIds()];
+    const idx = ids.indexOf(episode.id);
+    if (idx >= 0) {
+      ids.splice(idx, 1);
+    } else {
+      ids.unshift(episode.id);
+    }
+    await this.persistHeroCuration(ids);
+  }
+
+  private async fetchHeroCuration(): Promise<void> {
+    const curation = await this.heroCuration.getHeroCuration();
+    this.curatedEpisodeIds.set(curation.episodeIds ?? []);
+    this.curatedUpdatedAt.set(curation.updatedAt ?? null);
+  }
+
+  private async persistHeroCuration(ids: string[]): Promise<void> {
+    const previous = this.curatedEpisodeIds();
+    const previousUpdatedAt = this.curatedUpdatedAt();
+    this.curatedEpisodeIds.set(ids);
+    try {
+      const saved = await this.heroCuration.setHeroCuration(ids, previousUpdatedAt);
+      this.curatedEpisodeIds.set(saved.episodeIds);
+      this.curatedUpdatedAt.set(saved.updatedAt);
+    } catch {
+      this.curatedEpisodeIds.set(previous);
+      this.curatedUpdatedAt.set(previousUpdatedAt);
+    }
   }
 
   loadingSubjectName(episodeId: string): string | null {

--- a/cultpodcasts/src/app/hero-curation.interface.ts
+++ b/cultpodcasts/src/app/hero-curation.interface.ts
@@ -1,6 +1,9 @@
 export interface HeroCuration {
   episodeIds: string[];
-  /** Ordered subjects a curator pinned as homepage rails. */
+  /**
+   * Ordered homepage rails: pinned subject names mixed with relative day slots
+   * (`day:0` = newest / n, `day:1` = n−1, …).
+   */
   railSubjects: string[];
   updatedAt: string | null;
 }

--- a/cultpodcasts/src/app/hero-curation.service.spec.ts
+++ b/cultpodcasts/src/app/hero-curation.service.spec.ts
@@ -156,11 +156,11 @@ describe('HeroCurationService', () => {
     });
   });
 
-  it('toggleEpisode promotes via append and demotes via PUT', async () => {
-    const appendUrl = new URL('/hero-curation/episodes', environment.api).toString();
+  it('toggleEpisode promotes via append and demotes via DELETE', async () => {
+    const episodesUrl = new URL('/hero-curation/episodes', environment.api).toString();
 
     const promote = service.toggleEpisode('e2', ['e1'], 't0');
-    const appendReq = httpMock.expectOne(appendUrl);
+    const appendReq = httpMock.expectOne(episodesUrl);
     expect(appendReq.request.method).toBe('POST');
     expect(appendReq.request.body).toEqual({ episodeIds: ['e2'] });
     appendReq.flush({
@@ -175,13 +175,10 @@ describe('HeroCurationService', () => {
     });
 
     const demote = service.toggleEpisode('e2', ['e2', 'e1'], 't1');
-    const putReq = httpMock.expectOne(url);
-    expect(putReq.request.method).toBe('PUT');
-    expect(putReq.request.body).toEqual({
-      episodeIds: ['e1'],
-      expectedUpdatedAt: 't1',
-    });
-    putReq.flush({
+    const deleteReq = httpMock.expectOne(episodesUrl);
+    expect(deleteReq.request.method).toBe('DELETE');
+    expect(deleteReq.request.body).toEqual({ episodeIds: ['e2'] });
+    deleteReq.flush({
       episodeIds: ['e1'],
       railSubjects: [],
       updatedAt: 't2',
@@ -193,42 +190,21 @@ describe('HeroCurationService', () => {
     });
   });
 
-  it('toggleEpisode demote retries once after a CAS conflict', async () => {
-    const pending = service.toggleEpisode('e1', ['e2', 'e1'], 'stale');
-
-    const first = httpMock.expectOne(url);
-    expect(first.request.body).toEqual({
-      episodeIds: ['e2'],
-      expectedUpdatedAt: 'stale',
-    });
-    first.flush(
-      {
-        error: 'Conflict',
-        episodeIds: ['e2', 'e1', 'e0'],
-        railSubjects: ['day:0'],
-        updatedAt: 'fresh',
-      },
-      { status: 409, statusText: 'Conflict' }
-    );
-
-    await Promise.resolve();
-    await Promise.resolve();
-
-    const retry = httpMock.expectOne(url);
-    expect(retry.request.body).toEqual({
-      episodeIds: ['e2', 'e0'],
-      expectedUpdatedAt: 'fresh',
-    });
-    retry.flush({
-      episodeIds: ['e2', 'e0'],
+  it('removeEpisodes sends DELETE without expectedUpdatedAt', async () => {
+    const episodesUrl = new URL('/hero-curation/episodes', environment.api).toString();
+    const pending = service.removeEpisodes(['e1', 'e2']);
+    const req = httpMock.expectOne(episodesUrl);
+    expect(req.request.method).toBe('DELETE');
+    expect(req.request.body).toEqual({ episodeIds: ['e1', 'e2'] });
+    req.flush({
+      episodeIds: ['e0'],
       railSubjects: ['day:0'],
-      updatedAt: 'saved',
+      updatedAt: 't3',
     });
-
     await expect(pending).resolves.toEqual({
-      episodeIds: ['e2', 'e0'],
+      episodeIds: ['e0'],
       railSubjects: ['day:0'],
-      updatedAt: 'saved',
+      updatedAt: 't3',
     });
   });
 

--- a/cultpodcasts/src/app/hero-curation.service.spec.ts
+++ b/cultpodcasts/src/app/hero-curation.service.spec.ts
@@ -120,6 +120,118 @@ describe('HeroCurationService', () => {
     });
   });
 
+  it('treats 400 Conflict bodies as CAS conflicts', async () => {
+    const pending = service.setHeroCuration(['e1'], 'stale');
+    httpMock.expectOne(url).flush(
+      {
+        error: 'Conflict',
+        episodeIds: ['other'],
+        railSubjects: [],
+        updatedAt: 'newer',
+      },
+      { status: 400, statusText: 'Bad Request' }
+    );
+    await expect(pending).rejects.toMatchObject({
+      name: 'HeroCurationConflictError',
+      current: { updatedAt: 'newer' },
+    });
+  });
+
+  it('appends episodes via POST without CAS', async () => {
+    const appendUrl = new URL('/hero-curation/episodes', environment.api).toString();
+    const pending = service.appendEpisodes(['e2']);
+    const req = httpMock.expectOne(appendUrl);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ episodeIds: ['e2'] });
+    expect(req.request.context.get(AUTH_SCOPE)).toBe('curate');
+    req.flush({
+      episodeIds: ['e2', 'e1'],
+      railSubjects: ['day:0'],
+      updatedAt: 't1',
+    });
+    await expect(pending).resolves.toEqual({
+      episodeIds: ['e2', 'e1'],
+      railSubjects: ['day:0'],
+      updatedAt: 't1',
+    });
+  });
+
+  it('toggleEpisode promotes via append and demotes via PUT', async () => {
+    const appendUrl = new URL('/hero-curation/episodes', environment.api).toString();
+
+    const promote = service.toggleEpisode('e2', ['e1'], 't0');
+    const appendReq = httpMock.expectOne(appendUrl);
+    expect(appendReq.request.method).toBe('POST');
+    expect(appendReq.request.body).toEqual({ episodeIds: ['e2'] });
+    appendReq.flush({
+      episodeIds: ['e2', 'e1'],
+      railSubjects: [],
+      updatedAt: 't1',
+    });
+    await expect(promote).resolves.toEqual({
+      episodeIds: ['e2', 'e1'],
+      railSubjects: [],
+      updatedAt: 't1',
+    });
+
+    const demote = service.toggleEpisode('e2', ['e2', 'e1'], 't1');
+    const putReq = httpMock.expectOne(url);
+    expect(putReq.request.method).toBe('PUT');
+    expect(putReq.request.body).toEqual({
+      episodeIds: ['e1'],
+      expectedUpdatedAt: 't1',
+    });
+    putReq.flush({
+      episodeIds: ['e1'],
+      railSubjects: [],
+      updatedAt: 't2',
+    });
+    await expect(demote).resolves.toEqual({
+      episodeIds: ['e1'],
+      railSubjects: [],
+      updatedAt: 't2',
+    });
+  });
+
+  it('toggleEpisode demote retries once after a CAS conflict', async () => {
+    const pending = service.toggleEpisode('e1', ['e2', 'e1'], 'stale');
+
+    const first = httpMock.expectOne(url);
+    expect(first.request.body).toEqual({
+      episodeIds: ['e2'],
+      expectedUpdatedAt: 'stale',
+    });
+    first.flush(
+      {
+        error: 'Conflict',
+        episodeIds: ['e2', 'e1', 'e0'],
+        railSubjects: ['day:0'],
+        updatedAt: 'fresh',
+      },
+      { status: 409, statusText: 'Conflict' }
+    );
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const retry = httpMock.expectOne(url);
+    expect(retry.request.body).toEqual({
+      episodeIds: ['e2', 'e0'],
+      expectedUpdatedAt: 'fresh',
+    });
+    retry.flush({
+      episodeIds: ['e2', 'e0'],
+      railSubjects: ['day:0'],
+      updatedAt: 'saved',
+    });
+
+    await expect(pending).resolves.toEqual({
+      episodeIds: ['e2', 'e0'],
+      railSubjects: ['day:0'],
+      updatedAt: 'saved',
+    });
+  });
+
   it('rethrows when PUT fails', async () => {
     const err = vi.spyOn(console, 'error').mockImplementation(() => undefined);
     const pending = service.setHeroCuration(['e1']);

--- a/cultpodcasts/src/app/hero-curation.service.ts
+++ b/cultpodcasts/src/app/hero-curation.service.ts
@@ -20,8 +20,11 @@ interface HeroCurationUpdate {
 
 /**
  * Homepage curation: hero episode picks and pinned subject rails (Durable Object).
- * GET is public; PUT requires curate scope. Failures return empty lists so the
+ * GET is public; PUT/POST require curate scope. Failures return empty lists so the
  * homepage can still autofill when the worker endpoint is missing or down.
+ *
+ * Prefer {@link appendEpisodes} / {@link toggleEpisode} for single-id promote —
+ * full-list PUT is for demote, manage-hero reorder, and rail saves, and needs CAS.
  */
 @Injectable({ providedIn: 'root' })
 export class HeroCurationService {
@@ -50,6 +53,65 @@ export class HeroCurationService {
     return this.put({ railSubjects, expectedUpdatedAt });
   }
 
+  /**
+   * Append hero episode IDs (server-side merge, no CAS). Used by indexer
+   * auto-promote and by curator star-to-add.
+   */
+  async appendEpisodes(episodeIds: string[]): Promise<HeroCuration> {
+    const url = new URL('/hero-curation/episodes', environment.api).toString();
+    const saved = await firstValueFrom(
+      this.http.post<HeroCuration>(
+        url,
+        { episodeIds },
+        { context: new HttpContext().set(AUTH_SCOPE, 'curate') }
+      )
+    );
+    return {
+      episodeIds: saved.episodeIds ?? [],
+      railSubjects: saved.railSubjects ?? [],
+      updatedAt: saved.updatedAt ?? null,
+    };
+  }
+
+  /**
+   * Toggle an episode in the hero list.
+   * Promote uses POST append (no CAS). Demote uses PUT replace with CAS + one retry.
+   */
+  async toggleEpisode(
+    episodeId: string,
+    currentIds: readonly string[],
+    expectedUpdatedAt: string | null
+  ): Promise<HeroCuration> {
+    const wantPromoted = !currentIds.includes(episodeId);
+    if (wantPromoted) {
+      return this.appendEpisodes([episodeId]);
+    }
+
+    const nextIds = currentIds.filter((id) => id !== episodeId);
+    try {
+      return await this.setHeroCuration(nextIds, expectedUpdatedAt);
+    } catch (error) {
+      if (!(error instanceof HeroCurationConflictError)) {
+        throw error;
+      }
+      const retryIds = error.current.episodeIds.filter((id) => id !== episodeId);
+      if (
+        retryIds.length === error.current.episodeIds.length &&
+        retryIds.every((id, i) => id === error.current.episodeIds[i])
+      ) {
+        return error.current;
+      }
+      try {
+        return await this.setHeroCuration(retryIds, error.current.updatedAt);
+      } catch (retryError) {
+        if (retryError instanceof HeroCurationConflictError) {
+          return retryError.current;
+        }
+        throw retryError;
+      }
+    }
+  }
+
   /** Persist any combination of hero and rail picks in one PUT. */
   setHomepageCuration(update: HeroCurationUpdate): Promise<HeroCuration> {
     return this.put(update);
@@ -70,8 +132,8 @@ export class HeroCurationService {
         updatedAt: saved.updatedAt ?? null,
       };
     } catch (error) {
-      if (error instanceof HttpErrorResponse && error.status === 409) {
-        const body = error.error as Partial<HeroCuration> | null;
+      if (error instanceof HttpErrorResponse && this.isConflictResponse(error)) {
+        const body = error.error as (Partial<HeroCuration> & { error?: string }) | null;
         throw new HeroCurationConflictError({
           episodeIds: body?.episodeIds ?? [],
           railSubjects: body?.railSubjects ?? [],
@@ -81,5 +143,13 @@ export class HeroCurationService {
       console.error('Failed to save hero curation.', error);
       throw error;
     }
+  }
+
+  private isConflictResponse(error: HttpErrorResponse): boolean {
+    if (error.status === 409) {
+      return true;
+    }
+    const body = error.error as { error?: string } | null;
+    return error.status === 400 && body?.error === 'Conflict';
   }
 }

--- a/cultpodcasts/src/app/hero-curation.service.ts
+++ b/cultpodcasts/src/app/hero-curation.service.ts
@@ -20,11 +20,12 @@ interface HeroCurationUpdate {
 
 /**
  * Homepage curation: hero episode picks and pinned subject rails (Durable Object).
- * GET is public; PUT/POST require curate scope. Failures return empty lists so the
- * homepage can still autofill when the worker endpoint is missing or down.
+ * GET is public; mutations require curate scope.
  *
- * Prefer {@link appendEpisodes} / {@link toggleEpisode} for single-id promote —
- * full-list PUT is for demote, manage-hero reorder, and rail saves, and needs CAS.
+ * Episode membership:
+ * - promote → POST /hero-curation/episodes (append, no CAS)
+ * - demote → DELETE /hero-curation/episodes (remove, no CAS)
+ * Full-list PUT of episodeIds is only for Manage-hero reorder/set-order.
  */
 @Injectable({ providedIn: 'root' })
 export class HeroCurationService {
@@ -45,6 +46,7 @@ export class HeroCurationService {
     }
   }
 
+  /** Manage-hero reorder / set ordered list. Prefer append/remove for single-id changes. */
   setHeroCuration(episodeIds: string[], expectedUpdatedAt?: string | null): Promise<HeroCuration> {
     return this.put({ episodeIds, expectedUpdatedAt });
   }
@@ -53,68 +55,52 @@ export class HeroCurationService {
     return this.put({ railSubjects, expectedUpdatedAt });
   }
 
-  /**
-   * Append hero episode IDs (server-side merge, no CAS). Used by indexer
-   * auto-promote and by curator star-to-add.
-   */
+  /** Append hero episode IDs (server-side merge, no CAS). */
   async appendEpisodes(episodeIds: string[]): Promise<HeroCuration> {
+    return this.mutateEpisodeIds('POST', episodeIds);
+  }
+
+  /** Remove hero episode IDs (idempotent, no CAS). */
+  async removeEpisodes(episodeIds: string[]): Promise<HeroCuration> {
+    return this.mutateEpisodeIds('DELETE', episodeIds);
+  }
+
+  /**
+   * Toggle an episode in the hero list via POST append or DELETE remove — never
+   * a full-list PUT.
+   */
+  async toggleEpisode(
+    episodeId: string,
+    currentIds: readonly string[],
+    _expectedUpdatedAt?: string | null
+  ): Promise<HeroCuration> {
+    if (currentIds.includes(episodeId)) {
+      return this.removeEpisodes([episodeId]);
+    }
+    return this.appendEpisodes([episodeId]);
+  }
+
+  /** Persist any combination of hero and rail picks in one PUT. */
+  setHomepageCuration(update: HeroCurationUpdate): Promise<HeroCuration> {
+    return this.put(update);
+  }
+
+  private async mutateEpisodeIds(
+    method: 'POST' | 'DELETE',
+    episodeIds: string[]
+  ): Promise<HeroCuration> {
     const url = new URL('/hero-curation/episodes', environment.api).toString();
     const saved = await firstValueFrom(
-      this.http.post<HeroCuration>(
-        url,
-        { episodeIds },
-        { context: new HttpContext().set(AUTH_SCOPE, 'curate') }
-      )
+      this.http.request<HeroCuration>(method, url, {
+        body: { episodeIds },
+        context: new HttpContext().set(AUTH_SCOPE, 'curate'),
+      })
     );
     return {
       episodeIds: saved.episodeIds ?? [],
       railSubjects: saved.railSubjects ?? [],
       updatedAt: saved.updatedAt ?? null,
     };
-  }
-
-  /**
-   * Toggle an episode in the hero list.
-   * Promote uses POST append (no CAS). Demote uses PUT replace with CAS + one retry.
-   */
-  async toggleEpisode(
-    episodeId: string,
-    currentIds: readonly string[],
-    expectedUpdatedAt: string | null
-  ): Promise<HeroCuration> {
-    const wantPromoted = !currentIds.includes(episodeId);
-    if (wantPromoted) {
-      return this.appendEpisodes([episodeId]);
-    }
-
-    const nextIds = currentIds.filter((id) => id !== episodeId);
-    try {
-      return await this.setHeroCuration(nextIds, expectedUpdatedAt);
-    } catch (error) {
-      if (!(error instanceof HeroCurationConflictError)) {
-        throw error;
-      }
-      const retryIds = error.current.episodeIds.filter((id) => id !== episodeId);
-      if (
-        retryIds.length === error.current.episodeIds.length &&
-        retryIds.every((id, i) => id === error.current.episodeIds[i])
-      ) {
-        return error.current;
-      }
-      try {
-        return await this.setHeroCuration(retryIds, error.current.updatedAt);
-      } catch (retryError) {
-        if (retryError instanceof HeroCurationConflictError) {
-          return retryError.current;
-        }
-        throw retryError;
-      }
-    }
-  }
-
-  /** Persist any combination of hero and rail picks in one PUT. */
-  setHomepageCuration(update: HeroCurationUpdate): Promise<HeroCuration> {
-    return this.put(update);
   }
 
   /** Partial update: the worker merges, so hero and rail picks don't clobber each other. */

--- a/cultpodcasts/src/app/hero-promote-button/hero-promote-button.component.html
+++ b/cultpodcasts/src/app/hero-promote-button/hero-promote-button.component.html
@@ -1,0 +1,6 @@
+<button type="button" class="hero-promote-button" [class.is-promoted]="promoted()"
+  [attr.aria-pressed]="promoted()"
+  [attr.aria-label]="promoted() ? 'Remove from hero' : 'Promote to hero'"
+  (click)="onClick($event)">
+  <mat-icon>{{ promoted() ? 'star' : 'star_border' }}</mat-icon>
+</button>

--- a/cultpodcasts/src/app/hero-promote-button/hero-promote-button.component.sass
+++ b/cultpodcasts/src/app/hero-promote-button/hero-promote-button.component.sass
@@ -3,8 +3,10 @@
 
 .hero-promote-button
     position: absolute
+    // Top-left on art — clears the card's top-right kebab on stacked multi-col cards.
     top: 6px
-    right: 6px
+    left: 6px
+    right: auto
     z-index: 2
     width: 32px
     height: 32px

--- a/cultpodcasts/src/app/hero-promote-button/hero-promote-button.component.sass
+++ b/cultpodcasts/src/app/hero-promote-button/hero-promote-button.component.sass
@@ -1,13 +1,7 @@
 :host
-    display: contents
+    display: block
 
 .hero-promote-button
-    position: absolute
-    // Top-left on art — clears the card's top-right kebab on stacked multi-col cards.
-    top: 6px
-    left: 6px
-    right: auto
-    z-index: 2
     width: 32px
     height: 32px
     padding: 0

--- a/cultpodcasts/src/app/hero-promote-button/hero-promote-button.component.sass
+++ b/cultpodcasts/src/app/hero-promote-button/hero-promote-button.component.sass
@@ -1,0 +1,32 @@
+:host
+    display: contents
+
+.hero-promote-button
+    position: absolute
+    top: 6px
+    right: 6px
+    z-index: 2
+    width: 32px
+    height: 32px
+    padding: 0
+    border: 1px solid #ffffff59
+    border-radius: 50%
+    background: #1a1a1ae6
+    color: #fff
+    display: inline-flex
+    align-items: center
+    justify-content: center
+    cursor: pointer
+    transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease
+    mat-icon
+        font-size: 18px
+        width: 18px
+        height: 18px
+    &:hover,
+    &:focus-visible
+        background: #ffffff26
+        border-color: var(--nflx-accent, #e8a23a)
+        outline: none
+    &.is-promoted
+        color: var(--nflx-accent, #e8a23a)
+        border-color: var(--nflx-accent, #e8a23a)

--- a/cultpodcasts/src/app/hero-promote-button/hero-promote-button.component.ts
+++ b/cultpodcasts/src/app/hero-promote-button/hero-promote-button.component.ts
@@ -1,0 +1,20 @@
+import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
+import { MatIconModule } from '@angular/material/icon';
+
+@Component({
+  selector: 'app-hero-promote-button',
+  imports: [MatIconModule],
+  templateUrl: './hero-promote-button.component.html',
+  styleUrl: './hero-promote-button.component.sass',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class HeroPromoteButtonComponent {
+  readonly promoted = input(false);
+  readonly promoteToggle = output<MouseEvent>();
+
+  onClick(event: MouseEvent): void {
+    event.preventDefault();
+    event.stopPropagation();
+    this.promoteToggle.emit(event);
+  }
+}

--- a/cultpodcasts/src/app/hero-slides.spec.ts
+++ b/cultpodcasts/src/app/hero-slides.spec.ts
@@ -3,6 +3,7 @@ import {
   HERO_POOL_SIZE,
   buildAutofillPool,
   buildHeroSlides,
+  isWithinHeroWeek,
   pruneCuratedIdsToWeek,
   resolveCuratedEpisodes,
 } from './hero-slides';
@@ -48,6 +49,14 @@ describe('hero-slides', () => {
       ids: ['e0', 'e1'],
       pruned: false,
     });
+  });
+
+  it('gates hero-week eligibility to the rolling past week', () => {
+    const now = new Date('2026-08-01T12:00:00Z');
+    expect(isWithinHeroWeek(new Date('2026-07-30T12:00:00Z'), now)).toBe(true);
+    expect(isWithinHeroWeek(new Date('2026-07-25T12:00:00Z'), now)).toBe(true);
+    expect(isWithinHeroWeek(new Date('2026-07-25T11:59:00Z'), now)).toBe(false);
+    expect(isWithinHeroWeek(null, now)).toBe(false);
   });
 
   it('uses curated list alone when resolved count is at least pool size', () => {

--- a/cultpodcasts/src/app/hero-slides.ts
+++ b/cultpodcasts/src/app/hero-slides.ts
@@ -9,6 +9,29 @@ export const HERO_DISCOVER_CONTRIBUTION = 6;
 /** Recency window to rotate through before capping contribution. */
 export const HERO_RECENT_WINDOW = 48;
 
+/** Approximate homepage week window for gating promote UI outside the homepage. */
+export const HERO_WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * Whether a release falls in the rolling past week (with a small future slack).
+ * Used to show the hero star on curator pages; the homepage still resolves
+ * against actual `recentEpisodes`.
+ */
+export function isWithinHeroWeek(
+  release: Date | string | null | undefined,
+  now: Date = new Date()
+): boolean {
+  if (release == null) {
+    return false;
+  }
+  const time = release instanceof Date ? release.getTime() : new Date(release).getTime();
+  if (Number.isNaN(time)) {
+    return false;
+  }
+  const nowMs = now.getTime();
+  return time >= nowMs - HERO_WEEK_MS && time <= nowMs + 24 * 60 * 60 * 1000;
+}
+
 export interface HeroRailLike {
   episodes: HomepageEpisode[];
 }

--- a/cultpodcasts/src/app/homepage-api/homepage-api.component.spec.ts
+++ b/cultpodcasts/src/app/homepage-api/homepage-api.component.spec.ts
@@ -58,6 +58,7 @@ describe('HomepageApiComponent', () => {
     setHeroCuration: ReturnType<typeof vi.fn>;
     setRailSubjects: ReturnType<typeof vi.fn>;
     setHomepageCuration: ReturnType<typeof vi.fn>;
+    toggleEpisode: ReturnType<typeof vi.fn>;
   };
   let roles$: ReplaySubject<string[]>;
 
@@ -86,6 +87,15 @@ describe('HomepageApiComponent', () => {
           railSubjects: update.railSubjects ?? [],
           updatedAt: null,
         })
+      ),
+      toggleEpisode: vi.fn().mockImplementation(
+        async (episodeId: string, currentIds: string[]) => {
+          const wantPromoted = !currentIds.includes(episodeId);
+          const episodeIds = wantPromoted
+            ? [episodeId, ...currentIds.filter((id) => id !== episodeId)]
+            : currentIds.filter((id) => id !== episodeId);
+          return { episodeIds, railSubjects: [], updatedAt: null };
+        }
       ),
     };
 
@@ -173,7 +183,7 @@ describe('HomepageApiComponent', () => {
   it('rolls back promote when persist fails', async () => {
     roles$.next(['Curator']);
     apply([ep('a'), ep('b')], { episodeIds: [] });
-    heroCuration.setHeroCuration.mockRejectedValueOnce(new Error('fail'));
+    heroCuration.toggleEpisode.mockRejectedValueOnce(new Error('fail'));
     await component.togglePromote(ep('a'));
     expect(component['curatedEpisodeIds']()).toEqual([]);
   });

--- a/cultpodcasts/src/app/homepage-api/homepage-api.component.spec.ts
+++ b/cultpodcasts/src/app/homepage-api/homepage-api.component.spec.ts
@@ -59,6 +59,7 @@ describe('HomepageApiComponent', () => {
     setRailSubjects: ReturnType<typeof vi.fn>;
     setHomepageCuration: ReturnType<typeof vi.fn>;
     toggleEpisode: ReturnType<typeof vi.fn>;
+    removeEpisodes: ReturnType<typeof vi.fn>;
   };
   let roles$: ReplaySubject<string[]>;
 
@@ -97,6 +98,11 @@ describe('HomepageApiComponent', () => {
           return { episodeIds, railSubjects: [], updatedAt: null };
         }
       ),
+      removeEpisodes: vi.fn().mockImplementation(async (ids: string[]) => ({
+        episodeIds: [],
+        railSubjects: [],
+        updatedAt: null,
+      })),
     };
 
     await TestBed.configureTestingModule({

--- a/cultpodcasts/src/app/homepage-api/homepage-api.component.spec.ts
+++ b/cultpodcasts/src/app/homepage-api/homepage-api.component.spec.ts
@@ -219,7 +219,7 @@ describe('HomepageApiComponent', () => {
     expect(component['visibleCount']).toBe(visibleBefore);
   });
 
-  it('interleaves newest day, then pinned subject rails, then remaining days', () => {
+  it('interleaves newest day, then pinned subject rails, then remaining days by default', () => {
     roles$.next(['Curator']);
     const subject = 'TestSubject';
     const newest = Array.from({ length: SUBJECT_RAIL_MIN_EPISODES }, (_, i) =>
@@ -235,6 +235,30 @@ describe('HomepageApiComponent', () => {
     expect(rails[0].id.startsWith('day:')).toBe(true);
     expect(rails[1].id).toBe(`subject:${subject}`);
     expect(rails.slice(2).every((r) => r.id.startsWith('day:'))).toBe(true);
+  });
+
+  it('honours a curated mixed day/subject rail order', () => {
+    roles$.next(['Curator']);
+    const subject = 'OrderedSubject';
+    const newest = Array.from({ length: SUBJECT_RAIL_MIN_EPISODES }, (_, i) =>
+      ep(`n${i}`, { daysAgo: 0, subjects: [subject] })
+    );
+    const older = Array.from({ length: SUBJECT_RAIL_MIN_EPISODES }, (_, i) =>
+      ep(`o${i}`, { daysAgo: 2, subjects: [subject] })
+    );
+    apply([...newest, ...older], {
+      railSubjects: ['day:1', subject, 'day:0'],
+    });
+
+    const rails = component['rails']();
+    expect(rails).toHaveLength(3);
+    expect(rails[0].id.startsWith('day:')).toBe(true);
+    expect(rails[1].id).toBe(`subject:${subject}`);
+    expect(rails[2].id.startsWith('day:')).toBe(true);
+    expect(rails[0].id).not.toBe(rails[2].id);
+    // day:1 (older) before day:0 (newest)
+    expect(rails[0].episodes[0].id.startsWith('o')).toBe(true);
+    expect(rails[2].episodes[0].id.startsWith('n')).toBe(true);
   });
 
   it('caps subject rails to RAIL_DISPLAY_SIZE but leaves day rails uncapped', () => {

--- a/cultpodcasts/src/app/homepage-api/homepage-api.component.ts
+++ b/cultpodcasts/src/app/homepage-api/homepage-api.component.ts
@@ -364,8 +364,20 @@ export class HomepageApiComponent {
     if (!this.isCurator() || !episodeId) {
       return;
     }
-    const ids = this.curatedEpisodeIds().filter((id) => id !== episodeId);
-    await this.persistCuration(ids);
+    const previous = this.curatedEpisodeIds();
+    const previousUpdatedAt = this.curatedUpdatedAt();
+    this.curatedEpisodeIds.set(previous.filter((id) => id !== episodeId));
+    try {
+      const saved = await this.heroCurationService.removeEpisodes([episodeId]);
+      this.curatedEpisodeIds.set(saved.episodeIds);
+      this.curatedUpdatedAt.set(saved.updatedAt);
+      if (saved.railSubjects) {
+        this.curatedRailSubjects.set(saved.railSubjects);
+      }
+    } catch {
+      this.curatedEpisodeIds.set(previous);
+      this.curatedUpdatedAt.set(previousUpdatedAt);
+    }
   }
 
   openManageHero(): void {

--- a/cultpodcasts/src/app/homepage-api/homepage-api.component.ts
+++ b/cultpodcasts/src/app/homepage-api/homepage-api.component.ts
@@ -36,6 +36,12 @@ import {
   pruneRailSubjectsToWeek,
 } from '../rail-subjects';
 import {
+  normalizeRailOrder,
+  parseDayRailOffset,
+  subjectEntries,
+  toggleSubjectInRailOrder,
+} from '../rail-order';
+import {
   HeroManageDialogComponent,
   HeroManageDialogResult,
 } from '../hero-manage-dialog/hero-manage-dialog.component';
@@ -122,7 +128,10 @@ export class HomepageApiComponent {
 
   /** Ordered episode IDs from the hero-curation API (may include stale ids). */
   protected readonly curatedEpisodeIds = signal<string[]>([]);
-  /** Ordered subject names pinned as homepage rails (may include stale names). */
+  /**
+   * Ordered homepage rails: relative day slots (`day:0` = n, `day:1` = n−1, …)
+   * mixed with pinned subject names (may include stale entries).
+   */
   protected readonly curatedRailSubjects = signal<string[]>([]);
   protected readonly curatedUpdatedAt = signal<string | null>(null);
 
@@ -173,7 +182,7 @@ export class HomepageApiComponent {
   );
 
   protected readonly curatedRailSubjectSet = computed(
-    () => new Set(this.curatedRailSubjects())
+    () => new Set(subjectEntries(this.curatedRailSubjects()))
   );
 
   /** Lesser-known named groups from this week's episodes. */
@@ -187,24 +196,62 @@ export class HomepageApiComponent {
 
   protected readonly rails = computed((): EpisodeRail[] => {
     const g = this.grouped();
-    const keys = Object.keys(g).sort((a, b) => this.descDateKey(a, b));
-    const dayRails = keys.map((key) => {
+    const weekKeys = this.weekDayKeysNewestFirst();
+    const dayRails = weekKeys.map((key) => {
+      const episodes = g[key];
+      if (!episodes?.length) {
+        return undefined;
+      }
       const d = this.ToDate(key);
       return {
         id: `day:${key}`,
         title: `${this.Weekday[d.getDay()]} ${d.getDate()} ${this.Month[d.getMonth()]}`,
         // Day rails have no "Browse all" destination — show the full progressive window.
-        episodes: g[key],
+        episodes,
       } satisfies EpisodeRail;
     });
 
-    const subjects = this.subjectRails();
-    if (subjects.length === 0 || dayRails.length === 0) {
-      return [...dayRails, ...subjects];
+    const subjectByName = new Map(
+      this.subjectRails().map((rail) => [rail.subject!, rail])
+    );
+    const eligible = this.subjectRailCandidates().map((c) => c.subject);
+    const { order } = normalizeRailOrder(
+      this.curatedRailSubjects(),
+      weekKeys.length,
+      eligible
+    );
+
+    const usedDays = new Set<number>();
+    const usedSubjects = new Set<string>();
+    const result: EpisodeRail[] = [];
+
+    for (const entry of order) {
+      const offset = parseDayRailOffset(entry);
+      if (offset !== null) {
+        const day = dayRails[offset];
+        if (!day || usedDays.has(offset)) {
+          continue;
+        }
+        usedDays.add(offset);
+        result.push(day);
+        continue;
+      }
+      const subject = subjectByName.get(entry);
+      if (!subject || usedSubjects.has(entry)) {
+        continue;
+      }
+      usedSubjects.add(entry);
+      result.push(subject);
     }
 
-    // Lead with the newest day, then subject playlists, then remaining days.
-    return [dayRails[0], ...subjects, ...dayRails.slice(1)];
+    for (let offset = 0; offset < dayRails.length; offset++) {
+      const day = dayRails[offset];
+      if (day && !usedDays.has(offset)) {
+        result.push(day);
+      }
+    }
+
+    return result;
   });
 
   private siteService = inject(SiteService);
@@ -345,14 +392,13 @@ export class HomepageApiComponent {
     if (!subject || !this.isCurator()) {
       return;
     }
-    const subjects = [...this.curatedRailSubjects()];
-    const idx = subjects.indexOf(subject);
-    if (idx >= 0) {
-      subjects.splice(idx, 1);
-    } else {
-      subjects.push(subject);
-    }
-    await this.persistRailSubjects(subjects);
+    const eligible = this.subjectRailCandidates().map((c) => c.subject);
+    const { order } = normalizeRailOrder(
+      this.curatedRailSubjects(),
+      this.weekDayCount(),
+      eligible
+    );
+    await this.persistRailSubjects(toggleSubjectInRailOrder(order, subject));
   }
 
   openManageRails(): void {
@@ -360,19 +406,29 @@ export class HomepageApiComponent {
       return;
     }
     const candidates = this.subjectRailCandidates();
-    const pinned = this.curatedRailSubjects().filter((subject) =>
-      candidates.some((c) => c.subject === subject)
-    );
     const eligible = candidates.map((c) => c.subject);
+    const dayKeys = this.weekDayKeysNewestFirst();
+    const { order } = normalizeRailOrder(
+      this.curatedRailSubjects(),
+      dayKeys.length,
+      eligible
+    );
     const episodeCounts = Object.fromEntries(
       candidates.map((c) => [c.subject, c.episodes.length])
     );
+    const byDay = new Map<string, number>();
+    for (const episode of this.allEpisodes()) {
+      const key = dateKey(episode.release as Date);
+      byDay.set(key, (byDay.get(key) ?? 0) + 1);
+    }
+    const dayEpisodeCounts = dayKeys.map((key) => byDay.get(key) ?? 0);
 
     const ref = this.dialog.open(RailsManageDialogComponent, {
       data: {
-        pinned,
+        order,
         eligible,
         episodeCounts,
+        dayEpisodeCounts,
         updatedAt: this.curatedUpdatedAt(),
       },
       ...this.manageDialogOptions(),
@@ -476,6 +532,22 @@ export class HomepageApiComponent {
    * Drop curated picks / pinned rails that left the current homepage week window
    * for local display only. Server cron (every 6h) owns Durable Object prune writes.
    */
+  private weekDayCount(): number {
+    const keys = new Set<string>();
+    for (const episode of this.allEpisodes()) {
+      keys.add(dateKey(episode.release as Date));
+    }
+    return keys.size;
+  }
+
+  private weekDayKeysNewestFirst(): string[] {
+    const keys = new Set<string>();
+    for (const episode of this.allEpisodes()) {
+      keys.add(dateKey(episode.release as Date));
+    }
+    return [...keys].sort((a, b) => this.descDateKey(a, b));
+  }
+
   private pruneCurationToCurrentWeek(): void {
     const rawEpisodes = this.curatedEpisodeIds();
     const episodePrune = pruneCuratedIdsToWeek(rawEpisodes, this.allEpisodes());
@@ -486,7 +558,8 @@ export class HomepageApiComponent {
     const rawRails = this.curatedRailSubjects();
     const railPrune = pruneRailSubjectsToWeek(
       rawRails,
-      this.subjectRailCandidates()
+      this.subjectRailCandidates(),
+      this.weekDayCount()
     );
     if (railPrune.pruned) {
       this.curatedRailSubjects.set(railPrune.subjects);

--- a/cultpodcasts/src/app/homepage-api/homepage-api.component.ts
+++ b/cultpodcasts/src/app/homepage-api/homepage-api.component.ts
@@ -335,15 +335,29 @@ export class HomepageApiComponent {
     if (!this.isCurator()) {
       return;
     }
-    const ids = [...this.curatedEpisodeIds()];
-    const idx = ids.indexOf(episode.id);
-    if (idx >= 0) {
-      ids.splice(idx, 1);
-    } else {
-      // Newest star leads the hero rotation.
-      ids.unshift(episode.id);
+    const previous = this.curatedEpisodeIds();
+    const previousUpdatedAt = this.curatedUpdatedAt();
+    const wantPromoted = !previous.includes(episode.id);
+    this.curatedEpisodeIds.set(
+      wantPromoted
+        ? [episode.id, ...previous.filter((id) => id !== episode.id)]
+        : previous.filter((id) => id !== episode.id)
+    );
+    try {
+      const saved = await this.heroCurationService.toggleEpisode(
+        episode.id,
+        previous,
+        previousUpdatedAt
+      );
+      this.curatedEpisodeIds.set(saved.episodeIds);
+      this.curatedUpdatedAt.set(saved.updatedAt);
+      if (saved.railSubjects) {
+        this.curatedRailSubjects.set(saved.railSubjects);
+      }
+    } catch {
+      this.curatedEpisodeIds.set(previous);
+      this.curatedUpdatedAt.set(previousUpdatedAt);
     }
-    await this.persistCuration(ids);
   }
 
   async removeFeaturedFromHero(episodeId: string): Promise<void> {

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.html
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.html
@@ -116,7 +116,7 @@
       </button>
       }
       <button type="button" class="billboard__manage" (click)="manageRails.emit()"
-        aria-label="Manage subject rails">
+        aria-label="Manage rails">
         <mat-icon>view_week</mat-icon>
         <span>Manage rails</span>
       </button>

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
@@ -168,7 +168,8 @@
 @media screen and (min-width: 1280px)
     .billboard__stage.has-edge-extend
         .billboard__stage-motion
-            transform-origin: 70% 40%
+            // Zoom toward the right-anchored art edge so scale does not crop it off.
+            transform-origin: 90% 40%
         // Prefer a wide left fill under copy; pin sharp art to the right edge.
         .billboard__stage-edge--left
             width: max(0px, calc(100% - min(100cqw, 100cqh * var(--hero-art-aspect))))

--- a/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.html
+++ b/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.html
@@ -103,6 +103,10 @@
         <div class="curator-card__body">
             <div class="curator-card__art">
                 <app-episode-image [apiEpisode]="result" layout="tile"></app-episode-image>
+                @if (showHeroPromote(result)) {
+                <app-hero-promote-button [promoted]="curatedIdSet().has(result.id)"
+                    (promoteToggle)="togglePromote(result)" />
+                }
             </div>
             <div class="curator-card__main">
                 <mat-card-header>

--- a/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.html
+++ b/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.html
@@ -73,6 +73,12 @@
     <div class="curator-card-grid">
     @for (result of episodes(); track result.id) {
     <mat-card class="result curator-card">
+        @if (showHeroPromote(result)) {
+        <div class="curator-card__promote">
+            <app-hero-promote-button [promoted]="curatedIdSet().has(result.id)"
+                (promoteToggle)="togglePromote(result)" />
+        </div>
+        }
         <button mat-icon-button type="button" class="curator-card__overflow" [matMenuTriggerFor]="menu"
             aria-label="Episode actions">
             <mat-icon>more_vert</mat-icon>
@@ -103,10 +109,6 @@
         <div class="curator-card__body">
             <div class="curator-card__art">
                 <app-episode-image [apiEpisode]="result" layout="tile"></app-episode-image>
-                @if (showHeroPromote(result)) {
-                <app-hero-promote-button [promoted]="curatedIdSet().has(result.id)"
-                    (promoteToggle)="togglePromote(result)" />
-                }
             </div>
             <div class="curator-card__main">
                 <mat-card-header>

--- a/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.ts
+++ b/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.ts
@@ -259,34 +259,32 @@ export class OutgoingEpisodesApiComponent implements AfterViewInit {
     if (!this.showHeroPromote(episode)) {
       return;
     }
-    const ids = [...this.curatedEpisodeIds()];
-    const idx = ids.indexOf(episode.id);
-    if (idx >= 0) {
-      ids.splice(idx, 1);
-    } else {
-      ids.unshift(episode.id);
-    }
-    await this.persistHeroCuration(ids);
-  }
-
-  private async fetchHeroCuration(): Promise<void> {
-    const curation = await this.heroCuration.getHeroCuration();
-    this.curatedEpisodeIds.set(curation.episodeIds ?? []);
-    this.curatedUpdatedAt.set(curation.updatedAt ?? null);
-  }
-
-  private async persistHeroCuration(ids: string[]): Promise<void> {
     const previous = this.curatedEpisodeIds();
     const previousUpdatedAt = this.curatedUpdatedAt();
-    this.curatedEpisodeIds.set(ids);
+    const wantPromoted = !previous.includes(episode.id);
+    this.curatedEpisodeIds.set(
+      wantPromoted
+        ? [episode.id, ...previous.filter((id) => id !== episode.id)]
+        : previous.filter((id) => id !== episode.id)
+    );
     try {
-      const saved = await this.heroCuration.setHeroCuration(ids, previousUpdatedAt);
+      const saved = await this.heroCuration.toggleEpisode(
+        episode.id,
+        previous,
+        previousUpdatedAt
+      );
       this.curatedEpisodeIds.set(saved.episodeIds);
       this.curatedUpdatedAt.set(saved.updatedAt);
     } catch {
       this.curatedEpisodeIds.set(previous);
       this.curatedUpdatedAt.set(previousUpdatedAt);
     }
+  }
+
+  private async fetchHeroCuration(): Promise<void> {
+    const curation = await this.heroCuration.getHeroCuration();
+    this.curatedEpisodeIds.set(curation.episodeIds ?? []);
+    this.curatedUpdatedAt.set(curation.updatedAt ?? null);
   }
 
   loadingSubjectName(episodeId: string): string | null {

--- a/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.ts
+++ b/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, ChangeDetectionStrategy, Component, DestroyRef, ElementRef, PLATFORM_ID, ViewChild, inject, signal } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, DestroyRef, ElementRef, PLATFORM_ID, ViewChild, computed, inject, signal } from '@angular/core';
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { AuthServiceWrapper } from '../auth-service-wrapper.class';
@@ -42,6 +42,9 @@ import {
   syncCuratorSnapOffset,
   toggleCuratorSnapClass
 } from '../curator-snap';
+import { HeroCurationService } from '../hero-curation.service';
+import { HeroPromoteButtonComponent } from '../hero-promote-button/hero-promote-button.component';
+import { isWithinHeroWeek } from '../hero-slides';
 
 const sortParamDateAsc: string = "date-asc";
 const sortParamDateDesc: string = "date-desc";
@@ -65,7 +68,8 @@ const daysKey: string = "pref.outgoing-episodes.days";
     EpisodeImageComponent,
     SubjectsComponent,
     EpisodeGuestsComponent,
-    ClampableTextComponent
+    ClampableTextComponent,
+    HeroPromoteButtonComponent
   ],
   templateUrl: './outgoing-episodes-api.component.html',
   styleUrl: './outgoing-episodes-api.component.sass',
@@ -92,12 +96,16 @@ export class OutgoingEpisodesApiComponent implements AfterViewInit {
   protected updatingFlag = signal<'ignored' | 'removed' | 'tweeted' | 'bluesky' | 'subject' | null>(null);
   protected updatingSubjectName = signal<string | null>(null);
   protected addingGuest = signal<{ [episodeId: string]: string }>({});
+  protected readonly curatedEpisodeIds = signal<string[]>([]);
+  protected readonly curatedUpdatedAt = signal<string | null>(null);
+  protected readonly curatedIdSet = computed(() => new Set(this.curatedEpisodeIds()));
 
   private destroyRef = inject(DestroyRef);
   private route = inject(ActivatedRoute);
   protected auth = inject(AuthServiceWrapper);
   protected authRoles = toSignal(this.auth.roles, { initialValue: [] as string[] });
   private readonly platformId = inject(PLATFORM_ID);
+  private readonly heroCuration = inject(HeroCurationService);
   private snapOffsetObserver: ResizeObserver | undefined;
 
   constructor(
@@ -123,6 +131,8 @@ export class OutgoingEpisodesApiComponent implements AfterViewInit {
     if (!isPlatformBrowser(this.platformId)) {
       return;
     }
+
+    void this.fetchHeroCuration();
 
     const daysValue: string | null = localStorage.getItem(daysKey);
     if (daysValue && parseInt(daysValue)) {
@@ -236,6 +246,47 @@ export class OutgoingEpisodesApiComponent implements AfterViewInit {
 
   languageBadge(episode: ApiEpisode): LanguageFlagBadge | undefined {
     return languageFlagBadgeForEpisode(episode);
+  }
+
+  showHeroPromote(episode: ApiEpisode): boolean {
+    return (
+      this.authRoles().includes('Curator') &&
+      (this.curatedIdSet().has(episode.id) || isWithinHeroWeek(episode.release))
+    );
+  }
+
+  async togglePromote(episode: ApiEpisode): Promise<void> {
+    if (!this.showHeroPromote(episode)) {
+      return;
+    }
+    const ids = [...this.curatedEpisodeIds()];
+    const idx = ids.indexOf(episode.id);
+    if (idx >= 0) {
+      ids.splice(idx, 1);
+    } else {
+      ids.unshift(episode.id);
+    }
+    await this.persistHeroCuration(ids);
+  }
+
+  private async fetchHeroCuration(): Promise<void> {
+    const curation = await this.heroCuration.getHeroCuration();
+    this.curatedEpisodeIds.set(curation.episodeIds ?? []);
+    this.curatedUpdatedAt.set(curation.updatedAt ?? null);
+  }
+
+  private async persistHeroCuration(ids: string[]): Promise<void> {
+    const previous = this.curatedEpisodeIds();
+    const previousUpdatedAt = this.curatedUpdatedAt();
+    this.curatedEpisodeIds.set(ids);
+    try {
+      const saved = await this.heroCuration.setHeroCuration(ids, previousUpdatedAt);
+      this.curatedEpisodeIds.set(saved.episodeIds);
+      this.curatedUpdatedAt.set(saved.updatedAt);
+    } catch {
+      this.curatedEpisodeIds.set(previous);
+      this.curatedUpdatedAt.set(previousUpdatedAt);
+    }
   }
 
   loadingSubjectName(episodeId: string): string | null {

--- a/cultpodcasts/src/app/podcast-episode/podcast-episode.component.sass
+++ b/cultpodcasts/src/app/podcast-episode/podcast-episode.component.sass
@@ -149,9 +149,10 @@
             -webkit-mask-image: linear-gradient(90deg, transparent 0, #000 36px, #000)
             mask-image: linear-gradient(90deg, transparent 0, #000 36px, #000)
         // Wide: Ken Burns on the shared motion layer (sharp art + left blur together).
+        // Zoom toward the right-anchored art edge so scale does not crop it off.
         &.is-kenburns .episode-backdrop__motion
             animation: nflx-ken-burns var(--episode-ken-burns) ease-out forwards
-            transform-origin: 70% 40%
+            transform-origin: 90% 40%
     // Let the left edge blur read through under copy — avoid a solid black slab.
     .episode-backdrop__scrim
         background: linear-gradient(90deg, rgba(0, 0, 0, 0.78) 0%, rgba(0, 0, 0, 0.55) 18%, rgba(0, 0, 0, 0.28) 36%, rgba(0, 0, 0, 0.1) 52%, transparent 68%), linear-gradient(to top, #0b0b0b 0%, transparent 42%), linear-gradient(to bottom, rgba(0, 0, 0, 0.45) 0%, transparent 20%)

--- a/cultpodcasts/src/app/rail-order.spec.ts
+++ b/cultpodcasts/src/app/rail-order.spec.ts
@@ -1,0 +1,78 @@
+import {
+  dayRailEntry,
+  dayRailLabel,
+  defaultRailOrder,
+  isDayRailEntry,
+  normalizeRailOrder,
+  parseDayRailOffset,
+  subjectEntries,
+  toggleSubjectInRailOrder,
+} from './rail-order';
+
+describe('rail-order', () => {
+  it('encodes and labels relative day slots as n, n−1, n−2', () => {
+    expect(dayRailEntry(0)).toBe('day:0');
+    expect(dayRailEntry(2)).toBe('day:2');
+    expect(parseDayRailOffset('day:0')).toBe(0);
+    expect(parseDayRailOffset('day:3')).toBe(3);
+    expect(parseDayRailOffset('day:2026-08-01')).toBeNull();
+    expect(parseDayRailOffset('Scientology')).toBeNull();
+    expect(isDayRailEntry('day:1')).toBe(true);
+    expect(dayRailLabel(0)).toBe('n');
+    expect(dayRailLabel(1)).toBe('n−1');
+    expect(dayRailLabel(3)).toBe('n−3');
+  });
+
+  it('defaults to newest day, then subjects, then older days', () => {
+    expect(defaultRailOrder(3, ['A', 'B'])).toEqual([
+      'day:0',
+      'A',
+      'B',
+      'day:1',
+      'day:2',
+    ]);
+    expect(defaultRailOrder(0, ['A'])).toEqual(['A']);
+    expect(defaultRailOrder(1, [])).toEqual(['day:0']);
+  });
+
+  it('upgrades legacy subject-only lists with the default day interleave', () => {
+    const { order, changed } = normalizeRailOrder(
+      ['NXIVM', 'gone', 'NXIVM', 'Scientology'],
+      3,
+      ['NXIVM', 'Scientology']
+    );
+    expect(order).toEqual(['day:0', 'NXIVM', 'Scientology', 'day:1', 'day:2']);
+    expect(changed).toBe(true);
+  });
+
+  it('preserves mixed order, drops stale subjects, injects missing days', () => {
+    const { order, changed } = normalizeRailOrder(
+      ['day:1', 'Scientology', 'day:0', 'gone', 'day:9', 'day:1'],
+      3,
+      ['Scientology', 'NXIVM']
+    );
+    expect(order).toEqual(['day:1', 'Scientology', 'day:0', 'day:2']);
+    expect(changed).toBe(true);
+  });
+
+  it('reports unchanged when order already matches the week', () => {
+    const saved = ['day:0', 'Scientology', 'day:1'];
+    expect(normalizeRailOrder(saved, 2, ['Scientology'])).toEqual({
+      order: saved,
+      changed: false,
+    });
+  });
+
+  it('filters subject entries and toggles pins without dropping days', () => {
+    expect(subjectEntries(['day:0', 'A', 'day:1', 'B'])).toEqual(['A', 'B']);
+    expect(toggleSubjectInRailOrder(['day:0', 'A', 'day:1'], 'A')).toEqual([
+      'day:0',
+      'day:1',
+    ]);
+    expect(toggleSubjectInRailOrder(['day:0', 'day:1'], 'B')).toEqual([
+      'day:0',
+      'day:1',
+      'B',
+    ]);
+  });
+});

--- a/cultpodcasts/src/app/rail-order.ts
+++ b/cultpodcasts/src/app/rail-order.ts
@@ -1,0 +1,130 @@
+/**
+ * Homepage rail order mixes pinned subjects with relative day slots.
+ *
+ * Day entries use `day:{offset}` where offset 0 is the newest day (n),
+ * 1 is n−1, 2 is n−2, and so on. Absolute dates are never stored — slots
+ * stay put as the calendar rolls.
+ */
+
+export const DAY_RAIL_PREFIX = 'day:';
+
+const DAY_RAIL_RE = /^day:(\d+)$/;
+
+export function dayRailEntry(offset: number): string {
+  return `${DAY_RAIL_PREFIX}${offset}`;
+}
+
+export function parseDayRailOffset(entry: string): number | null {
+  const match = DAY_RAIL_RE.exec(entry);
+  if (!match) {
+    return null;
+  }
+  return Number.parseInt(match[1], 10);
+}
+
+export function isDayRailEntry(entry: string): boolean {
+  return parseDayRailOffset(entry) !== null;
+}
+
+/** UI / dialog label: n, n−1, n−2, … */
+export function dayRailLabel(offset: number): string {
+  return offset === 0 ? 'n' : `n−${offset}`;
+}
+
+export function subjectEntries(order: string[]): string[] {
+  return order.filter((entry) => !isDayRailEntry(entry));
+}
+
+/**
+ * Legacy default: newest day, then pinned subjects, then older days
+ * (n−1, n−2, …).
+ */
+export function defaultRailOrder(dayCount: number, subjects: string[]): string[] {
+  if (dayCount <= 0) {
+    return [...subjects];
+  }
+  return [
+    dayRailEntry(0),
+    ...subjects,
+    ...Array.from({ length: dayCount - 1 }, (_, i) => dayRailEntry(i + 1)),
+  ];
+}
+
+/**
+ * Resolve a saved order against the current week: drop ineligible subjects and
+ * out-of-range day slots; inject any missing day slots. Subject-only legacy
+ * lists get the default day interleave.
+ */
+export function normalizeRailOrder(
+  saved: string[],
+  dayCount: number,
+  eligibleSubjects: ReadonlySet<string> | readonly string[]
+): { order: string[]; changed: boolean } {
+  const eligible =
+    eligibleSubjects instanceof Set
+      ? eligibleSubjects
+      : new Set(eligibleSubjects);
+
+  if (!saved.some(isDayRailEntry)) {
+    const subjects: string[] = [];
+    const seen = new Set<string>();
+    for (const entry of saved) {
+      if (isDayRailEntry(entry) || !eligible.has(entry) || seen.has(entry)) {
+        continue;
+      }
+      seen.add(entry);
+      subjects.push(entry);
+    }
+    const order = defaultRailOrder(dayCount, subjects);
+    return {
+      order,
+      changed:
+        order.length !== saved.length || order.some((entry, i) => entry !== saved[i]),
+    };
+  }
+
+  const seenDays = new Set<number>();
+  const seenSubjects = new Set<string>();
+  const order: string[] = [];
+
+  for (const entry of saved) {
+    const offset = parseDayRailOffset(entry);
+    if (offset !== null) {
+      if (offset >= dayCount || seenDays.has(offset)) {
+        continue;
+      }
+      seenDays.add(offset);
+      order.push(dayRailEntry(offset));
+      continue;
+    }
+    if (!eligible.has(entry) || seenSubjects.has(entry)) {
+      continue;
+    }
+    seenSubjects.add(entry);
+    order.push(entry);
+  }
+
+  for (let offset = 0; offset < dayCount; offset++) {
+    if (!seenDays.has(offset)) {
+      order.push(dayRailEntry(offset));
+    }
+  }
+
+  return {
+    order,
+    changed:
+      order.length !== saved.length || order.some((entry, i) => entry !== saved[i]),
+  };
+}
+
+/**
+ * Toggle a subject pin while preserving day-slot positions. New pins append
+ * after the last entry.
+ */
+export function toggleSubjectInRailOrder(order: string[], subject: string): string[] {
+  const idx = order.indexOf(subject);
+  if (idx >= 0) {
+    return order.filter((_, i) => i !== idx);
+  }
+  return [...order, subject];
+}

--- a/cultpodcasts/src/app/rail-subjects.spec.ts
+++ b/cultpodcasts/src/app/rail-subjects.spec.ts
@@ -90,6 +90,17 @@ describe('rail-subjects', () => {
     });
   });
 
+  it('prunes mixed day/subject order against the current day count', () => {
+    const candidates = collectSubjectRailCandidates(episodes);
+    const result = pruneRailSubjectsToWeek(
+      ['day:1', 'Gone', 'day:0', 'Scientology', 'day:5'],
+      candidates,
+      2
+    );
+    expect(result.subjects).toEqual(['day:1', 'day:0', 'Scientology']);
+    expect(result.pruned).toBe(true);
+  });
+
   it('builds rails from pinned subjects only with no autofill', () => {
     const candidates = collectSubjectRailCandidates(episodes);
     expect(

--- a/cultpodcasts/src/app/rail-subjects.ts
+++ b/cultpodcasts/src/app/rail-subjects.ts
@@ -1,4 +1,5 @@
 import { HomepageEpisode } from './homepage-episode.interface';
+import { isDayRailEntry, normalizeRailOrder, subjectEntries } from './rail-order';
 
 /** A subject needs at least this many week episodes to earn a rail. */
 export const SUBJECT_RAIL_MIN_EPISODES = 3;
@@ -55,17 +56,24 @@ export function collectSubjectRailCandidates(
 }
 
 /**
- * Drop pinned subjects that no longer qualify for a rail this week.
- * Returns whether the list changed (caller should PUT when a curator is signed in).
+ * Drop pinned subjects (and out-of-range day slots) that no longer belong
+ * this week. Day slots use relative offsets (n, n−1, …). Returns whether the
+ * list changed (local display prune — server cron owns Durable Object writes).
  */
 export function pruneRailSubjectsToWeek(
-  pinnedSubjects: string[],
-  candidates: SubjectRailCandidate[]
+  railOrder: string[],
+  candidates: SubjectRailCandidate[],
+  dayCount: number = 0
 ): { subjects: string[]; pruned: boolean } {
   const eligible = new Set(candidates.map((c) => c.subject));
+  if (railOrder.some(isDayRailEntry) || dayCount > 0) {
+    const { order, changed } = normalizeRailOrder(railOrder, dayCount, eligible);
+    return { subjects: order, pruned: changed };
+  }
+
   const seen = new Set<string>();
   const subjects: string[] = [];
-  for (const subject of pinnedSubjects) {
+  for (const subject of subjectEntries(railOrder)) {
     if (!eligible.has(subject) || seen.has(subject)) {
       continue;
     }
@@ -73,19 +81,20 @@ export function pruneRailSubjectsToWeek(
     subjects.push(subject);
   }
   const pruned =
-    subjects.length !== pinnedSubjects.length ||
-    subjects.some((subject, i) => subject !== pinnedSubjects[i]);
+    subjects.length !== railOrder.length ||
+    subjects.some((subject, i) => subject !== railOrder[i]);
   return { subjects, pruned };
 }
 
 /**
  * Build homepage subject rails from curator pins only — no popularity autofill.
- * Order follows the pinned list; unknown / ineligible pins are skipped.
+ * Order follows the pinned list; day slots and unknown / ineligible pins are skipped.
  */
 export function buildSubjectRails(
-  pinnedSubjects: string[],
+  railOrder: string[],
   candidates: SubjectRailCandidate[]
 ): SubjectRailCandidate[] {
+  const pinnedSubjects = subjectEntries(railOrder);
   if (pinnedSubjects.length === 0 || candidates.length === 0) {
     return [];
   }

--- a/cultpodcasts/src/app/rails-manage-dialog/rails-manage-dialog.component.html
+++ b/cultpodcasts/src/app/rails-manage-dialog/rails-manage-dialog.component.html
@@ -1,27 +1,37 @@
-<h2 mat-dialog-title>Manage subject rails</h2>
+<h2 mat-dialog-title>Manage rails</h2>
 
 <mat-dialog-content class="rails-manage">
   <p class="rails-manage__lede">
-    Pin subjects to show them as homepage rails. Drag to reorder. Only pinned subjects appear — nothing is autofilled.
+    Pin subjects and drag to reorder homepage rails. Day rails (n, n−1, …) stay in the list — reorder them, but they cannot be removed.
   </p>
 
-  @if (pinned().length === 0) {
-  <p class="rails-manage__empty">No pinned subjects yet. Use the pin on a rail heading, or add one below.</p>
+  @if (rows().length === 0) {
+  <p class="rails-manage__empty">No rails yet. Use the pin on a rail heading, or add a subject below.</p>
   } @else {
   <ul class="rails-manage__list" cdkDropList (cdkDropListDropped)="drop($event)">
-    @for (subject of pinned(); track subject; let i = $index) {
-    <li class="rails-manage__item" cdkDrag>
+    @for (row of rows(); track row.id; let i = $index) {
+    <li class="rails-manage__item" [class.rails-manage__item--day]="row.kind === 'day'" cdkDrag>
       <button type="button" class="rails-manage__handle" cdkDragHandle aria-label="Drag to reorder">
         <mat-icon>drag_indicator</mat-icon>
       </button>
       <span class="rails-manage__index">{{ i + 1 }}</span>
-      <app-subject-chip [subject]="subject" />
-      <span class="rails-manage__count">{{ episodeCount(subject) }} new</span>
+      @if (row.kind === 'day') {
+      <span class="rails-manage__day" [attr.aria-label]="'Day rail ' + row.label">{{ row.label }}</span>
+      } @else {
+      <app-subject-chip [subject]="row.label" />
+      }
+      <span class="rails-manage__count">{{ row.episodeCount }} new</span>
+      @if (row.locked) {
+      <span class="rails-manage__locked" aria-hidden="true">
+        <mat-icon>lock</mat-icon>
+      </span>
+      } @else {
       <button type="button" mat-icon-button class="rails-manage__remove"
-        [attr.aria-label]="'Unpin ' + displayCatalogName(subject)"
-        (click)="remove(subject)">
+        [attr.aria-label]="'Unpin ' + displayCatalogName(row.label)"
+        (click)="remove(row.id)">
         <mat-icon>close</mat-icon>
       </button>
+      }
     </li>
     }
   </ul>

--- a/cultpodcasts/src/app/rails-manage-dialog/rails-manage-dialog.component.sass
+++ b/cultpodcasts/src/app/rails-manage-dialog/rails-manage-dialog.component.sass
@@ -69,6 +69,36 @@
 .rails-manage__pin
     flex-shrink: 0
 
+.rails-manage__day
+    display: inline-flex
+    align-items: center
+    justify-content: center
+    min-width: 2.75rem
+    padding: 4px 10px
+    border-radius: 999px
+    border: 1px solid color-mix(in srgb, var(--cp-amber, #e8a23a) 55%, transparent)
+    color: var(--cp-amber, #e8a23a)
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace
+    font-size: 0.85rem
+    font-weight: 700
+    letter-spacing: 0.02em
+
+.rails-manage__item--day
+    border-color: color-mix(in srgb, var(--cp-amber, #e8a23a) 35%, transparent)
+
+.rails-manage__locked
+    display: inline-flex
+    align-items: center
+    justify-content: center
+    flex-shrink: 0
+    width: 40px
+    height: 40px
+    color: color-mix(in srgb, var(--mat-sys-on-surface, #fff) 40%, transparent)
+    mat-icon
+        font-size: 18px
+        width: 18px
+        height: 18px
+
 .rails-manage__remove
     flex-shrink: 0
 

--- a/cultpodcasts/src/app/rails-manage-dialog/rails-manage-dialog.component.spec.ts
+++ b/cultpodcasts/src/app/rails-manage-dialog/rails-manage-dialog.component.spec.ts
@@ -20,14 +20,15 @@ describe('RailsManageDialogComponent', () => {
     heroCuration = {
       setRailSubjects: vi.fn().mockResolvedValue({
         episodeIds: [],
-        railSubjects: ['Scientology', 'NXIVM'],
+        railSubjects: ['day:0', 'Scientology', 'NXIVM', 'day:1'],
         updatedAt: 't1',
       }),
     };
     const data: RailsManageDialogData = {
-      pinned: ['Scientology'],
+      order: ['day:0', 'Scientology', 'day:1'],
       eligible: ['Scientology', 'NXIVM', 'Flat Earth'],
       episodeCounts: { Scientology: 5, NXIVM: 4, 'Flat Earth': 3 },
+      dayEpisodeCounts: [10, 8],
       updatedAt: 't0',
     };
 
@@ -51,25 +52,67 @@ describe('RailsManageDialogComponent', () => {
     expect(component['available']()).toEqual(['NXIVM', 'Flat Earth']);
   });
 
-  it('pins, removes, and reorders', () => {
-    component.pin('NXIVM');
-    expect(component['pinned']()).toEqual(['Scientology', 'NXIVM']);
-    expect(component['available']()).toEqual(['Flat Earth']);
-
-    component.drop({ previousIndex: 0, currentIndex: 1 } as CdkDragDrop<string[]>);
-    expect(component['pinned']()).toEqual(['NXIVM', 'Scientology']);
-
-    component.remove('NXIVM');
-    expect(component['pinned']()).toEqual(['Scientology']);
+  it('builds locked day rows labeled n / n−1', () => {
+    expect(component['rows']()).toEqual([
+      {
+        id: 'day:0',
+        kind: 'day',
+        label: 'n',
+        episodeCount: 10,
+        locked: true,
+      },
+      {
+        id: 'Scientology',
+        kind: 'subject',
+        label: 'Scientology',
+        episodeCount: 5,
+        locked: false,
+      },
+      {
+        id: 'day:1',
+        kind: 'day',
+        label: 'n−1',
+        episodeCount: 8,
+        locked: true,
+      },
+    ]);
   });
 
-  it('saves pinned subjects and closes with the server response', async () => {
+  it('pins, reorders, and refuses to remove day slots', () => {
+    component.pin('NXIVM');
+    expect(component['order']()).toEqual([
+      'day:0',
+      'Scientology',
+      'day:1',
+      'NXIVM',
+    ]);
+    expect(component['available']()).toEqual(['Flat Earth']);
+
+    component.drop({ previousIndex: 0, currentIndex: 2 } as CdkDragDrop<string[]>);
+    expect(component['order']()).toEqual([
+      'Scientology',
+      'day:1',
+      'day:0',
+      'NXIVM',
+    ]);
+
+    component.remove('day:0');
+    expect(component['order']()).toContain('day:0');
+
+    component.remove('Scientology');
+    expect(component['order']()).toEqual(['day:1', 'day:0', 'NXIVM']);
+  });
+
+  it('saves mixed order and closes with the server response', async () => {
     component.pin('NXIVM');
     await component.save();
-    expect(heroCuration.setRailSubjects).toHaveBeenCalledWith(['Scientology', 'NXIVM'], 't0');
+    expect(heroCuration.setRailSubjects).toHaveBeenCalledWith(
+      ['day:0', 'Scientology', 'day:1', 'NXIVM'],
+      't0'
+    );
     expect(dialogRef.close).toHaveBeenCalledWith({
       saved: true,
-      railSubjects: ['Scientology', 'NXIVM'],
+      railSubjects: ['day:0', 'Scientology', 'NXIVM', 'day:1'],
       updatedAt: 't1',
     });
   });

--- a/cultpodcasts/src/app/rails-manage-dialog/rails-manage-dialog.component.ts
+++ b/cultpodcasts/src/app/rails-manage-dialog/rails-manage-dialog.component.ts
@@ -7,13 +7,22 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { HeroCurationConflictError, HeroCurationService } from '../hero-curation.service';
 import { displayCatalogName } from '../display-catalog-name';
 import { SubjectChipComponent } from '../subject-chip/subject-chip.component';
+import {
+  dayRailLabel,
+  isDayRailEntry,
+  parseDayRailOffset,
+  subjectEntries,
+} from '../rail-order';
 
 export interface RailsManageDialogData {
-  pinned: string[];
+  /** Mixed order: `day:{offset}` slots and subject names. */
+  order: string[];
   /** Eligible subjects this week, popularity-sorted. */
   eligible: string[];
   /** Episode count this week, keyed by subject name. */
   episodeCounts: Record<string, number>;
+  /** Episode count per relative day offset (0 = n). */
+  dayEpisodeCounts: number[];
   updatedAt: string | null;
 }
 
@@ -22,6 +31,15 @@ export interface RailsManageDialogResult {
   railSubjects?: string[];
   updatedAt?: string | null;
   conflict?: boolean;
+}
+
+export interface RailsManageRow {
+  id: string;
+  kind: 'day' | 'subject';
+  /** Subject name or day label (n, n−1, …). */
+  label: string;
+  episodeCount: number;
+  locked: boolean;
 }
 
 @Component({
@@ -44,25 +62,31 @@ export class RailsManageDialogComponent {
     MatDialogRef<RailsManageDialogComponent, RailsManageDialogResult>
   );
 
-  protected readonly pinned = signal<string[]>([]);
+  protected readonly order = signal<string[]>([]);
   private readonly eligible: string[];
   private readonly episodeCounts: Record<string, number>;
+  private readonly dayEpisodeCounts: number[];
   private readonly expectedUpdatedAt: string | null;
   protected readonly saving = signal(false);
   protected readonly error = signal(false);
   protected readonly conflict = signal(false);
   protected readonly displayCatalogName = displayCatalogName;
 
+  protected readonly rows = computed((): RailsManageRow[] =>
+    this.order().map((id) => this.toRow(id))
+  );
+
   /** Eligible subjects not currently pinned. */
   protected readonly available = computed(() => {
-    const pinned = new Set(this.pinned());
+    const pinned = new Set(subjectEntries(this.order()));
     return this.eligible.filter((subject) => !pinned.has(subject));
   });
 
   constructor(@Inject(MAT_DIALOG_DATA) data: RailsManageDialogData) {
-    this.pinned.set([...data.pinned]);
+    this.order.set([...data.order]);
     this.eligible = data.eligible;
     this.episodeCounts = data.episodeCounts ?? {};
+    this.dayEpisodeCounts = data.dayEpisodeCounts ?? [];
     this.expectedUpdatedAt = data.updatedAt;
   }
 
@@ -71,20 +95,23 @@ export class RailsManageDialogComponent {
   }
 
   drop(event: CdkDragDrop<string[]>): void {
-    const list = [...this.pinned()];
+    const list = [...this.order()];
     moveItemInArray(list, event.previousIndex, event.currentIndex);
-    this.pinned.set(list);
+    this.order.set(list);
   }
 
   remove(subject: string): void {
-    this.pinned.set(this.pinned().filter((s) => s !== subject));
+    if (isDayRailEntry(subject)) {
+      return;
+    }
+    this.order.set(this.order().filter((s) => s !== subject));
   }
 
   pin(subject: string): void {
-    if (this.pinned().includes(subject)) {
+    if (this.order().includes(subject)) {
       return;
     }
-    this.pinned.set([...this.pinned(), subject]);
+    this.order.set([...this.order(), subject]);
   }
 
   close(): void {
@@ -97,7 +124,7 @@ export class RailsManageDialogComponent {
     this.conflict.set(false);
     try {
       const result = await this.heroCuration.setRailSubjects(
-        this.pinned(),
+        this.order(),
         this.expectedUpdatedAt
       );
       this.dialogRef.close({
@@ -119,5 +146,25 @@ export class RailsManageDialogComponent {
       this.error.set(true);
       this.saving.set(false);
     }
+  }
+
+  private toRow(id: string): RailsManageRow {
+    const offset = parseDayRailOffset(id);
+    if (offset !== null) {
+      return {
+        id,
+        kind: 'day',
+        label: dayRailLabel(offset),
+        episodeCount: this.dayEpisodeCounts[offset] ?? 0,
+        locked: true,
+      };
+    }
+    return {
+      id,
+      kind: 'subject',
+      label: id,
+      episodeCount: this.episodeCounts[id] ?? 0,
+      locked: false,
+    };
   }
 }

--- a/cultpodcasts/src/app/search-bar/search-bar.component.html
+++ b/cultpodcasts/src/app/search-bar/search-bar.component.html
@@ -4,8 +4,12 @@
             <mat-form-field id="searchbox" subscriptSizing="dynamic">
                 <mat-chip-grid #chips>
                     @if (searchChip()) {
-                    <mat-chip (removed)="removeSearchChip()">
-                        <span class="chiptext">{{searchChip()}}</span>
+                    <mat-chip (removed)="removeSearchChip()"
+                        [class.search-chip--subject]="searchBoxMode() === SearchBoxMode.Subject"
+                        [style.--search-chip-bg]="subjectChipColor()?.background"
+                        [style.--search-chip-border]="subjectChipColor()?.border"
+                        [style.--search-chip-fg]="subjectChipColor()?.text">
+                        <span class="chiptext">{{chipLabel()}}</span>
                         <mat-icon matChipRemove>cancel</mat-icon>
                     </mat-chip>
                     }

--- a/cultpodcasts/src/app/search-bar/search-bar.component.sass
+++ b/cultpodcasts/src/app/search-bar/search-bar.component.sass
@@ -54,6 +54,24 @@
                     display: block
                     overflow: hidden
                     text-overflow: ellipsis
+                &.search-chip--subject
+                    --mdc-chip-elevated-container-color: var(--search-chip-bg)
+                    --mdc-chip-outline-color: var(--search-chip-border)
+                    --mdc-chip-label-text-color: var(--search-chip-fg)
+                    --mdc-chip-with-trailing-icon-trailing-icon-color: var(--search-chip-fg)
+                    border: 1px solid var(--search-chip-border)
+                    background: var(--search-chip-bg) !important
+                    color: var(--search-chip-fg) !important
+                    .mdc-evolution-chip__action--primary,
+                    .mdc-evolution-chip__text-label,
+                    .mat-mdc-chip-action-label,
+                    .chiptext
+                        color: var(--search-chip-fg) !important
+                    .mat-mdc-chip-remove,
+                    button.mat-mdc-chip-remove,
+                    mat-icon
+                        color: var(--search-chip-fg) !important
+                        opacity: 0.85
             input.mat-mdc-chip-input
                 flex: 1 0 10px
         #search-suggestions-listbox

--- a/cultpodcasts/src/app/search-bar/search-bar.component.ts
+++ b/cultpodcasts/src/app/search-bar/search-bar.component.ts
@@ -3,6 +3,7 @@ import {
   Component,
   ElementRef,
   ViewChild,
+  computed,
   signal
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
@@ -21,6 +22,8 @@ import { MatChipsModule } from '@angular/material/chips';
 import { MatInputModule } from '@angular/material/input';
 import { MatIconModule } from '@angular/material/icon';
 import { TextFieldModule } from '@angular/cdk/text-field';
+import { displayCatalogName } from '../display-catalog-name';
+import { subjectColor } from '../subject-color';
 
 const SUGGESTION_DEBOUNCE_MS = 150;
 
@@ -44,11 +47,26 @@ const SUGGESTION_DEBOUNCE_MS = 150;
 })
 
 export class SearchBarComponent {
+  protected readonly SearchBoxMode = SearchBoxMode;
   protected readonly searchChip = signal<string | null>(null);
   protected readonly searchBoxMode = signal(SearchBoxMode.Default);
   protected readonly suggestions = signal<Suggestion[]>([]);
   protected readonly suggestionsOpen = signal<boolean>(false);
   protected readonly activeSuggestionIndex = signal<number>(-1);
+
+  /** Subject-mode chip uses the same deterministic colour as app-subject-chip. */
+  protected readonly subjectChipColor = computed(() => {
+    if (this.searchBoxMode() !== SearchBoxMode.Subject) {
+      return null;
+    }
+    const chip = this.searchChip();
+    return chip ? subjectColor(chip) : null;
+  });
+
+  protected readonly chipLabel = computed(() => {
+    const chip = this.searchChip();
+    return chip ? displayCatalogName(chip) : '';
+  });
 
   @ViewChild('searchBox', { static: true })
   searchBox: ElementRef | undefined;

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -257,8 +257,22 @@ mat-card.curator-card > button.curator-card__overflow {
   z-index: 3;
 }
 
+/* Hero star sits immediately left of the kebab. */
+mat-card.curator-card > .curator-card__promote {
+  position: absolute;
+  top: 10px;
+  right: 48px;
+  left: auto;
+  z-index: 3;
+  line-height: 0;
+}
+
 mat-card.curator-card mat-card-header {
   padding-right: 40px;
+}
+
+mat-card.curator-card:has(> .curator-card__promote) mat-card-header {
+  padding-right: 88px;
 }
 
 mat-card.curator-card mat-card-title {

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -233,6 +233,7 @@ mat-card.curator-card {
 }
 
 .curator-card__art {
+  position: relative;
   flex: 0 0 88px;
   width: 88px;
   min-width: 0;


### PR DESCRIPTION
## Summary
- Manage rails shows relative day slots (`n`, `n−1`, …) in the drag list — reorderable, not removable
- Homepage rail composition follows the mixed curated order; legacy subject-only lists keep the default n → subjects → older days interleave
- Curators can star past-week episodes from Review / Outgoing so they appear in the homepage hero
- Ken Burns on wide hero/episode art zooms from `90%` (right-anchored) so the right edge is not cropped
- Depends on Api support for `day:{offset}` entries in `railSubjects`

## Test plan
- [x] As Curator, open Manage rails — day rows show as n / n−1 / … with lock icons
- [x] Drag a day rail between subjects, Save, confirm homepage order matches
- [x] Confirm day rows cannot be removed; subjects still pin/unpin
- [x] On Review / Outgoing, star a past-week episode and confirm it leads the homepage hero
- [ ] Confirm older-than-a-week episodes have no star
- [ ] On wide viewport, Ken Burns keeps the right edge of hero/episode art visible
- [ ] `npx ng test --watch=false --include=src/app/rail-order.spec.ts --include=src/app/rail-subjects.spec.ts --include=src/app/rails-manage-dialog/rails-manage-dialog.component.spec.ts --include=src/app/homepage-api/homepage-api.component.spec.ts --include=src/app/hero-slides.spec.ts`
