### PR TITLE
fix(ui): cheapen hero edge blur for Firefox

### DIFF
--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.html
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.html
@@ -11,19 +11,19 @@
       [class.is-kenburns]="heroKenBurnsA()"
       [class.has-edge-extend]="heroAspectA() != null"
       [style.--hero-art-aspect]="heroAspectA() ?? null">
+      <div class="billboard__stage-edge billboard__stage-edge--left">
+        <div class="billboard__stage-edge-strip">
+          <div class="billboard__stage-edge-sample"
+            [style.background-image]="heroLayerA() ? 'url(' + heroLayerA() + ')' : null"></div>
+        </div>
+      </div>
+      <div class="billboard__stage-edge billboard__stage-edge--right">
+        <div class="billboard__stage-edge-strip">
+          <div class="billboard__stage-edge-sample"
+            [style.background-image]="heroLayerA() ? 'url(' + heroLayerA() + ')' : null"></div>
+        </div>
+      </div>
       <div class="billboard__stage-motion">
-        <div class="billboard__stage-edge billboard__stage-edge--left">
-          <div class="billboard__stage-edge-strip">
-            <div class="billboard__stage-edge-sample"
-              [style.background-image]="heroLayerA() ? 'url(' + heroLayerA() + ')' : null"></div>
-          </div>
-        </div>
-        <div class="billboard__stage-edge billboard__stage-edge--right">
-          <div class="billboard__stage-edge-strip">
-            <div class="billboard__stage-edge-sample"
-              [style.background-image]="heroLayerA() ? 'url(' + heroLayerA() + ')' : null"></div>
-          </div>
-        </div>
         <div class="billboard__stage-focus-slot">
           <div class="billboard__stage-focus"
             [style.background-image]="heroLayerA() ? 'url(' + heroLayerA() + ')' : null"></div>
@@ -34,19 +34,19 @@
       [class.is-kenburns]="heroKenBurnsB()"
       [class.has-edge-extend]="heroAspectB() != null"
       [style.--hero-art-aspect]="heroAspectB() ?? null">
+      <div class="billboard__stage-edge billboard__stage-edge--left">
+        <div class="billboard__stage-edge-strip">
+          <div class="billboard__stage-edge-sample"
+            [style.background-image]="heroLayerB() ? 'url(' + heroLayerB() + ')' : null"></div>
+        </div>
+      </div>
+      <div class="billboard__stage-edge billboard__stage-edge--right">
+        <div class="billboard__stage-edge-strip">
+          <div class="billboard__stage-edge-sample"
+            [style.background-image]="heroLayerB() ? 'url(' + heroLayerB() + ')' : null"></div>
+        </div>
+      </div>
       <div class="billboard__stage-motion">
-        <div class="billboard__stage-edge billboard__stage-edge--left">
-          <div class="billboard__stage-edge-strip">
-            <div class="billboard__stage-edge-sample"
-              [style.background-image]="heroLayerB() ? 'url(' + heroLayerB() + ')' : null"></div>
-          </div>
-        </div>
-        <div class="billboard__stage-edge billboard__stage-edge--right">
-          <div class="billboard__stage-edge-strip">
-            <div class="billboard__stage-edge-sample"
-              [style.background-image]="heroLayerB() ? 'url(' + heroLayerB() + ')' : null"></div>
-          </div>
-        </div>
         <div class="billboard__stage-focus-slot">
           <div class="billboard__stage-focus"
             [style.background-image]="heroLayerB() ? 'url(' + heroLayerB() + ')' : null"></div>

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.html
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.html
@@ -13,12 +13,16 @@
       [style.--hero-art-aspect]="heroAspectA() ?? null">
       <div class="billboard__stage-motion">
         <div class="billboard__stage-edge billboard__stage-edge--left">
-          <div class="billboard__stage-edge-strip"
-            [style.background-image]="heroLayerA() ? 'url(' + heroLayerA() + ')' : null"></div>
+          <div class="billboard__stage-edge-strip">
+            <div class="billboard__stage-edge-sample"
+              [style.background-image]="heroLayerA() ? 'url(' + heroLayerA() + ')' : null"></div>
+          </div>
         </div>
         <div class="billboard__stage-edge billboard__stage-edge--right">
