### PR TITLE
fix(ui): avoid truncating chips when width allows

### DIFF
--- a/cultpodcasts/src/app/app.component.sass
+++ b/cultpodcasts/src/app/app.component.sass
@@ -184,8 +184,6 @@
             letter-spacing: 0
             background: var(--nflx-accent, #e8a23a) !important
             color: #111 !important
-        .chiptext
-            max-width: 5.5rem
 
 @media screen and (max-width: 700px)
     .chrome-search--docked
@@ -194,8 +192,6 @@
                 padding-left: 8px
                 padding-right: 8px
                 font-size: 0.75rem
-            .chiptext
-                max-width: 3.5rem
 
 @media screen and (max-width: 599.9px)
     .chrome-search--docked
@@ -209,8 +205,6 @@
                 padding-left: 6px
                 padding-right: 6px
                 font-size: 0.7rem
-            .chiptext
-                max-width: 2.75rem
 
 // Homepage at top: dark glass over the billboard.
 .home-shell:not(.chrome-stuck) .chrome-search

--- a/cultpodcasts/src/app/browse-facet-scroller.directive.ts
+++ b/cultpodcasts/src/app/browse-facet-scroller.directive.ts
@@ -1,0 +1,66 @@
+import {
+  AfterViewInit,
+  Directive,
+  ElementRef,
+  OnDestroy,
+  inject,
+  signal,
+} from '@angular/core';
+
+/**
+ * Adds `.browse-facet__scroller--overflow` when facet pills exceed the row width,
+ * so the fade mask only appears when scrolling is actually needed.
+ */
+@Directive({
+  selector: '.browse-facet__scroller',
+  standalone: true,
+  host: {
+    '[class.browse-facet__scroller--overflow]': 'overflows()',
+  },
+})
+export class BrowseFacetScrollerDirective implements AfterViewInit, OnDestroy {
+  private readonly el = inject<ElementRef<HTMLElement>>(ElementRef);
+  readonly overflows = signal(false);
+
+  private resizeObserver?: ResizeObserver;
+  private mutationObserver?: MutationObserver;
+  private measureRaf = 0;
+
+  ngAfterViewInit(): void {
+    const node = this.el.nativeElement;
+    this.scheduleMeasure();
+
+    if (typeof ResizeObserver !== 'undefined') {
+      this.resizeObserver = new ResizeObserver(() => this.scheduleMeasure());
+      this.resizeObserver.observe(node);
+    }
+
+    if (typeof MutationObserver !== 'undefined') {
+      this.mutationObserver = new MutationObserver(() => this.scheduleMeasure());
+      this.mutationObserver.observe(node, { childList: true, subtree: true, characterData: true });
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.resizeObserver?.disconnect();
+    this.mutationObserver?.disconnect();
+    if (this.measureRaf) {
+      cancelAnimationFrame(this.measureRaf);
+    }
+  }
+
+  private scheduleMeasure(): void {
+    if (this.measureRaf) {
+      cancelAnimationFrame(this.measureRaf);
+    }
+    this.measureRaf = requestAnimationFrame(() => {
+      this.measureRaf = 0;
+      this.measure();
+    });
+  }
+
+  private measure(): void {
+    const node = this.el.nativeElement;
+    this.overflows.set(node.scrollWidth > node.clientWidth + 1);
+  }
+}

--- a/cultpodcasts/src/app/podcast-api/podcast-api.component.ts
+++ b/cultpodcasts/src/app/podcast-api/podcast-api.component.ts
@@ -32,6 +32,7 @@ import { SearchIndexerState } from '../search-indexer-state.interface';
 import { EpisodePosterComponent } from '../episode-poster/episode-poster.component';
 import { SiteLoadingComponent } from '../site-loading/site-loading.component';
 import { BrowseLoadingSkeletonComponent } from '../browse-loading-skeleton/browse-loading-skeleton.component';
+import { BrowseFacetScrollerDirective } from '../browse-facet-scroller.directive';
 import { SearchDisplayEpisode } from '../search-result-links';
 import { startEpisodePlayback } from '../episode-embed';
 import { PlayerService } from '../player.service';
@@ -52,6 +53,7 @@ const sortParamDateDesc: string = "date-desc";
     EpisodePosterComponent,
     SiteLoadingComponent,
     BrowseLoadingSkeletonComponent,
+    BrowseFacetScrollerDirective,
   ],
   templateUrl: './podcast-api.component.html',
   styleUrl: './podcast-api.component.sass',

--- a/cultpodcasts/src/app/search-api/search-api.component.ts
+++ b/cultpodcasts/src/app/search-api/search-api.component.ts
@@ -15,6 +15,7 @@ import { InfiniteScrollStrategy } from '../infinite-scroll-strategy';
 import { EpisodePosterComponent } from '../episode-poster/episode-poster.component';
 import { SiteLoadingComponent } from '../site-loading/site-loading.component';
 import { BrowseLoadingSkeletonComponent } from '../browse-loading-skeleton/browse-loading-skeleton.component';
+import { BrowseFacetScrollerDirective } from '../browse-facet-scroller.directive';
 import { SearchDisplayEpisode } from '../search-result-links';
 import { startEpisodePlayback } from '../episode-embed';
 import { SearchResultsFacets } from '../search-results-facets.interface';
@@ -39,6 +40,7 @@ const sortParamDateDesc: string = "date-desc";
     EpisodePosterComponent,
     SiteLoadingComponent,
     BrowseLoadingSkeletonComponent,
+    BrowseFacetScrollerDirective,
   ],
   templateUrl: './search-api.component.html',
   styleUrl: './search-api.component.sass',

