### PR TITLE
fix(ui): show full clamped description lines

### DIFF
--- a/cultpodcasts/src/app/clampable-text/clampable-text.component.sass
+++ b/cultpodcasts/src/app/clampable-text/clampable-text.component.sass
@@ -14,7 +14,8 @@
 
     &.is-clamped
         overflow: hidden
-        max-height: calc(var(--clamp-lines) * 1.3em)
+        // lh tracks the element's line-height so N full lines fit (1.3em clipped the last).
+        max-height: calc(var(--clamp-lines) * 1lh)
 
 .clampable-text__toggle
     position: absolute


### PR DESCRIPTION
## Summary
- Curator card descriptions (`app-clampable-text`) clipped the last visible line mid-glyph because clamp height used `1.3em` per line while card content is `line-height: 1.45`.
- Clamp max-height now uses `1lh` so N full lines fit and overflow only starts at line N+1.

## Test plan
- [ ] Open Outgoing Episodes (or Episodes / Discovery) curator grid
- [ ] Confirm 3-line descriptions show the full third line (no mid-glyph clip)
- [ ] Confirm expand/collapse still works when text exceeds 3 lines
- [ ] Spot-check Discovery item descriptions with `maxLines` 2 and 3