-          <div class="billboard__stage-edge-strip"
-            [style.background-image]="heroLayerA() ? 'url(' + heroLayerA() + ')' : null"></div>
+          <div class="billboard__stage-edge-strip">
+            <div class="billboard__stage-edge-sample"
+              [style.background-image]="heroLayerA() ? 'url(' + heroLayerA() + ')' : null"></div>
+          </div>
         </div>
         <div class="billboard__stage-focus-slot">
           <div class="billboard__stage-focus"
@@ -32,12 +36,16 @@
       [style.--hero-art-aspect]="heroAspectB() ?? null">
       <div class="billboard__stage-motion">
         <div class="billboard__stage-edge billboard__stage-edge--left">
-          <div class="billboard__stage-edge-strip"
-            [style.background-image]="heroLayerB() ? 'url(' + heroLayerB() + ')' : null"></div>
+          <div class="billboard__stage-edge-strip">
+            <div class="billboard__stage-edge-sample"
+              [style.background-image]="heroLayerB() ? 'url(' + heroLayerB() + ')' : null"></div>
+          </div>
         </div>
         <div class="billboard__stage-edge billboard__stage-edge--right">
-          <div class="billboard__stage-edge-strip"
-            [style.background-image]="heroLayerB() ? 'url(' + heroLayerB() + ')' : null"></div>
+          <div class="billboard__stage-edge-strip">
+            <div class="billboard__stage-edge-sample"
+              [style.background-image]="heroLayerB() ? 'url(' + heroLayerB() + ')' : null"></div>
+          </div>
         </div>
         <div class="billboard__stage-focus-slot">
           <div class="billboard__stage-focus"

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
@@ -62,8 +62,10 @@
     transform-origin: center 40%
     will-change: transform
 
-// Side fills: stretch a thin strip of the image's true left/right edge outward
-// (not a blurred cover of the whole frame — that looks wrong on square art).
+// Side fills: sample a thin column at the art edge, blur that small bitmap,
+// then scaleX the already-blurred result across the gutter.
+// (CSS applies transform before filter on one element — scaleX(400)+blur(28)
+// forces a huge Gaussian every Ken Burns frame and is especially slow in Firefox.)
 .billboard__stage-edge
     display: none
     position: absolute
@@ -71,32 +73,48 @@
     bottom: 0
     overflow: hidden
     pointer-events: none
+    contain: paint
 
 .billboard__stage-edge-strip
     position: absolute
-    top: -6%
-    bottom: -6%
-    width: 14px
+    top: -10%
+    bottom: -10%
+    // Wider sample → smaller scaleX → practical inner blur (≥1px) browsers handle well.
+    width: 64px
+    background-color: #121212
+    will-change: transform
+
+.billboard__stage-edge-sample
+    position: absolute
+    inset: 0
     background-color: #121212
     background-size: auto 100%
     background-repeat: no-repeat
-    filter: blur(32px) saturate(1.12) brightness(0.88)
+    // Blur on the unscaled sample; parent scaleX multiplies the visual radius.
+    // ~1.5px × scaleX(50) ≈ 75px soft wash (close to the old post-scale blur look).
+    filter: blur(1.5px) saturate(1.2) brightness(0.95)
+    // Promote once so Ken Burns on the motion ancestor can composite the texture.
+    transform: translateZ(0)
 
 .billboard__stage-edge--left
     left: 0
     .billboard__stage-edge-strip
         right: 0
-        background-position: left center
+        left: auto
         transform-origin: right center
-        transform: scaleX(70)
+        transform: scaleX(50)
+    .billboard__stage-edge-sample
+        background-position: left center
 
 .billboard__stage-edge--right
     right: 0
     .billboard__stage-edge-strip
         left: 0
-        background-position: right center
+        right: auto
         transform-origin: left center
-        transform: scaleX(70)
+        transform: scaleX(50)
+    .billboard__stage-edge-sample
+        background-position: right center
 
 // Slot sizes/positions the sharp art; Ken Burns scales the shared motion layer.
 .billboard__stage-focus-slot
@@ -124,31 +142,6 @@
     .billboard__stage-edge--left,
     .billboard__stage-edge--right
         width: max(0px, calc((100% - min(100cqw, 100cqh * var(--hero-art-aspect))) / 2))