--- a/cultpodcasts/src/app/search-bar/search-bar.component.sass
+++ b/cultpodcasts/src/app/search-bar/search-bar.component.sass
@@ -49,7 +49,9 @@
                     min-width: 0 !important
                     padding-top: 0 !important
                     padding-bottom: 0 !important
-                    padding-left: 12px !important
+                    // Modest inset; Material outline already supplies the leading edge.
+                    // Narrow overrides reclaim the left gap for the chip.
+                    padding-left: 8px !important
                     padding-right: 12px !important
                     display: flex
                     align-items: center
@@ -61,6 +63,9 @@
                     min-width: 0
                     max-width: 100%
                     flex-wrap: nowrap !important
+                    // Material chip-set often adds leading padding we don't want.
+                    margin-left: 0 !important
+                    padding-left: 0 !important
                 input.mat-mdc-chip-input,
                 #searchtext
                     margin: 0
@@ -164,6 +169,11 @@
 
 // Phone / docked: keep the chip under half the field so "Search" stays readable.
 @container searchbox (max-width: 420px)
+    #searchbox
+        ::ng-deep
+            .mat-mdc-form-field-infix
+                padding-left: 2px !important
+                padding-right: 8px !important
     mat-chip
         max-width: min(10.5rem, 52cqi)
     input.mat-mdc-chip-input

--- a/cultpodcasts/src/app/search-bar/search-bar.component.sass
+++ b/cultpodcasts/src/app/search-bar/search-bar.component.sass
@@ -49,32 +49,41 @@
                     min-width: 0 !important
                     padding-top: 0 !important
                     padding-bottom: 0 !important
-                    // Modest inset; Material outline already supplies the leading edge.
-                    // Narrow overrides reclaim the left gap for the chip.
-                    padding-left: 8px !important
-                    padding-right: 12px !important
+                    // No left pad here — chips sit flush; input carries its own inset.
+                    padding-left: 0 !important
+                    padding-right: 8px !important
                     display: flex
                     align-items: center
                     box-sizing: border-box
                 .mat-mdc-chip-grid,
+                .mat-mdc-chip-set,
                 .mdc-evolution-chip-set__chips
                     align-items: center
                     min-height: 0
                     min-width: 0
                     max-width: 100%
                     flex-wrap: nowrap !important
-                    // Material chip-set often adds leading padding we don't want.
+                    // Material uses margin-left:-8px + chip margin-left:8px; flatten both.
                     margin-left: 0 !important
+                    margin-right: 0 !important
                     padding-left: 0 !important
+                .mat-mdc-chip-set .mdc-evolution-chip,
+                .mat-mdc-chip-grid .mdc-evolution-chip
+                    // Override Material `margin: 4px 0 4px 8px` — that 8px is the gap.
+                    margin: 2px 6px 2px 2px !important
                 input.mat-mdc-chip-input,
                 #searchtext
                     margin: 0
+                    // Inset when there is no chip; after a chip this is the typing gap.
+                    margin-left: 0 !important
+                    padding-left: 10px
                     line-height: 1.25
             mat-chip
                 margin-top: -4px
                 margin-bottom: -4px
-                margin-left: 0
-                margin-right: 8px
+                // Keep in sync with ::ng-deep .mdc-evolution-chip override above.
+                margin-left: 2px !important
+                margin-right: 6px !important
                 // Cap the whole chip (label + remove), not just the text span — otherwise
                 // padding/icon still overflow the field and collide with Search.
                 // Reserve room for the placeholder / typing gap.
@@ -169,11 +178,6 @@
 
 // Phone / docked: keep the chip under half the field so "Search" stays readable.
 @container searchbox (max-width: 420px)
-    #searchbox
-        ::ng-deep
-            .mat-mdc-form-field-infix
-                padding-left: 2px !important
-                padding-right: 8px !important
     mat-chip
         max-width: min(10.5rem, 52cqi)
     input.mat-mdc-chip-input

--- a/cultpodcasts/src/app/search-bar/search-bar.component.sass
+++ b/cultpodcasts/src/app/search-bar/search-bar.component.sass
@@ -10,6 +10,9 @@
         #searchboxwrapper
             position: relative
             flex-grow: 1
+            // Chip label width tracks the field so we only ellipsize when space is tight.
+            container-type: inline-size
+            container-name: searchbox
         #searchbox
             width: 100%
             margin-bottom: 0
@@ -54,6 +57,9 @@
                     display: block
                     overflow: hidden
                     text-overflow: ellipsis
+                    white-space: nowrap
+                    // Leave room for the remove icon + a short typing gap.
+                    max-width: min(36rem, calc(100cqi - 5.5rem))
                 &.search-chip--subject
                     --mdc-chip-elevated-container-color: var(--search-chip-bg)
                     --mdc-chip-outline-color: var(--search-chip-border)
@@ -127,12 +133,7 @@
             letter-spacing: 0.02em
             line-height: 1
 
-@media screen and (min-width: 400px)
+// Very narrow fields: keep a usable typing gap even if the label must shorten.
+@container searchbox (max-width: 220px)
     .chiptext
-        max-width: 150px
-@media screen and (max-width: 400px)
-    .chiptext
-        max-width: 75px
-@media screen and (max-width: 300px)
-    .chiptext
-        max-width: 40px
+        max-width: calc(100cqi - 3.25rem)

--- a/cultpodcasts/src/app/search-bar/search-bar.component.sass
+++ b/cultpodcasts/src/app/search-bar/search-bar.component.sass
@@ -106,8 +106,8 @@
                         color: var(--search-chip-fg) !important
                         opacity: 0.85
             input.mat-mdc-chip-input
-                flex: 1 1 1.5rem
-                min-width: 1.5rem
+                flex: 1 1 4.5rem
+                min-width: 4.5rem
         #search-suggestions-listbox
             position: absolute
             top: calc(100% + 6px)
@@ -162,7 +162,14 @@
             letter-spacing: 0.02em
             line-height: 1
 
-// Very narrow fields: keep a usable typing gap; ellipsize harder.
+// Phone / docked: keep the chip under half the field so "Search" stays readable.
+@container searchbox (max-width: 420px)
+    mat-chip
+        max-width: min(10.5rem, 52cqi)
+    input.mat-mdc-chip-input
+        flex-basis: 4.5rem
+        min-width: 4.5rem
+
 @container searchbox (max-width: 280px)
     mat-chip
-        max-width: calc(100cqi - 4.5rem)
+        max-width: min(8.5rem, 48cqi)

--- a/cultpodcasts/src/app/search-bar/search-bar.component.sass
+++ b/cultpodcasts/src/app/search-bar/search-bar.component.sass
@@ -9,12 +9,15 @@
         gap: 10px
         #searchboxwrapper
             position: relative
-            flex-grow: 1
-            // Chip label width tracks the field so we only ellipsize when space is tight.
+            flex: 1 1 auto
+            min-width: 0
+            // Chip width tracks the field so we only ellipsize when space is tight.
             container-type: inline-size
             container-name: searchbox
         #searchbox
             width: 100%