-    // Sample only a thin column at the art edge, then stretch it across the gutter.
-    // A full-gutter background-image shows most of the cover (static whole-frame blur).
-    .billboard__stage-edge--left .billboard__stage-edge-strip
-        top: -10%
-        bottom: -10%
-        left: auto
-        right: 0
-        width: 8px
-        background-size: auto 100%
-        background-position: left center
-        transform-origin: right center
-        // Large scale fills ultrawide gutters; overflow:hidden on the edge clips excess.
-        transform: scaleX(400)
-        filter: blur(28px) saturate(1.2) brightness(0.95)
-    .billboard__stage-edge--right .billboard__stage-edge-strip
-        top: -10%
-        bottom: -10%
-        right: auto
-        left: 0
-        width: 8px
-        background-size: auto 100%
-        background-position: right center
-        transform-origin: left center
-        transform: scaleX(400)
-        filter: blur(28px) saturate(1.2) brightness(0.95)
     .billboard__stage-focus-slot
         inset: auto
         top: 50%
@@ -190,6 +183,14 @@
         background: linear-gradient(90deg, rgba(0, 0, 0, 0.78) 0%, rgba(0, 0, 0, 0.55) 18%, rgba(0, 0, 0, 0.28) 36%, rgba(0, 0, 0, 0.1) 52%, transparent 68%), linear-gradient(to top, #0b0b0b 0%, transparent 42%), linear-gradient(to bottom, rgba(0, 0, 0, 0.45) 0%, transparent 20%)
     .billboard__vignette
         background: linear-gradient(90deg, rgba(0, 0, 0, 0.28) 0%, rgba(0, 0, 0, 0.12) 24%, transparent 48%), radial-gradient(ellipse at 88% 42%, transparent 28%, rgba(0, 0, 0, 0.28) 100%)
+
+// Firefox re-rasters filtered descendants during ancestor transform animations.
+// Prefer a static fill over janky Ken Burns when the left edge blur is active.
+@supports (-moz-appearance: none)
+    @media screen and (min-width: 1280px)
+        .billboard__stage.has-edge-extend.is-kenburns .billboard__stage-motion
+            animation: none
+            transform: none
 
 .billboard__content
     position: relative

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
@@ -54,18 +54,20 @@
         .billboard__stage-motion
             animation: nflx-ken-burns var(--hero-interval) ease-out forwards
 
-// Sharp art + edge fills share one motion layer so Ken Burns zooms them together.
+// Ken Burns zooms sharp art only. Edge fills stay outside this layer so
+// Firefox does not re-raster filters every animation frame.
 .billboard__stage-motion
     position: absolute
     inset: 0
     transform: scale(1.08)
     transform-origin: center 40%
     will-change: transform
+    z-index: 1
 
 // Side fills: sample a thin column at the art edge, blur that small bitmap,
 // then scaleX the already-blurred result across the gutter.
 // (CSS applies transform before filter on one element — scaleX(400)+blur(28)
-// forces a huge Gaussian every Ken Burns frame and is especially slow in Firefox.)
+// forces a huge Gaussian and is especially slow in Firefox.)
 .billboard__stage-edge
     display: none
     position: absolute
@@ -74,6 +76,7 @@
     overflow: hidden
     pointer-events: none
     contain: paint
+    z-index: 0
 
 .billboard__stage-edge-strip
     position: absolute
@@ -82,7 +85,6 @@
     // Wider sample → smaller scaleX → practical inner blur (≥1px) browsers handle well.
     width: 64px
     background-color: #121212
-    will-change: transform
 
 .billboard__stage-edge-sample
     position: absolute
@@ -93,7 +95,6 @@
     // Blur on the unscaled sample; parent scaleX multiplies the visual radius.
     // ~1.5px × scaleX(50) ≈ 75px soft wash (close to the old post-scale blur look).
     filter: blur(1.5px) saturate(1.2) brightness(0.95)
-    // Promote once so Ken Burns on the motion ancestor can composite the texture.
     transform: translateZ(0)
 
 .billboard__stage-edge--left
@@ -116,7 +117,7 @@
     .billboard__stage-edge-sample
         background-position: right center
 
-// Slot sizes/positions the sharp art; Ken Burns scales the shared motion layer.
+// Slot sizes/positions the sharp art; Ken Burns scales the motion wrapper.
 .billboard__stage-focus-slot
     position: absolute
     inset: 0
@@ -138,7 +139,6 @@
         transform-origin: center center
     .billboard__stage-edge
         display: block
-        z-index: 0
     .billboard__stage-edge--left,
     .billboard__stage-edge--right
         width: max(0px, calc((100% - min(100cqw, 100cqh * var(--hero-art-aspect))) / 2))
@@ -146,7 +146,6 @@
         inset: auto
         top: 50%
         left: 50%
-        z-index: 1
         width: min(100cqw, calc(100cqh * var(--hero-art-aspect)))
         height: min(100cqh, calc(100cqw / var(--hero-art-aspect)))
         transform: translate(-50%, -50%)
@@ -175,7 +174,7 @@
             // Soften the hard seam where sharp art meets the left fill.
             -webkit-mask-image: linear-gradient(90deg, transparent 0, #000 36px, #000)
             mask-image: linear-gradient(90deg, transparent 0, #000 36px, #000)
-        // Wide: Ken Burns on the shared motion layer (sharp art + left blur together).
+        // Wide: Ken Burns on sharp art only (edge fills stay static — cheaper in Firefox).
         &.is-kenburns .billboard__stage-motion
             animation: nflx-ken-burns var(--hero-interval) ease-out forwards
     // Let the left edge blur read through under copy — avoid a solid black slab.
@@ -183,14 +182,6 @@
         background: linear-gradient(90deg, rgba(0, 0, 0, 0.78) 0%, rgba(0, 0, 0, 0.55) 18%, rgba(0, 0, 0, 0.28) 36%, rgba(0, 0, 0, 0.1) 52%, transparent 68%), linear-gradient(to top, #0b0b0b 0%, transparent 42%), linear-gradient(to bottom, rgba(0, 0, 0, 0.45) 0%, transparent 20%)
     .billboard__vignette
         background: linear-gradient(90deg, rgba(0, 0, 0, 0.28) 0%, rgba(0, 0, 0, 0.12) 24%, transparent 48%), radial-gradient(ellipse at 88% 42%, transparent 28%, rgba(0, 0, 0, 0.28) 100%)
-
-// Firefox re-rasters filtered descendants during ancestor transform animations.
-// Prefer a static fill over janky Ken Burns when the left edge blur is active.
-@supports (-moz-appearance: none)
-    @media screen and (min-width: 1280px)
-        .billboard__stage.has-edge-extend.is-kenburns .billboard__stage-motion
-            animation: none
-            transform: none
 
 .billboard__content
     position: relative

--- a/cultpodcasts/src/app/podcast-episode/podcast-episode.component.html
+++ b/cultpodcasts/src/app/podcast-episode/podcast-episode.component.html
@@ -15,12 +15,16 @@
       [class.is-kenburns]="backdropKenBurns()">
       <div class="episode-backdrop__motion">
         <div class="episode-backdrop__edge episode-backdrop__edge--left">
-          <div class="episode-backdrop__edge-strip"
-            [style.background-image]="backdropUrl() ? 'url(' + backdropUrl() + ')' : null"></div>
+          <div class="episode-backdrop__edge-strip">
+            <div class="episode-backdrop__edge-sample"
+              [style.background-image]="backdropUrl() ? 'url(' + backdropUrl() + ')' : null"></div>
+          </div>
         </div>
         <div class="episode-backdrop__edge episode-backdrop__edge--right">
-          <div class="episode-backdrop__edge-strip"
-            [style.background-image]="backdropUrl() ? 'url(' + backdropUrl() + ')' : null"></div>
+          <div class="episode-backdrop__edge-strip">
+            <div class="episode-backdrop__edge-sample"
+              [style.background-image]="backdropUrl() ? 'url(' + backdropUrl() + ')' : null"></div>
+          </div>
         </div>
         <div class="episode-backdrop__focus-slot">
           <div class="episode-backdrop__focus"

--- a/cultpodcasts/src/app/podcast-episode/podcast-episode.component.html
+++ b/cultpodcasts/src/app/podcast-episode/podcast-episode.component.html
@@ -13,19 +13,19 @@
     <div class="episode-backdrop" aria-hidden="true"
       [class.has-edge-extend]="backdropAspect() != null"
       [class.is-kenburns]="backdropKenBurns()">
+      <div class="episode-backdrop__edge episode-backdrop__edge--left">
+        <div class="episode-backdrop__edge-strip">
+          <div class="episode-backdrop__edge-sample"
+            [style.background-image]="backdropUrl() ? 'url(' + backdropUrl() + ')' : null"></div>
+        </div>
+      </div>
+      <div class="episode-backdrop__edge episode-backdrop__edge--right">
+        <div class="episode-backdrop__edge-strip">
+          <div class="episode-backdrop__edge-sample"
+            [style.background-image]="backdropUrl() ? 'url(' + backdropUrl() + ')' : null"></div>
+        </div>
+      </div>
       <div class="episode-backdrop__motion">
-        <div class="episode-backdrop__edge episode-backdrop__edge--left">
-          <div class="episode-backdrop__edge-strip">
-            <div class="episode-backdrop__edge-sample"
-              [style.background-image]="backdropUrl() ? 'url(' + backdropUrl() + ')' : null"></div>
-          </div>
-        </div>
-        <div class="episode-backdrop__edge episode-backdrop__edge--right">
-          <div class="episode-backdrop__edge-strip">
-            <div class="episode-backdrop__edge-sample"
-              [style.background-image]="backdropUrl() ? 'url(' + backdropUrl() + ')' : null"></div>
-          </div>
-        </div>
         <div class="episode-backdrop__focus-slot">
           <div class="episode-backdrop__focus"
             [style.background-image]="backdropUrl() ? 'url(' + backdropUrl() + ')' : null"></div>

--- a/cultpodcasts/src/app/podcast-episode/podcast-episode.component.sass
+++ b/cultpodcasts/src/app/podcast-episode/podcast-episode.component.sass
@@ -46,8 +46,8 @@
     animation: nflx-ken-burns var(--episode-ken-burns) ease-out forwards
     transform-origin: center 40%
 
-// Side fills: thin strip of the image's true left/right edge, stretched outward
-// (same technique as homepage billboard — not a full-frame blur).
+// Side fills: blur a small edge sample, then scaleX (same as homepage billboard).
+// Avoid scale-then-filter on one element — Firefox re-blurs a huge surface each frame.
 .episode-backdrop__edge
     display: none
     position: absolute
@@ -56,34 +56,44 @@
     overflow: hidden
     pointer-events: none
     z-index: 0
+    contain: paint
 
 .episode-backdrop__edge-strip
     position: absolute
     top: -10%
     bottom: -10%
-    width: 8px
+    width: 64px
+    background-color: #121212
+    will-change: transform
+
+.episode-backdrop__edge-sample
+    position: absolute
+    inset: 0
     background-color: #121212
     background-size: auto 100%
     background-repeat: no-repeat
-    filter: blur(28px) saturate(1.2) brightness(0.95)
+    filter: blur(1.5px) saturate(1.2) brightness(0.95)
+    transform: translateZ(0)
 
 .episode-backdrop__edge--left
     left: 0
     .episode-backdrop__edge-strip
         right: 0
         left: auto
-        background-position: left center
         transform-origin: right center
-        transform: scaleX(400)
+        transform: scaleX(50)
+    .episode-backdrop__edge-sample
+        background-position: left center
 
 .episode-backdrop__edge--right
     right: 0
     .episode-backdrop__edge-strip
         left: 0
         right: auto
-        background-position: right center
         transform-origin: left center
-        transform: scaleX(400)
+        transform: scaleX(50)
+    .episode-backdrop__edge-sample
+        background-position: right center
 
 .episode-backdrop__focus-slot
     position: absolute
@@ -158,6 +168,13 @@
         background: linear-gradient(90deg, rgba(0, 0, 0, 0.78) 0%, rgba(0, 0, 0, 0.55) 18%, rgba(0, 0, 0, 0.28) 36%, rgba(0, 0, 0, 0.1) 52%, transparent 68%), linear-gradient(to top, #0b0b0b 0%, transparent 42%), linear-gradient(to bottom, rgba(0, 0, 0, 0.45) 0%, transparent 20%)
     .episode-backdrop__vignette
         background: linear-gradient(90deg, rgba(0, 0, 0, 0.28) 0%, rgba(0, 0, 0, 0.12) 24%, transparent 48%), radial-gradient(ellipse at 88% 42%, transparent 28%, rgba(0, 0, 0, 0.28) 100%)
+
+// Firefox: skip Ken Burns when edge blur is active (ancestor transform re-rasters filters).
+@supports (-moz-appearance: none)
+    @media screen and (min-width: 1280px)
+        .episode-backdrop.has-edge-extend.is-kenburns .episode-backdrop__motion
+            animation: none
+            transform: none
 
 // Below ~1280: match homepage — aspect media band at top; copy in flow below.
 // In-flow ::before reserves the art height so the absolute backdrop does not

--- a/cultpodcasts/src/app/podcast-episode/podcast-episode.component.sass
+++ b/cultpodcasts/src/app/podcast-episode/podcast-episode.component.sass
@@ -41,13 +41,14 @@
     position: absolute
     inset: 0
     will-change: transform
+    z-index: 1
 
 .episode-backdrop.is-kenburns .episode-backdrop__motion
     animation: nflx-ken-burns var(--episode-ken-burns) ease-out forwards
     transform-origin: center 40%
 
 // Side fills: blur a small edge sample, then scaleX (same as homepage billboard).
-// Avoid scale-then-filter on one element — Firefox re-blurs a huge surface each frame.
+// Kept outside __motion so Ken Burns does not re-raster filters (esp. Firefox).
 .episode-backdrop__edge
     display: none
     position: absolute
@@ -64,7 +65,6 @@
     bottom: -10%
     width: 64px
     background-color: #121212
-    will-change: transform
 
 .episode-backdrop__edge-sample
     position: absolute
@@ -98,7 +98,6 @@
 .episode-backdrop__focus-slot
     position: absolute
     inset: 0
-    z-index: 1
 
 .episode-backdrop__focus
     position: absolute
@@ -158,8 +157,7 @@
             transform: translateY(-50%)
             -webkit-mask-image: linear-gradient(90deg, transparent 0, #000 36px, #000)
             mask-image: linear-gradient(90deg, transparent 0, #000 36px, #000)
-        // Wide: Ken Burns on the shared motion layer (sharp art + left blur together).
-        // Zoom toward the right-anchored art edge so scale does not crop it off.
+        // Wide: Ken Burns on sharp art only (edge fills stay static).
         &.is-kenburns .episode-backdrop__motion
             animation: nflx-ken-burns var(--episode-ken-burns) ease-out forwards
             transform-origin: 90% 40%
@@ -168,13 +166,6 @@
         background: linear-gradient(90deg, rgba(0, 0, 0, 0.78) 0%, rgba(0, 0, 0, 0.55) 18%, rgba(0, 0, 0, 0.28) 36%, rgba(0, 0, 0, 0.1) 52%, transparent 68%), linear-gradient(to top, #0b0b0b 0%, transparent 42%), linear-gradient(to bottom, rgba(0, 0, 0, 0.45) 0%, transparent 20%)
     .episode-backdrop__vignette
         background: linear-gradient(90deg, rgba(0, 0, 0, 0.28) 0%, rgba(0, 0, 0, 0.12) 24%, transparent 48%), radial-gradient(ellipse at 88% 42%, transparent 28%, rgba(0, 0, 0, 0.28) 100%)
-
-// Firefox: skip Ken Burns when edge blur is active (ancestor transform re-rasters filters).
-@supports (-moz-appearance: none)
-    @media screen and (min-width: 1280px)
-        .episode-backdrop.has-edge-extend.is-kenburns .episode-backdrop__motion
-            animation: none
-            transform: none
 
 // Below ~1280: match homepage — aspect media band at top; copy in flow below.
 // In-flow ::before reserves the art height so the absolute backdrop does not


### PR DESCRIPTION
## Summary
- Restructure homepage and episode hero edge fills to blur a small sample first, then `scaleX` — avoids CSS scale-then-filter which made Firefox Gaussian-blur a huge surface
- Keep Ken Burns on all browsers: edge fills sit outside the motion layer so zoom only animates sharp art (no Firefox kill-switch)

## Test plan
- [ ] Homepage hero on wide viewport (≥1280px) in Firefox: left fill still soft-washes under copy; Ken Burns zoom still runs; scroll/interaction feels smoother
- [ ] Episode page same check in Firefox
- [ ] Chrome/Safari: edge fill + Ken Burns still look correct (fill static, art zooms)
- [ ] Narrow / mobile: no edge gutters (unchanged)