+            max-width: 100%
+            min-width: 0
             margin-bottom: 0
             height: var(--search-bar-control-h)
             ::ng-deep
@@ -30,20 +33,33 @@
                 .mdc-text-field--no-label
                     height: var(--search-bar-control-h) !important
                     min-height: var(--search-bar-control-h) !important
+                    max-width: 100%
+                    min-width: 0
                     align-items: center !important
                 .mat-mdc-form-field-flex
                     height: var(--search-bar-control-h) !important
+                    max-width: 100%
+                    min-width: 0
                     align-items: center !important
                 .mat-mdc-form-field-infix
                     min-height: var(--search-bar-control-h) !important
+                    // Material defaults a large min-width that blows out narrow docked search.
+                    min-width: 0 !important
+                    width: 100%
+                    max-width: 100%
                     padding-top: 0 !important
                     padding-bottom: 0 !important
                     display: flex
                     align-items: center
+                    overflow: hidden
                 .mat-mdc-chip-grid,
                 .mdc-evolution-chip-set__chips
                     align-items: center
                     min-height: 0
+                    min-width: 0
+                    max-width: 100%
+                    width: 100%
+                    flex-wrap: nowrap !important
                 input.mat-mdc-chip-input,
                 #searchtext
                     margin: 0
@@ -53,13 +69,22 @@
                 margin-bottom: -4px
                 margin-left: 0
                 margin-right: 8px
+                // Cap the whole chip (label + remove), not just the text span — otherwise
+                // padding/icon still overflow the field and collide with Search.
+                max-width: min(36rem, calc(100cqi - 2.75rem))
+                min-width: 0
+                overflow: hidden
+                .mdc-evolution-chip__action--primary,
+                .mdc-evolution-chip__text-label,
+                .mat-mdc-chip-action-label
+                    min-width: 0
+                    overflow: hidden
                 .chiptext
                     display: block
                     overflow: hidden
                     text-overflow: ellipsis
                     white-space: nowrap
-                    // Leave room for the remove icon + a short typing gap.
-                    max-width: min(36rem, calc(100cqi - 5.5rem))
+                    max-width: 100%
                 &.search-chip--subject
                     --mdc-chip-elevated-container-color: var(--search-chip-bg)
                     --mdc-chip-outline-color: var(--search-chip-border)
@@ -79,7 +104,8 @@
                         color: var(--search-chip-fg) !important
                         opacity: 0.85
             input.mat-mdc-chip-input
-                flex: 1 0 10px
+                flex: 1 1 1.5rem
+                min-width: 1.5rem
         #search-suggestions-listbox
             position: absolute
             top: calc(100% + 6px)
@@ -124,6 +150,7 @@
             display: inline-flex
             align-items: center
             justify-content: center
+            flex: 0 0 auto
             height: var(--search-bar-control-h)
             min-height: var(--search-bar-control-h)
             margin: 0
@@ -133,7 +160,7 @@
             letter-spacing: 0.02em
             line-height: 1
 
-// Very narrow fields: keep a usable typing gap even if the label must shorten.
-@container searchbox (max-width: 220px)
-    .chiptext
-        max-width: calc(100cqi - 3.25rem)
+// Very narrow fields: keep a usable typing gap; ellipsize harder.
+@container searchbox (max-width: 280px)
+    mat-chip
+        max-width: calc(100cqi - 2rem)

--- a/cultpodcasts/src/app/search-bar/search-bar.component.sass
+++ b/cultpodcasts/src/app/search-bar/search-bar.component.sass
@@ -43,22 +43,23 @@
                     align-items: center !important
                 .mat-mdc-form-field-infix
                     min-height: var(--search-bar-control-h) !important
-                    // Material defaults a large min-width that blows out narrow docked search.
+                    // Kill Material's large default min-width so docked search can shrink,
+                    // but do not force width/overflow — that pulls content under the
+                    // outlined leading edge and crops the first glyph / chip.
                     min-width: 0 !important
-                    width: 100%
-                    max-width: 100%
                     padding-top: 0 !important
                     padding-bottom: 0 !important
+                    padding-left: 12px !important
+                    padding-right: 12px !important
                     display: flex
                     align-items: center
-                    overflow: hidden
+                    box-sizing: border-box
                 .mat-mdc-chip-grid,
                 .mdc-evolution-chip-set__chips
                     align-items: center
                     min-height: 0
                     min-width: 0
                     max-width: 100%
-                    width: 100%
                     flex-wrap: nowrap !important
                 input.mat-mdc-chip-input,
                 #searchtext
@@ -71,7 +72,8 @@
                 margin-right: 8px
                 // Cap the whole chip (label + remove), not just the text span — otherwise
                 // padding/icon still overflow the field and collide with Search.
-                max-width: min(36rem, calc(100cqi - 2.75rem))
+                // Reserve room for the placeholder / typing gap.
+                max-width: min(36rem, calc(100cqi - 5.5rem))
                 min-width: 0
                 overflow: hidden
                 .mdc-evolution-chip__action--primary,
@@ -163,4 +165,4 @@
 // Very narrow fields: keep a usable typing gap; ellipsize harder.
 @container searchbox (max-width: 280px)
     mat-chip
-        max-width: calc(100cqi - 2rem)
+        max-width: calc(100cqi - 4.5rem)

--- a/cultpodcasts/src/app/subject-api/subject-api.component.ts
+++ b/cultpodcasts/src/app/subject-api/subject-api.component.ts
@@ -34,6 +34,7 @@ import { SearchResultFacet } from '../search-result-facet.interface';
 import { EpisodePosterComponent } from '../episode-poster/episode-poster.component';
 import { SiteLoadingComponent } from '../site-loading/site-loading.component';
 import { BrowseLoadingSkeletonComponent } from '../browse-loading-skeleton/browse-loading-skeleton.component';
+import { BrowseFacetScrollerDirective } from '../browse-facet-scroller.directive';
 import { SearchDisplayEpisode } from '../search-result-links';
 import { startEpisodePlayback } from '../episode-embed';
 import { displayCatalogName } from '../display-catalog-name';
@@ -54,6 +55,7 @@ const sortParamDateDesc: string = "date-desc";
     EpisodePosterComponent,
     SiteLoadingComponent,
     BrowseLoadingSkeletonComponent,
+    BrowseFacetScrollerDirective,
   ],
   templateUrl: './subject-api.component.html',
   styleUrl: './subject-api.component.sass',

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -1288,7 +1288,10 @@ option {
   scrollbar-width: thin;
   scrollbar-color: #444 transparent;
   -webkit-overflow-scrolling: touch;
-  mask-image: linear-gradient(90deg, #000 0%, #000 calc(100% - 28px), transparent 100%);
+  // Fade only when pills overflow — see BrowseFacetScrollerDirective.
+  &.browse-facet__scroller--overflow {
+    mask-image: linear-gradient(90deg, #000 0%, #000 calc(100% - 28px), transparent 100%);
+  }
 }
 
 .browse-pill {
@@ -1435,7 +1438,9 @@ option {
   }
 
   .browse-facet__scroller {
-    mask-image: none;
+    &.browse-facet__scroller--overflow {
+      mask-image: none;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Search podcast/subject chips use container-query width instead of fixed max-widths, so labels like "Jehovah's Witnesses" show in full when the field is wide enough (including docked chrome search).
- Browse facet pill rows (Shows / Language / Subjects) only apply the right-edge fade mask when the row actually overflows.

## Pages impacted
**Search chip (site-wide chrome)** — any page with the search bar that has a podcast or subject chip:
- Homepage
- Subject grids (`/subject/...`)
- Podcast grids (`/podcast/...`)
- Search results (`/search/...`)
- Other routes that keep the shared search chrome (e.g. bookmarks, episode)

**Facet pill rows (browse filters)** — only grids that render `.browse-facet__scroller`:
- Subject page — Shows + Language
- Podcast page — Subjects
- Search results — Subjects + Shows

## Test plan
- [ ] Open a subject page with a long name (e.g. Jehovah's Witnesses): search chip should show the full label when the bar is wide; still ellipsize only when the field is very narrow
- [ ] Same check with search docked into the sticky header (desktop + ≤700px)
- [ ] Subject page Language row (fits): no fade/cutoff on the last pill
- [ ] Subject page Shows row (overflows): fade still appears; horizontal scroll still works
- [ ] Podcast page Subjects row and search results Subjects/Shows rows behave the same
- [ ] Spot-check homepage search with no chip still looks normal
