### PR TITLE
fix(ui): frame hero art above the copy on narrow layouts

### DIFF
--- a/cultpodcasts/docs/hero-legibility.html
+++ b/cultpodcasts/docs/hero-legibility.html
@@ -1,0 +1,1755 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Hero legibility proof — cultpodcasts</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --ok: #4ade80;
+      --bad: #f87171;
+      --warn: #fbbf24;
+      --line: #2a2a2a;
+      --dim: #9a9a9a;
+    }
+
+    body {
+      margin: 0;
+      padding: 24px clamp(16px, 3vw, 40px) 64px;
+      background: #0b0b0b;
+      color: #ececec;
+      font: 14px/1.5 ui-sans-serif, "Segoe UI", system-ui, sans-serif;
+    }
+
+    h1 {
+      font-size: 1.5rem;
+      margin: 0 0 4px;
+    }
+
+    h2 {
+      font-size: 1.05rem;
+      margin: 32px 0 10px;
+      padding-bottom: 6px;
+      border-bottom: 1px solid var(--line);
+    }
+
+    p {
+      max-width: 82ch;
+    }
+
+    .sub {
+      color: var(--dim);
+      margin: 0 0 20px;
+    }
+
+    code {
+      background: #191919;
+      padding: 1px 5px;
+      border-radius: 4px;
+      font-size: 0.9em;
+    }
+
+    fieldset {
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 12px 16px 16px;
+      margin: 0 0 16px;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 18px;
+      align-items: flex-end;
+    }
+
+    legend {
+      padding: 0 6px;
+      color: var(--dim);
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      font-size: 0.72rem;
+    }
+
+    label {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      font-size: 0.8rem;
+      color: var(--dim);
+    }
+
+    label.inline {
+      flex-direction: row;
+      align-items: center;
+      gap: 8px;
+      color: #ececec;
+    }
+
+    select,
+    input[type="number"] {
+      background: #161616;
+      color: #fff;
+      border: 1px solid #333;
+      border-radius: 6px;
+      padding: 7px 9px;
+      font: inherit;
+      min-width: 110px;
+    }
+
+    button {
+      background: #e8a23a;
+      color: #171717;
+      border: 0;
+      border-radius: 6px;
+      padding: 9px 18px;
+      font: inherit;
+      font-weight: 700;
+      cursor: pointer;
+    }
+
+    button.secondary {
+      background: #232323;
+      color: #ececec;
+      border: 1px solid #3a3a3a;
+    }
+
+    button[disabled] {
+      opacity: 0.5;
+      cursor: progress;
+    }
+
+    #verdict {
+      font-size: 1.15rem;
+      font-weight: 700;
+      padding: 14px 18px;
+      border-radius: 10px;
+      border: 1px solid var(--line);
+      background: #141414;
+      margin: 0 0 14px;
+    }
+
+    #verdict.pass {
+      border-color: #2f6b45;
+      background: #10241a;
+      color: var(--ok);
+    }
+
+    #verdict.fail {
+      border-color: #7a2f2f;
+      background: #251111;
+      color: var(--bad);
+    }
+
+    #verdict.idle {
+      color: var(--dim);
+      font-weight: 400;
+    }
+
+    .cards {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+      gap: 10px;
+      margin-bottom: 8px;
+    }
+
+    .card {
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 10px 12px;
+      background: #131313;
+    }
+
+    .card .k {
+      color: var(--dim);
+      font-size: 0.72rem;
+      text-transform: uppercase;
+      letter-spacing: 0.07em;
+    }
+
+    .card .v {
+      font-size: 1.15rem;
+      font-weight: 700;
+      margin-top: 2px;
+    }
+
+    table {
+      border-collapse: collapse;
+      width: 100%;
+      font-variant-numeric: tabular-nums;
+      font-size: 0.82rem;
+    }
+
+    th,
+    td {
+      text-align: left;
+      padding: 5px 9px;
+      border-bottom: 1px solid #1e1e1e;
+      white-space: nowrap;
+    }
+
+    th {
+      position: sticky;
+      top: 0;
+      background: #131313;
+      color: var(--dim);
+      font-weight: 600;
+      text-transform: uppercase;
+      font-size: 0.68rem;
+      letter-spacing: 0.06em;
+      z-index: 1;
+    }
+
+    tr.fail td {
+      background: #1e1010;
+    }
+
+    .tag {
+      display: inline-block;
+      padding: 1px 7px;
+      border-radius: 999px;
+      font-size: 0.7rem;
+      font-weight: 700;
+    }
+
+    .tag.pass {
+      background: #16371f;
+      color: var(--ok);
+    }
+
+    .tag.fail {
+      background: #3a1414;
+      color: var(--bad);
+    }
+
+    .tag.warn {
+      background: #3a2d0f;
+      color: var(--warn);
+    }
+
+    .swatch {
+      display: inline-block;
+      width: 11px;
+      height: 11px;
+      border-radius: 2px;
+      border: 1px solid #444;
+      vertical-align: -1px;
+      margin-right: 5px;
+    }
+
+    .scroll {
+      max-height: 62vh;
+      overflow: auto;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+    }
+
+    #previewWrap {
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      overflow: hidden;
+      background: #000;
+      position: relative;
+    }
+
+    #previewWrap iframe {
+      border: 0;
+      display: block;
+      transform-origin: 0 0;
+    }
+
+    /* Offscreen measuring rig: must stay laid out, so no display:none. */
+    #rigWrap {
+      position: fixed;
+      left: 0;
+      top: 0;
+      width: 1px;
+      height: 1px;
+      overflow: hidden;
+      opacity: 0;
+      pointer-events: none;
+      z-index: -1;
+    }
+
+    #rig {
+      border: 0;
+      display: block;
+    }
+
+    ul.notes {
+      max-width: 82ch;
+      color: #cfcfcf;
+    }
+
+    ul.notes li {
+      margin-bottom: 6px;
+    }
+
+    .prov {
+      color: var(--dim);
+      font-size: 0.76rem;
+    }
+  </style>
+</head>
+
+<body>
+  <h1>Hero legibility proof</h1>
+  <p class="sub">
+    Renders <code>homepage-hero.component.sass</code> against a worst-case <strong>solid #fff</strong> hero image and
+    checks, at every width, that hero copy keeps a legible background.
+  </p>
+
+  <p class="prov" id="prov"></p>
+
+  <fieldset>
+    <legend>Run</legend>
+    <label>Scenarios
+      <select id="scenarios">
+        <option value="framed">Framed art (16:9, 1:1, 4:3)</option>
+        <option value="all">All, incl. pre-measure fallback</option>
+        <option value="16:9">16:9 only</option>
+      </select>
+    </label>
+    <label>Viewport heights
+      <select id="heights">
+        <option value="900">900 only</option>
+        <option value="700,900,1200" selected>700, 900, 1200</option>
+        <option value="640,700,800,900,1080,1200">640 … 1200 (six)</option>
+      </select>
+    </label>
+    <label>Width step (px)
+      <input type="number" id="step" value="8" min="1" max="64">
+    </label>
+    <label class="inline"><input type="checkbox" id="failOnly"> Failures only</label>
+    <button id="run">Run sweep</button>
+    <button id="runStrict" class="secondary">Strict (step 1)</button>
+  </fieldset>
+
+  <div id="verdict" class="idle">Not run yet.</div>
+  <div class="cards" id="cards"></div>
+
+  <h2>Per-width results</h2>
+  <div class="scroll">
+    <table id="results">
+      <thead>
+        <tr>
+          <th>Width</th>
+          <th>Layout w</th>
+          <th>Height</th>
+          <th>Art</th>
+          <th>Mode</th>
+          <th>Worst bg in column</th>
+          <th>Min ratio (bound)</th>
+          <th>Limiting text</th>
+          <th>Needs</th>
+          <th>Geometry</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </div>
+
+  <h2>Visual check</h2>
+  <fieldset>
+    <legend>Preview</legend>
+    <label>Width
+      <input type="number" id="pvWidth" value="1440" min="320" max="3840" step="1">
+    </label>
+    <label>Height
+      <input type="number" id="pvHeight" value="900" min="480" max="1600" step="1">
+    </label>
+    <label>Art aspect
+      <select id="pvAspect">
+        <option value="1.7777777777777777">16:9</option>
+        <option value="1">1:1 square</option>
+        <option value="1.3333333333333333">4:3</option>
+        <option value="none">pre-measure (no aspect)</option>
+      </select>
+    </label>
+    <label class="inline"><input type="checkbox" id="pvIsolate" checked> Isolate band (match model)</label>
+    <button id="pvGo" class="secondary">Render</button>
+  </fieldset>
+  <div id="previewWrap"></div>
+
+  <h2>What this proves — and what it does not</h2>
+  <ul class="notes">
+    <li><strong>Font independent.</strong> Copy is capped at <code>min(640px, 100%)</code>, so text can never be wider
+      than the copy column. The bound samples the <em>entire column</em>, not just where glyphs happen to land, so no
+      title length or font substitution can escape it. Measured ink is reported separately as a sanity check.</li>
+    <li><strong>The model is read from the live render</strong>, not re-declared here. Band edges, tint stops and mask
+      stops come from <code>getComputedStyle(el, '::before')</code> inside the rig, so it tracks the stylesheet.</li>
+    <li><strong>Deliberately pessimistic.</strong> <code>.billboard__scrim</code> and <code>.billboard__vignette</code>
+      also darken the art but are excluded from the model, so the real background is always at least as dark as the
+      number shown. <code>.billboard__grain</code> (7% soft-light noise) is disabled and excluded.</li>
+    <li><strong>Uniform art only.</strong> A solid fill is the worst case for contrast, and it makes
+      <code>backdrop-filter</code> irrelevant — blurring #fff still yields #fff — so the tint alone is measured. It does
+      not model whether blur adequately suppresses <em>detail</em> (the artwork's own burnt-in title); that remains a
+      visual judgement.</li>
+    <li><strong>Not pixel readback.</strong> Backgrounds are composited analytically from computed styles. The
+      "Isolate band" preview makes the render match the model so the two can be compared by eye.</li>
+    <li><strong>Buttons and chips</strong> use plain harness markup, not Angular Material / <code>app-subject-chip</code>,
+      so their box metrics differ from production. Their <em>backgrounds</em> come from the real stylesheet and are
+      composited over the band.</li>
+    <li>Thresholds are WCAG 2.1 AA: 4.5:1 body text, 3:1 large text (≥24px, or ≥18.66px at weight ≥700).</li>
+  </ul>
+
+  <div id="rigWrap"><iframe id="rig" title="measuring rig"></iframe></div>
+
+  <script id="hero-css" type="text/css">.hero-host {
+  display: block;
+  --hero-interval: 7.5s;
+}
+
+.billboard {
+  position: relative;
+  width: 100%;
+  min-height: min(88vh, 720px);
+  display: flex;
+  align-items: flex-end;
+  padding: var(--nflx-hero-search-clearance, 140px) 4vw 48px;
+  box-sizing: border-box;
+  overflow: hidden;
+  background-color: #0b0b0b;
+}
+
+.billboard__stages,
+.billboard__grain,
+.billboard__scrim,
+.billboard__vignette {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.billboard__grain {
+  opacity: 0.07;
+  mix-blend-mode: soft-light;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.55'/%3E%3C/svg%3E");
+  background-size: 160px 160px;
+}
+
+.billboard__scrim {
+  background: linear-gradient(85deg, rgba(0, 0, 0, 0.94) 0%, rgba(0, 0, 0, 0.62) 38%, rgba(0, 0, 0, 0.15) 68%, transparent 82%), linear-gradient(to top, #0b0b0b 0%, transparent 45%), linear-gradient(to bottom, rgba(0, 0, 0, 0.55) 0%, transparent 22%);
+}
+
+.billboard__vignette {
+  background: radial-gradient(ellipse at 70% 40%, transparent 20%, rgba(0, 0, 0, 0.45) 100%);
+}
+
+.billboard__stage {
+  position: absolute;
+  inset: 0;
+  background-color: #121212;
+  opacity: 0;
+  overflow: hidden;
+  container-type: size;
+  --hero-art-aspect: 1.777;
+  transition: opacity 1.15s cubic-bezier(0.33, 0.1, 0.25, 1);
+}
+.billboard__stage.is-active {
+  opacity: 1;
+}
+.billboard__stage.is-kenburns .billboard__stage-motion {
+  animation: nflx-ken-burns var(--hero-interval) ease-out forwards;
+}
+
+.billboard__stage-motion {
+  position: absolute;
+  inset: 0;
+  transform: scale(1.08);
+  transform-origin: center 40%;
+  will-change: transform;
+  z-index: 1;
+}
+
+.billboard__stage-edge {
+  display: none;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  overflow: hidden;
+  pointer-events: none;
+  contain: paint;
+  z-index: 0;
+}
+
+.billboard__stage-edge-strip {
+  position: absolute;
+  top: -10%;
+  bottom: -10%;
+  width: 64px;
+  background-color: #121212;
+}
+
+.billboard__stage-edge-sample {
+  position: absolute;
+  inset: 0;
+  background-color: #121212;
+  background-size: auto 100%;
+  background-repeat: no-repeat;
+  filter: blur(1.5px) saturate(1.2) brightness(0.95);
+  transform: translateZ(0);
+}
+
+.billboard__stage-edge--left {
+  left: 0;
+}
+.billboard__stage-edge--left .billboard__stage-edge-strip {
+  right: 0;
+  left: auto;
+  transform-origin: right center;
+  transform: scaleX(50);
+}
+.billboard__stage-edge--left .billboard__stage-edge-sample {
+  background-position: left center;
+}
+
+.billboard__stage-edge--right {
+  right: 0;
+}
+.billboard__stage-edge--right .billboard__stage-edge-strip {
+  left: 0;
+  right: auto;
+  transform-origin: left center;
+  transform: scaleX(50);
+}
+.billboard__stage-edge--right .billboard__stage-edge-sample {
+  background-position: right center;
+}
+
+.billboard__stage-focus-slot {
+  position: absolute;
+  inset: 0;
+}
+
+.billboard__stage-focus {
+  position: absolute;
+  inset: 0;
+  background-color: transparent;
+  background-size: cover;
+  background-position: center 20%;
+  background-repeat: no-repeat;
+}
+
+.billboard__stage.has-edge-extend .billboard__stage-motion {
+  transform: none;
+  transform-origin: center center;
+}
+.billboard__stage.has-edge-extend .billboard__stage-edge {
+  display: block;
+}
+.billboard__stage.has-edge-extend .billboard__stage-edge--left,
+.billboard__stage.has-edge-extend .billboard__stage-edge--right {
+  width: max(0px, (100% - min(100cqw, 100cqh * var(--hero-art-aspect))) / 2);
+}
+.billboard__stage.has-edge-extend .billboard__stage-focus-slot {
+  inset: auto;
+  top: 50%;
+  left: 50%;
+  width: min(100cqw, 100cqh * var(--hero-art-aspect));
+  height: min(100cqh, 100cqw / var(--hero-art-aspect));
+  transform: translate(-50%, -50%);
+}
+.billboard__stage.has-edge-extend .billboard__stage-focus {
+  background-size: 100% 100%;
+  background-position: center center;
+}
+.billboard__stage.has-edge-extend.is-kenburns .billboard__stage-motion {
+  animation: none;
+  transform: none;
+}
+
+@media screen and (min-width: 1280px) {
+  .billboard__stage.has-edge-extend .billboard__stage-motion {
+    transform-origin: 90% 40%;
+  }
+  .billboard__stage.has-edge-extend .billboard__stage-edge--left {
+    width: max(0px, 100% - min(100cqw, 100cqh * var(--hero-art-aspect)));
+  }
+  .billboard__stage.has-edge-extend .billboard__stage-edge--right {
+    width: 0;
+  }
+  .billboard__stage.has-edge-extend .billboard__stage-focus-slot {
+    left: auto;
+    right: 0;
+    transform: translateY(-50%);
+    -webkit-mask-image: linear-gradient(90deg, transparent 0, #000 36px, #000);
+    mask-image: linear-gradient(90deg, transparent 0, #000 36px, #000);
+  }
+  .billboard__stage.has-edge-extend.is-kenburns .billboard__stage-motion {
+    animation: nflx-ken-burns var(--hero-interval) ease-out forwards;
+  }
+  .billboard__scrim {
+    background: linear-gradient(90deg, rgba(0, 0, 0, 0.78) 0%, rgba(0, 0, 0, 0.55) 18%, rgba(0, 0, 0, 0.28) 36%, rgba(0, 0, 0, 0.1) 52%, transparent 68%), linear-gradient(to top, #0b0b0b 0%, transparent 42%), linear-gradient(to bottom, rgba(0, 0, 0, 0.45) 0%, transparent 20%);
+  }
+  .billboard__vignette {
+    background: linear-gradient(90deg, rgba(0, 0, 0, 0.28) 0%, rgba(0, 0, 0, 0.12) 24%, transparent 48%), radial-gradient(ellipse at 88% 42%, transparent 28%, rgba(0, 0, 0, 0.28) 100%);
+  }
+  .billboard__content::before {
+    content: "";
+    position: absolute;
+    top: -100%;
+    bottom: -100%;
+    left: -6vw;
+    right: -240px;
+    z-index: -1;
+    pointer-events: none;
+    background: linear-gradient(90deg, rgba(0, 0, 0, 0.8) 0%, rgba(0, 0, 0, 0.72) 55%, rgba(0, 0, 0, 0.6) 100%);
+    -webkit-mask-image: linear-gradient(90deg, #000 0%, #000 82%, transparent 100%);
+    mask-image: linear-gradient(90deg, #000 0%, #000 82%, transparent 100%);
+  }
+  @supports (backdrop-filter: blur(2px)) {
+    .billboard__content::before {
+      backdrop-filter: blur(22px) saturate(0.85);
+    }
+  }
+}
+@media screen and (min-width: 1280px) and (prefers-reduced-motion: reduce) {
+  .billboard__content::before {
+    backdrop-filter: none;
+  }
+}
+.billboard__content {
+  position: relative;
+  z-index: 2;
+  width: min(640px, 100%);
+  pointer-events: auto;
+  color: var(--nflx-on-media, #fff);
+}
+
+.billboard__feature {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  opacity: 1;
+  transition: opacity 0.55s cubic-bezier(0.33, 0.1, 0.25, 1);
+}
+.billboard__feature.is-hidden {
+  opacity: 0;
+  pointer-events: none;
+  transition-duration: 0.55s;
+}
+
+.billboard__copy {
+  min-width: 0;
+}
+
+.billboard__copy-body {
+  display: flex;
+  flex-direction: column;
+  min-height: calc(4.35em + 44px);
+  margin-bottom: 4px;
+}
+
+.billboard__eyebrow {
+  margin: 0 0 10px;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--nflx-accent);
+}
+
+.billboard__live {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--nflx-accent);
+  box-shadow: 0 0 0 0 rgba(232, 162, 58, 0.7019607843);
+  animation: nflx-pulse-live 1.8s ease-out infinite;
+}
+
+.billboard__title {
+  margin: 0 0 12px;
+  font-family: var(--cp-font-display);
+  font-size: clamp(2.3rem, 6.5vw, 3.85rem);
+  font-weight: 400;
+  line-height: 1.02;
+  letter-spacing: -0.025em;
+  color: var(--nflx-on-media, #fff);
+  text-shadow: 0 4px 40px rgba(0, 0, 0, 0.7490196078);
+}
+
+.billboard__meta {
+  margin: 0 0 12px;
+  font-size: 0.95rem;
+  color: var(--nflx-on-media-muted, #e8e8e8);
+}
+.billboard__meta a {
+  color: var(--nflx-on-media, #fff);
+  text-decoration: none;
+  font-weight: 600;
+}
+.billboard__meta a:hover {
+  text-decoration: underline;
+}
+
+.billboard__lang {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: 8px;
+  padding: 2px 10px 2px 8px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.1215686275);
+  border: 1px solid rgba(255, 255, 255, 0.2196078431);
+  color: var(--nflx-on-media, #fff);
+  font-size: 0.78rem;
+  font-weight: 600;
+  vertical-align: middle;
+}
+
+.billboard__lang-flag {
+  font-size: 1rem;
+  line-height: 1;
+  font-weight: 400;
+  font-family: "Twemoji Country Flags", var(--cp-font-ui);
+}
+
+.billboard__lang-name {
+  line-height: 1.2;
+}
+
+.billboard__desc {
+  margin: 0 0 12px;
+  font-size: 1.05rem;
+  line-height: 1.45;
+  color: var(--nflx-on-media-muted, #e8e8e8);
+  max-width: 36em;
+  text-shadow: 0 1px 12px rgba(0, 0, 0, 0.5490196078);
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  line-clamp: 3;
+  overflow: hidden;
+  min-height: 4.35em;
+}
+
+.billboard__subjects {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 0 0 8px;
+  max-height: 2.4rem;
+  overflow: hidden;
+}
+
+.billboard__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: auto;
+  flex: 0 0 auto;
+}
+
+.billboard__play {
+  background: #fff !important;
+  color: #000 !important;
+  font-weight: 700;
+  padding-inline: 22px;
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.3490196078);
+}
+.billboard__play mat-icon {
+  margin-right: 4px;
+}
+
+.billboard__more {
+  border-color: rgba(255, 255, 255, 0.5490196078) !important;
+  color: #fff !important;
+  background: rgba(42, 42, 42, 0.8) !important;
+  font-weight: 600;
+}
+
+.billboard__controls {
+  position: absolute;
+  right: 4vw;
+  bottom: 56px;
+  z-index: 3;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 10px;
+  max-width: min(520px, 100% - 8vw);
+  pointer-events: auto;
+}
+
+.billboard__admin {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+  max-width: 100%;
+}
+
+.billboard__manage {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 36px;
+  padding: 0 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.3490196078);
+  background: rgba(20, 20, 20, 0.9019607843);
+  color: #fff;
+  font-size: 0.78rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease;
+  white-space: nowrap;
+}
+.billboard__manage mat-icon {
+  font-size: 18px;
+  width: 18px;
+  height: 18px;
+  color: var(--nflx-accent);
+  flex: 0 0 auto;
+}
+.billboard__manage:hover, .billboard__manage:focus-visible {
+  background: #2a2a2a;
+  border-color: var(--nflx-accent);
+  outline: none;
+}
+.billboard__manage--curate {
+  border-color: rgba(232, 162, 58, 0.6);
+  color: var(--nflx-accent);
+}
+
+.billboard__pager {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  width: 100%;
+  max-width: min(420px, 100%);
+}
+
+.billboard__nav {
+  width: 44px;
+  height: 44px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.3490196078);
+  background: rgba(20, 20, 20, 0.9019607843);
+  color: #fff;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+.billboard__nav:hover {
+  background: #2a2a2a;
+  border-color: rgba(255, 255, 255, 0.7019607843);
+  transform: scale(1.05);
+}
+
+.billboard__dots-viewport {
+  position: relative;
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow-x: auto;
+  overflow-y: hidden;
+  touch-action: pan-x;
+  scroll-behavior: smooth;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+.billboard__dots-viewport::-webkit-scrollbar {
+  display: none;
+}
+.billboard__dots-viewport {
+  mask-image: linear-gradient(to right, #000, #000);
+}
+.billboard__dots-viewport.has-overflow-start {
+  mask-image: linear-gradient(to right, transparent, #000 18px, #000);
+}
+.billboard__dots-viewport.has-overflow-end {
+  mask-image: linear-gradient(to right, #000, #000 calc(100% - 18px), transparent);
+}
+.billboard__dots-viewport.has-overflow-start.has-overflow-end {
+  mask-image: linear-gradient(to right, transparent, #000 18px, #000 calc(100% - 18px), transparent);
+}
+
+.billboard__dots {
+  display: flex;
+  gap: 6px;
+  width: max-content;
+  padding: 4px 2px;
+}
+
+.billboard__dot {
+  position: relative;
+  flex-shrink: 0;
+  box-sizing: content-box;
+  width: 28px;
+  height: 3px;
+  padding: 14px 4px;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+.billboard__dot::before {
+  content: "";
+  position: absolute;
+  left: 4px;
+  top: 50%;
+  width: 28px;
+  height: 3px;
+  margin-top: -1.5px;
+  border-radius: 2px;
+  background: rgba(255, 255, 255, 0.2784313725);
+}
+.billboard__dot.is-active::before {
+  background: rgba(255, 255, 255, 0.3490196078);
+}
+.billboard__dot.is-curated::before {
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--nflx-accent) 55%, transparent);
+}
+
+.billboard__dot-fill {
+  position: absolute;
+  left: 4px;
+  top: 50%;
+  height: 3px;
+  margin-top: -1.5px;
+  width: 0;
+  max-width: 28px;
+  background: var(--nflx-accent);
+  border-radius: 2px;
+}
+.billboard__dot-fill.is-running {
+  animation: nflx-dot-progress var(--hero-interval) linear forwards;
+}
+
+.billboard.is-paused .billboard__dot-fill.is-running {
+  animation-play-state: paused;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .billboard__grain {
+    display: none;
+  }
+  .billboard__stage.is-kenburns .billboard__stage-motion {
+    animation: none;
+  }
+  .billboard__stage-motion {
+    transform: scale(1.05);
+  }
+  .billboard__stage.has-edge-extend .billboard__stage-motion {
+    transform: none;
+  }
+  .billboard__stage {
+    transition: none;
+  }
+  .billboard__feature,
+  .billboard__dot-fill.is-running,
+  .billboard__live {
+    animation: none;
+    transition: none;
+  }
+  .billboard__feature.is-hidden {
+    opacity: 0;
+  }
+  .billboard__dot-fill.is-running {
+    width: 100%;
+  }
+  .billboard__dots-viewport {
+    scroll-behavior: auto;
+  }
+}
+@media screen and (max-width: 900px), (hover: none) and (pointer: coarse) {
+  .billboard__grain {
+    display: none;
+  }
+  .billboard__stage.is-kenburns .billboard__stage-motion {
+    animation: none;
+  }
+  .billboard__stage-motion {
+    transform: scale(1.05);
+  }
+  .billboard__stage.has-edge-extend .billboard__stage-motion {
+    transform: none;
+  }
+  .billboard__live {
+    animation: none;
+    box-shadow: none;
+  }
+}
+.cdk-global-scrollblock .billboard__stage.is-kenburns .billboard__stage-motion {
+  animation-play-state: paused;
+}
+.cdk-global-scrollblock .billboard__live {
+  animation-play-state: paused;
+}
+
+@media screen and (min-width: 900px) {
+  .billboard__pager {
+    max-width: min(480px, 42vw);
+  }
+}
+@media screen and (max-width: 1280px) {
+  .billboard {
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: stretch;
+    gap: 16px;
+    padding-top: 0;
+    padding-bottom: 24px;
+    min-height: 0;
+    --hero-band-h: clamp(180px, calc(100vh - 320px), 56.25vw);
+    --hero-copy-fade: 0px;
+  }
+  .billboard::before {
+    content: "";
+    flex: 0 0 max(var(--nflx-hero-search-clearance, 140px), var(--hero-band-h));
+    min-height: max(var(--nflx-hero-search-clearance, 140px), var(--hero-band-h));
+    width: 100%;
+    pointer-events: none;
+  }
+  .billboard:not(.has-art-aspect) {
+    --hero-copy-fade: 96px;
+  }
+  .billboard.has-art-aspect .billboard__stages,
+  .billboard.has-art-aspect .billboard__grain,
+  .billboard.has-art-aspect .billboard__scrim,
+  .billboard.has-art-aspect .billboard__vignette {
+    inset: auto;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: auto;
+    width: 100%;
+    height: var(--hero-band-h);
+  }
+  .billboard.has-art-aspect .billboard__stage {
+    background-color: #0b0b0b;
+  }
+  .billboard.has-art-aspect .billboard__stage.has-edge-extend .billboard__stage-edge {
+    display: none;
+  }
+  .billboard__content {
+    width: 100%;
+    max-width: min(640px, 100%);
+    flex: 0 1 auto;
+    padding-top: 8px;
+    position: relative;
+    z-index: 2;
+  }
+  .billboard__content::before {
+    content: "";
+    position: absolute;
+    left: -4vw;
+    top: calc(-1 * var(--hero-copy-fade));
+    width: 100vw;
+    height: calc(100vh + 100%);
+    z-index: -1;
+    pointer-events: none;
+    background: linear-gradient(to bottom, rgba(11, 11, 11, 0) 0%, rgba(11, 11, 11, 0.82) 72%, #0b0b0b 100%) no-repeat top/100% var(--hero-copy-fade), linear-gradient(#0b0b0b, #0b0b0b) no-repeat bottom/100% calc(100% - var(--hero-copy-fade));
+    backdrop-filter: none;
+    -webkit-mask-image: none;
+    mask-image: none;
+  }
+  .billboard__scrim {
+    background: linear-gradient(to bottom, rgba(0, 0, 0, 0.45) 0%, transparent 22%);
+  }
+  .billboard__vignette {
+    background: none;
+  }
+  .billboard__controls {
+    position: relative;
+    right: auto;
+    bottom: auto;
+    left: auto;
+    width: 100%;
+    max-width: none;
+    align-items: stretch;
+    flex: 0 0 auto;
+  }
+  .billboard__admin {
+    justify-content: flex-start;
+  }
+  .billboard__pager {
+    max-width: none;
+    width: 100%;
+  }
+}
+@media screen and (max-width: 700px) {
+  .billboard {
+    min-height: 0;
+    padding-bottom: 20px;
+    gap: 12px;
+  }
+  .billboard::before {
+    flex-basis: calc(var(--site-chrome-bar-h, 52px) + env(safe-area-inset-top, 0px) + var(--hero-band-h));
+    min-height: calc(var(--site-chrome-bar-h, 52px) + env(safe-area-inset-top, 0px) + var(--hero-band-h));
+  }
+  .billboard.has-art-aspect .billboard__stages,
+  .billboard.has-art-aspect .billboard__grain,
+  .billboard.has-art-aspect .billboard__scrim,
+  .billboard.has-art-aspect .billboard__vignette {
+    top: calc(var(--site-chrome-bar-h, 52px) + env(safe-area-inset-top, 0px));
+  }
+  .billboard.has-art-aspect .billboard__scrim {
+    background: none;
+  }
+  .billboard__content {
+    padding-top: 0;
+  }
+  .billboard__eyebrow {
+    position: relative;
+    z-index: 2;
+  }
+  .billboard__title {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 3;
+    line-clamp: 3;
+    overflow: hidden;
+    min-height: 3.06em;
+    font-size: clamp(1.85rem, 7vw, 2.6rem);
+    margin-bottom: 10px;
+  }
+  .billboard__copy-body {
+    min-height: calc(4.35em + 40px);
+  }
+  .billboard__desc {
+    font-size: 0.98rem;
+    -webkit-line-clamp: 3;
+    line-clamp: 3;
+  }
+  .billboard__actions {
+    flex-direction: column;
+    align-items: stretch;
+    width: 100%;
+    margin-top: 12px;
+  }
+  .billboard__admin {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 8px;
+  }
+  .billboard__manage {
+    width: 100%;
+    justify-content: center;
+  }
+  .billboard__nav {
+    width: 40px;
+    height: 40px;
+  }
+}</script>
+  <script id="hero-meta" type="application/json">{
+  "source": "src/app/homepage-hero/homepage-hero.component.sass",
+  "sha256": "c7b7d4e90689e30fdab286e520cace2e1d2b263ef8b2ca8aada3e2f0b6ee6f50",
+  "command": "npm run hero:legibility"
+}</script>
+
+  <script>
+    'use strict';
+
+    const HERO_CSS = document.getElementById('hero-css').textContent;
+    const META = JSON.parse(document.getElementById('hero-meta').textContent);
+
+    /* Mirrors the token declarations in app.component.sass / styles.scss that the
+       hero reads. Kept minimal and asserted at runtime: a missing token would
+       change layout, so the rig checks the ones that resolve to lengths. */
+    const TOKENS_CSS = `
+:root {
+  --nflx-accent: #e8a23a;
+  --nflx-on-media: #fff;
+  --nflx-on-media-muted: #e8e8e8;
+  --nflx-panel: #141414;
+  --cp-font-display: 'Instrument Serif', Georgia, 'Times New Roman', serif;
+  --cp-font-ui: Figtree, 'Segoe UI', system-ui, sans-serif;
+  --nflx-search-h: 48px;
+  --site-chrome-bar-h: 58px;
+  --site-chrome-search-gap: 12px;
+  --site-chrome-h: calc(var(--site-chrome-bar-h) + var(--site-chrome-search-gap) + var(--nflx-search-h) + 12px);
+  --nflx-hero-search-clearance: calc(var(--site-chrome-h) + 8px);
+}
+@media screen and (max-width: 700px) {
+  :root {
+    --site-chrome-bar-h: 52px;
+    --site-chrome-search-gap: 0px;
+    --site-chrome-h: var(--site-chrome-bar-h);
+    --nflx-hero-search-clearance: calc(var(--site-chrome-bar-h) + env(safe-area-inset-top, 0px) + 12px);
+  }
+}`;
+
+    /* Worst case under test: every surface that carries artwork is solid #fff.
+       .billboard and .billboard__stage are deliberately left alone — their
+       backgrounds are design colours (page backdrop and letterbox gutters), not
+       image data, so whitening them would test a broken token rather than
+       hostile artwork. */
+    const RIG_CSS = `
+html, body { margin: 0; padding: 0; background: #fff; }
+body { font-family: var(--cp-font-ui); }
+.hero-host { display: block; --hero-interval: 7.5s; }
+.billboard__stage-focus,
+.billboard__stage-edge-strip,
+.billboard__stage-edge-sample {
+  background-image: none !important;
+  background-color: #fff !important;
+  filter: none !important;
+}
+/* Excluded from the model, so excluded from the render. */
+.billboard__grain { display: none !important; }
+/* Measurements must be stable. */
+*, *::before, *::after { animation: none !important; transition: none !important; }
+/* Scrim + vignette also darken the art; the model ignores them, so isolating
+   them makes what you see equal what is measured. */
+.isolate-band .billboard__scrim,
+.isolate-band .billboard__vignette { background: none !important; }
+.harness-btn {
+  display: inline-flex; align-items: center; justify-content: center;
+  min-height: 40px; padding: 0 22px; border-radius: 6px;
+  border: 1px solid transparent; font: inherit; font-size: 0.9rem;
+  text-decoration: none; cursor: default; box-sizing: border-box;
+}
+.harness-chip {
+  display: inline-flex; align-items: center; height: 26px; padding: 0 10px;
+  border-radius: 999px; background: #ffffff1f; border: 1px solid #ffffff38;
+  font-size: 0.78rem;
+}
+.harness-nav { width: 44px; height: 44px; border-radius: 50%; background: #141414e6; border: 1px solid #ffffff59; flex: 0 0 auto; }
+.harness-dots { flex: 1 1 auto; height: 31px; }`;
+
+    const LONG_TITLE = 'Inside the Long-Running Investigation Into a Secretive Wellness Group, Its Charismatic Founder, and the Followers Who Say They Lost Everything';
+    const LONG_DESC = 'A reporter spends eighteen months tracing how a small breath-work studio grew into an international organisation with its own scripture, courts and currency, and what happened to the members who tried to leave. Contains descriptions of coercive control that some listeners may find distressing.';
+
+    const HERO_MARKUP = `
+<div class="hero-host">
+  <section class="billboard has-art-aspect" style="--hero-art-aspect: 1.7777777777777777">
+    <div class="billboard__stages" aria-hidden="true">
+      <div class="billboard__stage is-active has-edge-extend" style="--hero-art-aspect: 1.7777777777777777">
+        <div class="billboard__stage-edge billboard__stage-edge--left"><div class="billboard__stage-edge-strip"><div class="billboard__stage-edge-sample"></div></div></div>
+        <div class="billboard__stage-edge billboard__stage-edge--right"><div class="billboard__stage-edge-strip"><div class="billboard__stage-edge-sample"></div></div></div>
+        <div class="billboard__stage-motion"><div class="billboard__stage-focus-slot"><div class="billboard__stage-focus"></div></div></div>
+      </div>
+    </div>
+    <div class="billboard__grain" aria-hidden="true"></div>
+    <div class="billboard__scrim" aria-hidden="true"></div>
+    <div class="billboard__vignette" aria-hidden="true"></div>
+    <div class="billboard__content">
+      <div class="billboard__feature">
+        <div class="billboard__copy">
+          <p class="billboard__eyebrow"><span class="billboard__live" aria-hidden="true"></span>Now featuring</p>
+          <h1 class="billboard__title">${LONG_TITLE}</h1>
+          <p class="billboard__meta"><a href="#">A Podcast With Quite A Long Name</a><span> &middot; 1:04:22</span><span class="billboard__lang" title="English"><span class="billboard__lang-flag" aria-hidden="true">&#127468;&#127463;</span><span class="billboard__lang-name">English</span></span></p>
+          <div class="billboard__copy-body">
+            <p class="billboard__desc">${LONG_DESC}</p>
+            <div class="billboard__subjects" data-harness-ignore><span class="harness-chip">Cults</span><span class="harness-chip">Wellness</span><span class="harness-chip">Investigation</span></div>
+          </div>
+        </div>
+        <div class="billboard__actions">
+          <button type="button" class="billboard__play harness-btn">Watch</button>
+          <a class="billboard__more harness-btn" href="#">More info</a>
+        </div>
+      </div>
+    </div>
+    <div class="billboard__controls" data-harness-ignore>
+      <div class="billboard__pager"><span class="harness-nav"></span><span class="harness-dots"></span><span class="harness-nav"></span></div>
+    </div>
+  </section>
+</div>`;
+
+    function frameDoc() {
+      return '<!doctype html><html><head><meta charset="utf-8">'
+        + '<style>' + TOKENS_CSS + '</style>'
+        + '<style>' + HERO_CSS + '</style>'
+        + '<style>' + RIG_CSS + '</style>'
+        + '</head><body>' + HERO_MARKUP + '</body></html>';
+    }
+
+    /* ---------------- colour maths ---------------- */
+
+    function parseColor(str) {
+      const m = /^rgba?\(([^)]+)\)$/.exec(String(str).trim());
+      if (!m) return null;
+      const parts = m[1].split(/[,\s/]+/).filter(Boolean).map(Number);
+      return { r: parts[0], g: parts[1], b: parts[2], a: parts.length > 3 ? parts[3] : 1 };
+    }
+
+    // Paint `top` over opaque-or-not `bottom`.
+    function over(top, bottom) {
+      const a = top.a + bottom.a * (1 - top.a);
+      if (a === 0) return { r: 0, g: 0, b: 0, a: 0 };
+      const ch = (t, b) => (t * top.a + b * bottom.a * (1 - top.a)) / a;
+      return { r: ch(top.r, bottom.r), g: ch(top.g, bottom.g), b: ch(top.b, bottom.b), a };
+    }
+
+    function luminance(c) {
+      const f = (v) => {
+        const s = v / 255;
+        return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+      };
+      return 0.2126 * f(c.r) + 0.7152 * f(c.g) + 0.0722 * f(c.b);
+    }
+
+    function contrast(a, b) {
+      const l1 = luminance(a), l2 = luminance(b);
+      return (Math.max(l1, l2) + 0.05) / (Math.min(l1, l2) + 0.05);
+    }
+
+    function hex(c) {
+      const h = (v) => Math.round(Math.max(0, Math.min(255, v))).toString(16).padStart(2, '0');
+      return '#' + h(c.r) + h(c.g) + h(c.b);
+    }
+
+    /* ---------------- gradient parsing ---------------- */
+
+    function splitTopLevel(str) {
+      const out = [];
+      let depth = 0, cur = '';
+      for (const ch of str) {
+        if (ch === '(') depth++;
+        if (ch === ')') depth--;
+        if (ch === ',' && depth === 0) { out.push(cur.trim()); cur = ''; continue; }
+        cur += ch;
+      }
+      if (cur.trim()) out.push(cur.trim());
+      return out;
+    }
+
+    /* Returns { stops:[{pos,color}], horizontal:bool } or null.
+       Only left-to-right gradients are modelled; anything else is reported as
+       unmodelled rather than silently mis-measured. */
+    function parseLinearGradient(value) {
+      const m = /^linear-gradient\((.*)\)$/s.exec(String(value).trim());
+      if (!m) return null;
+      const parts = splitTopLevel(m[1]);
+      let horizontal = false;
+      if (/^(to\s|[-\d.]+deg|calc)/i.test(parts[0]) && !/^rgba?\(/i.test(parts[0])) {
+        const dir = parts.shift().trim().toLowerCase();
+        horizontal = dir === '90deg' || dir === 'to right';
+      }
+      const stops = [];
+      for (const p of parts) {
+        const cm = /^(rgba?\([^)]*\)|#[0-9a-f]{3,8}|[a-z]+)\s*(.*)$/i.exec(p);
+        if (!cm) return null;
+        const color = parseColor(cm[1]) || (cm[1] === 'transparent' ? { r: 0, g: 0, b: 0, a: 0 } : null);
+        if (!color) return null;
+        const pos = /([-\d.]+)%/.exec(cm[2]);
+        stops.push({ pos: pos ? parseFloat(pos[1]) / 100 : null, color });
+      }
+      if (!stops.length) return null;
+      if (stops[0].pos === null) stops[0].pos = 0;
+      if (stops[stops.length - 1].pos === null) stops[stops.length - 1].pos = 1;
+      for (let i = 1; i < stops.length - 1; i++) {
+        if (stops[i].pos === null) stops[i].pos = i / (stops.length - 1);
+      }
+      return { stops, horizontal };
+    }
+
+    /* CSS interpolates gradients in premultiplied space. */
+    function colorAtStop(stops, t) {
+      if (t <= stops[0].pos) return stops[0].color;
+      const last = stops[stops.length - 1];
+      if (t >= last.pos) return last.color;
+      for (let i = 1; i < stops.length; i++) {
+        const a = stops[i - 1], b = stops[i];
+        if (t > b.pos) continue;
+        const span = b.pos - a.pos;
+        const f = span === 0 ? 0 : (t - a.pos) / span;
+        const pa = a.color.a, pb = b.color.a;
+        const alpha = pa + (pb - pa) * f;
+        if (alpha === 0) return { r: 0, g: 0, b: 0, a: 0 };
+        const ch = (ca, cb) => ((ca * pa) + ((cb * pb) - (ca * pa)) * f) / alpha;
+        return { r: ch(a.color.r, b.color.r), g: ch(a.color.g, b.color.g), b: ch(a.color.b, b.color.b), a: alpha };
+      }
+      return last.color;
+    }
+
+    /* ---------------- rig ---------------- */
+
+    const rig = document.getElementById('rig');
+    let rigWin = null, rigDoc = null;
+
+    function writeRig() {
+      rigDoc = rig.contentDocument;
+      rigDoc.open();
+      rigDoc.write(frameDoc());
+      rigDoc.close();
+      rigWin = rig.contentWindow;
+    }
+
+    function setScenario(aspect) {
+      const bb = rigDoc.querySelector('.billboard');
+      const stage = rigDoc.querySelector('.billboard__stage');
+      if (aspect === 'none') {
+        bb.classList.remove('has-art-aspect');
+        stage.classList.remove('has-edge-extend');
+        bb.style.removeProperty('--hero-art-aspect');
+        stage.style.removeProperty('--hero-art-aspect');
+      } else {
+        bb.classList.add('has-art-aspect');
+        stage.classList.add('has-edge-extend');
+        bb.style.setProperty('--hero-art-aspect', aspect);
+        stage.style.setProperty('--hero-art-aspect', aspect);
+      }
+    }
+
+    function textLeaves(root) {
+      const out = [];
+      const walk = (el) => {
+        if (el.hasAttribute && el.hasAttribute('data-harness-ignore')) return;
+        let own = false;
+        for (const n of el.childNodes) {
+          if (n.nodeType === 3 && n.nodeValue.trim()) own = true;
+        }
+        if (own) out.push(el);
+        for (const c of el.children) walk(c);
+      };
+      walk(root);
+      return out;
+    }
+
+    function ownInkRects(el, clipTo) {
+      const rects = [];
+      for (const n of el.childNodes) {
+        if (n.nodeType !== 3 || !n.nodeValue.trim()) continue;
+        const r = rigDoc.createRange();
+        r.selectNodeContents(n);
+        for (const box of r.getClientRects()) {
+          const left = Math.max(box.left, clipTo.left);
+          const right = Math.min(box.right, clipTo.right);
+          const top = Math.max(box.top, clipTo.top);
+          const bottom = Math.min(box.bottom, clipTo.bottom);
+          if (right > left && bottom > top) rects.push({ left, right, top, bottom });
+        }
+      }
+      return rects;
+    }
+
+    function styleOf(el) {
+      const cs = rigWin.getComputedStyle(el);
+      const size = parseFloat(cs.fontSize);
+      const weightRaw = cs.fontWeight;
+      const weight = weightRaw === 'bold' ? 700 : weightRaw === 'normal' ? 400 : parseInt(weightRaw, 10) || 400;
+      const large = size >= 24 || (size >= 18.66 && weight >= 700);
+      return { color: parseColor(cs.color), size, weight, large, threshold: large ? 3 : 4.5 };
+    }
+
+    /* Backgrounds declared between the text element and the copy column, which
+       sit above the band and therefore change what the text is read against. */
+    function ancestorBackgrounds(el, stopAt) {
+      const layers = [];
+      let node = el;
+      while (node && node !== stopAt) {
+        const cs = rigWin.getComputedStyle(node);
+        if (cs.backgroundImage && cs.backgroundImage !== 'none') layers.push({ unmodelled: true });
+        const c = parseColor(cs.backgroundColor);
+        if (c && c.a > 0) layers.push({ color: c });
+        node = node.parentElement;
+      }
+      return layers.reverse();
+    }
+
+    const ART = { r: 255, g: 255, b: 255, a: 1 };
+    /* .billboard / .billboard__stage backgrounds — opaque design colours. */
+    const CHROME = { r: 11, g: 11, b: 11, a: 1 };
+
+    function intersect(a, b) {
+      const r = {
+        left: Math.max(a.left, b.left), right: Math.min(a.right, b.right),
+        top: Math.max(a.top, b.top), bottom: Math.min(a.bottom, b.bottom)
+      };
+      return r.right > r.left && r.bottom > r.top ? r : null;
+    }
+
+    function containsRect(outer, inner) {
+      return inner.left >= outer.left - 0.5 && inner.right <= outer.right + 0.5
+        && inner.top >= outer.top - 0.5 && inner.bottom <= outer.bottom + 0.5;
+    }
+
+    function measure(nominalWidth, height, aspectLabel) {
+      const win = rigWin, doc = rigDoc;
+      const bb = doc.querySelector('.billboard');
+      const content = doc.querySelector('.billboard__content');
+      const stages = doc.querySelector('.billboard__stages');
+
+      const layoutWidth = doc.documentElement.clientWidth;
+      const stacked = win.matchMedia('(max-width: 1280px)').matches;
+      const bbRect = bb.getBoundingClientRect();
+      const contentRect = content.getBoundingClientRect();
+      const before = win.getComputedStyle(content, '::before');
+      const notes = [];
+
+      // Sanity: the tokens the hero depends on must have resolved.
+      const clearance = win.getComputedStyle(bb).paddingTop;
+      if (!stacked && parseFloat(clearance) < 100) notes.push('search clearance token missing');
+
+      // bgAt(x, y) -> background colour immediately beneath the copy layer.
+      // boundOver(rect) -> the lightest background anywhere in that box, i.e.
+      // the worst case for any glyph the box could ever contain.
+      let bgAt, boundOver, geometry, unmodelled = false;
+
+      if (stacked) {
+        const fade = parseFloat(win.getComputedStyle(bb).getPropertyValue('--hero-copy-fade')) || 0;
+        const panel = {
+          left: contentRect.left + parseFloat(before.left),
+          top: contentRect.top + parseFloat(before.top),
+          right: contentRect.left + parseFloat(before.left) + parseFloat(before.width),
+          bottom: contentRect.top + parseFloat(before.top) + parseFloat(before.height)
+        };
+        // Clipped by .billboard (overflow: hidden); the fade band at the top is
+        // partially transparent, so it does not count as covered.
+        const safe = {
+          left: Math.max(panel.left, bbRect.left),
+          right: Math.min(panel.right, bbRect.right),
+          top: Math.max(panel.top + fade, bbRect.top),
+          bottom: Math.min(panel.bottom, bbRect.bottom)
+        };
+        const artRect = stages.getBoundingClientRect();
+        // Anything not on the panel still lands on .billboard's opaque #0b0b0b,
+        // so only artwork that escapes the panel can hurt legibility.
+        const bgFor = (rect) => {
+          const onArt = intersect(rect, artRect);
+          return !onArt || containsRect(safe, onArt) ? CHROME : ART;
+        };
+        bgAt = (x, y) => bgFor({ left: x, right: x, top: y, bottom: y });
+        boundOver = (rect) => bgFor(rect);
+
+        const artUnderCopy = intersect(contentRect, artRect);
+        const safeCopy = !artUnderCopy || containsRect(safe, artUnderCopy);
+        const framed = bb.classList.contains('has-art-aspect');
+        const clear = framed ? contentRect.top - artRect.bottom : null;
+        const shortBy = contentRect.bottom - safe.bottom;
+        if (shortBy > 0.5) {
+          notes.push('panel ends ' + Math.round(shortBy) + 'px above copy end (on #0b0b0b)');
+        }
+        if (fade > 0) notes.push('fade band ' + Math.round(fade) + 'px treated as unsafe');
+        geometry = {
+          label: !safeCopy
+            ? 'ARTWORK REACHES COPY'
+            : framed ? 'frame clear by ' + Math.round(clear) + 'px' : 'no artwork under copy',
+          ok: safeCopy && (clear === null || clear >= 0)
+        };
+      } else {
+        const grad = parseLinearGradient(before.backgroundImage);
+        const maskRaw = before.maskImage && before.maskImage !== 'none' ? before.maskImage : before.webkitMaskImage;
+        const mask = parseLinearGradient(maskRaw);
+        if (!grad || !grad.horizontal) { unmodelled = true; notes.push('band tint not a left-to-right gradient'); }
+        if (!mask || !mask.horizontal) { unmodelled = true; notes.push('band mask not a left-to-right gradient'); }
+        const bandLeft = contentRect.left + parseFloat(before.left);
+        const bandRight = contentRect.right - parseFloat(before.right);
+        const bandW = bandRight - bandLeft;
+        bgAt = (x) => {
+          if (unmodelled || x < bandLeft || x > bandRight || bandW <= 0) return ART;
+          const t = (x - bandLeft) / bandW;
+          const tint = colorAtStop(grad.stops, t);
+          const m = colorAtStop(mask.stops, t).a;
+          return over({ r: tint.r, g: tint.g, b: tint.b, a: tint.a * m }, ART);
+        };
+        // Tint is monotonic left-to-right, but sample rather than assume it.
+        boundOver = (rect) => {
+          let worst = null;
+          for (let x = rect.left; x <= rect.right; x += 2) {
+            const c = bgAt(x);
+            if (!worst || luminance(c) > luminance(worst)) worst = c;
+          }
+          return worst || ART;
+        };
+        const covers = bandLeft <= contentRect.left + 0.5 && bandRight >= contentRect.right - 0.5;
+        geometry = {
+          label: covers
+            ? 'band spans column +' + Math.round(bandRight - contentRect.right) + 'px'
+            : 'BAND NARROWER THAN COLUMN',
+          ok: covers
+        };
+        if (!covers) notes.push('band does not span the copy column');
+      }
+
+      const worstBg = boundOver(contentRect);
+
+      // Distinct text styles actually present, each judged against that bound.
+      const leaves = textLeaves(content);
+      const styles = new Map();
+      let inkWorst = null;
+      for (const el of leaves) {
+        const st = styleOf(el);
+        if (!st.color) continue;
+        const bgLayers = ancestorBackgrounds(el, content);
+        if (bgLayers.some((l) => l.unmodelled)) { notes.push('unmodelled background image on ' + (el.className || el.tagName)); }
+        const applyLayers = (base) => bgLayers.reduce((acc, l) => (l.color ? over(l.color, acc) : acc), base);
+
+        // Bound over the element's own box: text can never leave it, so this is
+        // independent of font metrics and of how long the episode title is.
+        const box = intersect(el.getBoundingClientRect(), bbRect);
+        if (!box) continue;
+        const boundBg = applyLayers(boundOver(box));
+        const ratio = contrast(over(st.color, boundBg), boundBg);
+        const key = el.className + '|' + Math.round(st.size) + '|' + st.weight;
+        const label = (el.className || el.tagName.toLowerCase()).replace('billboard__', '');
+        if (!styles.has(key) || styles.get(key).ratio > ratio) {
+          styles.set(key, { label, ratio, threshold: st.threshold, size: st.size, weight: st.weight });
+        }
+
+        // Measured ink, as a cross-check on the bound.
+        for (const r of ownInkRects(el, bbRect)) {
+          const y = (r.top + r.bottom) / 2;
+          for (let x = r.left; x <= r.right; x += 3) {
+            const bg = applyLayers(bgAt(x, y));
+            const ir = contrast(over(st.color, bg), bg);
+            if (!inkWorst || ir < inkWorst.ratio) inkWorst = { ratio: ir, label, threshold: st.threshold };
+          }
+        }
+      }
+
+      const styleList = [...styles.values()].sort((a, b) => (a.ratio / a.threshold) - (b.ratio / b.threshold));
+      const limiting = styleList[0] || null;
+      const pass = !unmodelled && geometry.ok && styleList.every((s) => s.ratio >= s.threshold)
+        && (!inkWorst || inkWorst.ratio >= inkWorst.threshold);
+
+      return {
+        nominalWidth, layoutWidth, height, aspectLabel,
+        mode: stacked ? 'stacked' : 'wide',
+        worstBg: hex(worstBg),
+        limiting, inkWorst, geometry, notes, pass, unmodelled
+      };
+    }
+
+    /* ---------------- sweep ---------------- */
+
+    const CRITICAL = [320, 360, 375, 390, 393, 412, 414, 430, 480, 540, 600, 639, 640, 699, 700, 701, 720, 768, 800, 834,
+      899, 900, 901, 960, 1024, 1080, 1100, 1180, 1200, 1279, 1280, 1281, 1300, 1366, 1400, 1440, 1500, 1536, 1600, 1700,
+      1800, 1900, 1920, 1978, 1980, 2000, 2048, 2200, 2400, 2560, 2880, 3000, 3200, 3440, 3840];
+
+    const SCENARIOS = {
+      'framed': [['16:9', '1.7777777777777777'], ['1:1', '1'], ['4:3', '1.3333333333333333']],
+      '16:9': [['16:9', '1.7777777777777777']],
+      'all': [['16:9', '1.7777777777777777'], ['1:1', '1'], ['4:3', '1.3333333333333333'], ['pre-measure', 'none']]
+    };
+
+    function widthList(step) {
+      const s = new Set(CRITICAL);
+      for (let w = 320; w <= 3840; w += step) s.add(w);
+      return [...s].sort((a, b) => a - b);
+    }
+
+    let rows = [];
+
+    async function run(step) {
+      const btns = [document.getElementById('run'), document.getElementById('runStrict')];
+      btns.forEach((b) => (b.disabled = true));
+      document.getElementById('verdict').className = 'idle';
+      document.getElementById('verdict').textContent = 'Running…';
+      await new Promise((r) => setTimeout(r, 0));
+
+      writeRig();
+      const scenarios = SCENARIOS[document.getElementById('scenarios').value];
+      const heights = document.getElementById('heights').value.split(',').map(Number);
+      const widths = widthList(step);
+      rows = [];
+
+      for (const [label, aspect] of scenarios) {
+        setScenario(aspect);
+        for (const h of heights) {
+          rig.style.height = h + 'px';
+          for (const w of widths) {
+            rig.style.width = w + 'px';
+            void rig.offsetWidth;
+            rows.push(measure(w, h, label));
+          }
+          await new Promise((r) => setTimeout(r, 0));
+        }
+      }
+
+      render();
+      btns.forEach((b) => (b.disabled = false));
+    }
+
+    function render() {
+      const failing = rows.filter((r) => !r.pass);
+      const verdict = document.getElementById('verdict');
+      if (!rows.length) { verdict.className = 'idle'; verdict.textContent = 'Not run yet.'; return; }
+      verdict.className = failing.length ? 'fail' : 'pass';
+      verdict.textContent = failing.length
+        ? failing.length + ' of ' + rows.length + ' width/height/art combinations FAIL'
+        : 'PASS — hero copy stays legible over solid #fff art at all ' + rows.length + ' combinations tested';
+
+      const worst = rows.reduce((a, b) => {
+        const ra = a.limiting ? a.limiting.ratio / a.limiting.threshold : Infinity;
+        const rb = b.limiting ? b.limiting.ratio / b.limiting.threshold : Infinity;
+        return rb < ra ? b : a;
+      });
+      const widths = [...new Set(rows.map((r) => r.nominalWidth))];
+      const cards = [
+        ['Combinations', rows.length],
+        ['Widths', widths.length + ' (' + Math.min(...widths) + '–' + Math.max(...widths) + 'px)'],
+        ['Failures', failing.length],
+        ['Tightest margin', worst.limiting ? worst.limiting.ratio.toFixed(2) + ':1 vs ' + worst.limiting.threshold + ':1' : '—'],
+        ['Tightest at', worst.nominalWidth + 'px ' + worst.mode + ' / ' + worst.aspectLabel],
+        ['Lightest bg seen', rows.reduce((a, b) => (luminance(parseColor('rgb(' + parseInt(b.worstBg.slice(1, 3), 16) + ',' + parseInt(b.worstBg.slice(3, 5), 16) + ',' + parseInt(b.worstBg.slice(5, 7), 16) + ')')) > luminance(parseColor('rgb(' + parseInt(a.worstBg.slice(1, 3), 16) + ',' + parseInt(a.worstBg.slice(3, 5), 16) + ',' + parseInt(a.worstBg.slice(5, 7), 16) + ')')) ? b : a)).worstBg]
+      ];
+      document.getElementById('cards').innerHTML = cards
+        .map(([k, v]) => '<div class="card"><div class="k">' + k + '</div><div class="v">' + v + '</div></div>').join('');
+
+      const failOnly = document.getElementById('failOnly').checked;
+      const show = failOnly ? failing : rows;
+      document.querySelector('#results tbody').innerHTML = show.map((r) => {
+        const lim = r.limiting;
+        const tag = r.pass ? '<span class="tag pass">pass</span>' : '<span class="tag fail">fail</span>';
+        const geo = '<span class="tag ' + (r.geometry.ok ? 'pass' : 'fail') + '">' + r.geometry.label + '</span>';
+        const ink = r.inkWorst ? ' <span style="color:#9a9a9a">(ink ' + r.inkWorst.ratio.toFixed(1) + ')</span>' : '';
+        return '<tr class="' + (r.pass ? '' : 'fail') + '">'
+          + '<td>' + r.nominalWidth + '</td>'
+          + '<td>' + r.layoutWidth + '</td>'
+          + '<td>' + r.height + '</td>'
+          + '<td>' + r.aspectLabel + '</td>'
+          + '<td>' + r.mode + '</td>'
+          + '<td><span class="swatch" style="background:' + r.worstBg + '"></span>' + r.worstBg + '</td>'
+          + '<td>' + (lim ? lim.ratio.toFixed(2) + ':1' : '—') + ink + '</td>'
+          + '<td>' + (lim ? lim.label + ' ' + Math.round(lim.size) + 'px/' + lim.weight : '—') + '</td>'
+          + '<td>' + (lim ? lim.threshold + ':1' : '—') + '</td>'
+          + '<td>' + geo + (r.notes.length ? ' <span class="tag warn">' + r.notes[0] + '</span>' : '') + '</td>'
+          + '<td>' + tag + '</td>'
+          + '</tr>';
+      }).join('');
+    }
+
+    /* ---------------- visual preview ---------------- */
+
+    function renderPreview() {
+      const w = +document.getElementById('pvWidth').value;
+      const h = +document.getElementById('pvHeight').value;
+      const aspect = document.getElementById('pvAspect').value;
+      const isolate = document.getElementById('pvIsolate').checked;
+      const wrap = document.getElementById('previewWrap');
+      wrap.innerHTML = '';
+      const f = document.createElement('iframe');
+      f.style.width = w + 'px';
+      f.style.height = h + 'px';
+      wrap.appendChild(f);
+      const d = f.contentDocument;
+      d.open(); d.write(frameDoc()); d.close();
+      const bb = d.querySelector('.billboard');
+      const stage = d.querySelector('.billboard__stage');
+      if (aspect === 'none') {
+        bb.classList.remove('has-art-aspect');
+        stage.classList.remove('has-edge-extend');
+        bb.style.removeProperty('--hero-art-aspect');
+        stage.style.removeProperty('--hero-art-aspect');
+      } else {
+        bb.style.setProperty('--hero-art-aspect', aspect);
+        stage.style.setProperty('--hero-art-aspect', aspect);
+      }
+      d.body.classList.toggle('isolate-band', isolate);
+      const scale = Math.min(1, (wrap.clientWidth || 1000) / w);
+      f.style.transform = 'scale(' + scale + ')';
+      wrap.style.height = Math.round(h * scale) + 'px';
+    }
+
+    document.getElementById('prov').textContent =
+      'Stylesheet: ' + META.source + ' — sha256 ' + META.sha256.slice(0, 16) + '… — regenerate with `' + META.command + '`';
+    document.getElementById('run').addEventListener('click', () => run(Math.max(1, +document.getElementById('step').value || 8)));
+    document.getElementById('runStrict').addEventListener('click', () => run(1));
+    document.getElementById('failOnly').addEventListener('change', render);
+    document.getElementById('pvGo').addEventListener('click', renderPreview);
+    renderPreview();
+  </script>
+</body>
+
+</html>

--- a/cultpodcasts/docs/hero-legibility.html
+++ b/cultpodcasts/docs/hero-legibility.html
@@ -588,38 +588,13 @@
   .billboard__vignette {
     background: linear-gradient(90deg, rgba(0, 0, 0, 0.28) 0%, rgba(0, 0, 0, 0.12) 24%, transparent 48%), radial-gradient(ellipse at 88% 42%, transparent 28%, rgba(0, 0, 0, 0.28) 100%);
   }
-  .billboard__content::before {
-    content: "";
-    position: absolute;
-    top: -100%;
-    bottom: -100%;
-    left: -6vw;
-    right: -240px;
-    z-index: -1;
-    pointer-events: none;
-    background: linear-gradient(90deg, rgba(0, 0, 0, 0.8) 0%, rgba(0, 0, 0, 0.72) 55%, rgba(0, 0, 0, 0.6) 100%);
-    -webkit-mask-image: linear-gradient(90deg, #000 0%, #000 calc(100% - 240px), transparent 100%);
-    mask-image: linear-gradient(90deg, #000 0%, #000 calc(100% - 240px), transparent 100%);
+  .billboard__title {
+    text-shadow: 0 0 0.045em rgb(0, 0, 0), 0 0 0.11em rgba(0, 0, 0, 0.98), 0 0 0.22em rgba(0, 0, 0, 0.92), 0 0 0.42em rgba(0, 0, 0, 0.8), 0 0 0.85em rgba(0, 0, 0, 0.55);
   }
-  @supports (backdrop-filter: blur(2px)) {
-    .billboard__content::before {
-      backdrop-filter: blur(22px) saturate(0.85);
-    }
-  }
-  @supports (mask-composite: intersect) {
-    .billboard__content::before {
-      top: -80px;
-      bottom: -48px;
-      -webkit-mask-image: linear-gradient(90deg, #000 0%, #000 calc(100% - 240px), transparent 100%), linear-gradient(180deg, transparent 0, #000 80px, #000 calc(100% - 48px), transparent 100%);
-      mask-image: linear-gradient(90deg, #000 0%, #000 calc(100% - 240px), transparent 100%), linear-gradient(180deg, transparent 0, #000 80px, #000 calc(100% - 48px), transparent 100%);
-      -webkit-mask-composite: source-in;
-      mask-composite: intersect;
-    }
-  }
-}
-@media screen and (min-width: 1280px) and (prefers-reduced-motion: reduce) {
-  .billboard__content::before {
-    backdrop-filter: none;
+  .billboard__eyebrow,
+  .billboard__meta,
+  .billboard__desc {
+    text-shadow: 0 0 1.5px rgb(0, 0, 0), 0 0 3px rgb(0, 0, 0), 0 0 6px rgba(0, 0, 0, 0.98), 0 0 12px rgba(0, 0, 0, 0.88), 0 0 22px rgba(0, 0, 0, 0.7), 0 0 38px rgba(0, 0, 0, 0.5);
   }
 }
 .billboard__content {
@@ -1155,7 +1130,7 @@
 }</script>
   <script id="hero-meta" type="application/json">{
   "source": "src/app/homepage-hero/homepage-hero.component.sass",
-  "sha256": "5fccd3f4f86a92a623476f54e1158b70898cd05fdb1ba4aa6e9be9465e8a3584",
+  "sha256": "afe8dbe4e72c3ae53f4b3b86f4bd1923f075c4f1d6ec316e33f0e5962463755e",
   "command": "npm run hero:legibility"
 }</script>
 

--- a/cultpodcasts/docs/hero-legibility.html
+++ b/cultpodcasts/docs/hero-legibility.html
@@ -373,11 +373,14 @@
 
   <h2>What this proves — and what it does not</h2>
   <ul class="notes">
-    <li><strong>Font independent.</strong> Copy is capped at <code>min(640px, 100%)</code>, so text can never be wider
-      than the copy column. The bound samples the <em>entire column</em>, not just where glyphs happen to land, so no
-      title length or font substitution can escape it. Measured ink is reported separately as a sanity check.</li>
-    <li><strong>The model is read from the live render</strong>, not re-declared here. Band edges, tint stops and mask
-      stops come from <code>getComputedStyle(el, '::before')</code> inside the rig, so it tracks the stylesheet.</li>
+    <li><strong>Font independent.</strong> Text cannot leave its own element box, so each text style is bounded over
+      <em>the whole of that box</em> rather than only where glyphs happen to land. Block copy fills the
+      <code>min(640px, 100%)</code> column, so no title length, locale or font substitution can escape the result.
+      Measured ink is reported alongside as a sanity check.</li>
+    <li><strong>The model is read from the live render</strong>, not re-declared here. Band edges, tint stops, mask stops
+      and <code>mask-composite</code> come from <code>getComputedStyle(el, '::before')</code> inside the rig, so it
+      tracks the stylesheet. Only axis-aligned gradients and <code>intersect</code> compositing are modelled; anything
+      else is reported as unmodelled and fails rather than being guessed at.</li>
     <li><strong>Deliberately pessimistic.</strong> <code>.billboard__scrim</code> and <code>.billboard__vignette</code>
       also darken the art but are excluded from the model, so the real background is always at least as dark as the
       number shown. <code>.billboard__grain</code> (7% soft-light noise) is disabled and excluded.</li>
@@ -595,12 +598,22 @@
     z-index: -1;
     pointer-events: none;
     background: linear-gradient(90deg, rgba(0, 0, 0, 0.8) 0%, rgba(0, 0, 0, 0.72) 55%, rgba(0, 0, 0, 0.6) 100%);
-    -webkit-mask-image: linear-gradient(90deg, #000 0%, #000 82%, transparent 100%);
-    mask-image: linear-gradient(90deg, #000 0%, #000 82%, transparent 100%);
+    -webkit-mask-image: linear-gradient(90deg, #000 0%, #000 calc(100% - 240px), transparent 100%);
+    mask-image: linear-gradient(90deg, #000 0%, #000 calc(100% - 240px), transparent 100%);
   }
   @supports (backdrop-filter: blur(2px)) {
     .billboard__content::before {
       backdrop-filter: blur(22px) saturate(0.85);
+    }
+  }
+  @supports (mask-composite: intersect) {
+    .billboard__content::before {
+      top: -80px;
+      bottom: -48px;
+      -webkit-mask-image: linear-gradient(90deg, #000 0%, #000 calc(100% - 240px), transparent 100%), linear-gradient(180deg, transparent 0, #000 80px, #000 calc(100% - 48px), transparent 100%);
+      mask-image: linear-gradient(90deg, #000 0%, #000 calc(100% - 240px), transparent 100%), linear-gradient(180deg, transparent 0, #000 80px, #000 calc(100% - 48px), transparent 100%);
+      -webkit-mask-composite: source-in;
+      mask-composite: intersect;
     }
   }
 }
@@ -1142,7 +1155,7 @@
 }</script>
   <script id="hero-meta" type="application/json">{
   "source": "src/app/homepage-hero/homepage-hero.component.sass",
-  "sha256": "c7b7d4e90689e30fdab286e520cace2e1d2b263ef8b2ca8aada3e2f0b6ee6f50",
+  "sha256": "5fccd3f4f86a92a623476f54e1158b70898cd05fdb1ba4aa6e9be9465e8a3584",
   "command": "npm run hero:legibility"
 }</script>
 
@@ -1313,17 +1326,27 @@ body { font-family: var(--cp-font-ui); }
       return out;
     }
 
-    /* Returns { stops:[{pos,color}], horizontal:bool } or null.
-       Only left-to-right gradients are modelled; anything else is reported as
+    /* A CSS length that may be a percentage of the containing block. */
+    function lenOf(value, basis) {
+      const s = String(value).trim();
+      const f = parseFloat(s);
+      if (!isFinite(f)) return NaN;
+      return s.endsWith('%') ? (f / 100) * basis : f;
+    }
+
+    /* Only axis-aligned gradients are modelled. Anything else is reported as
        unmodelled rather than silently mis-measured. */
     function parseLinearGradient(value) {
       const m = /^linear-gradient\((.*)\)$/s.exec(String(value).trim());
       if (!m) return null;
       const parts = splitTopLevel(m[1]);
-      let horizontal = false;
-      if (/^(to\s|[-\d.]+deg|calc)/i.test(parts[0]) && !/^rgba?\(/i.test(parts[0])) {
+      // Omitted direction means `to bottom`.
+      let axis = 'v';
+      if (/^(to\s+[a-z\s]+|[-\d.]+(deg|rad|turn|grad))$/i.test(parts[0])) {
         const dir = parts.shift().trim().toLowerCase();
-        horizontal = dir === '90deg' || dir === 'to right';
+        if (dir === '90deg' || dir === 'to right') axis = 'h';
+        else if (dir === '180deg' || dir === 'to bottom') axis = 'v';
+        else return null;
       }
       const stops = [];
       for (const p of parts) {
@@ -1331,16 +1354,40 @@ body { font-family: var(--cp-font-ui); }
         if (!cm) return null;
         const color = parseColor(cm[1]) || (cm[1] === 'transparent' ? { r: 0, g: 0, b: 0, a: 0 } : null);
         if (!color) return null;
-        const pos = /([-\d.]+)%/.exec(cm[2]);
-        stops.push({ pos: pos ? parseFloat(pos[1]) / 100 : null, color });
+        stops.push({ posRaw: cm[2].trim() || null, color });
       }
-      if (!stops.length) return null;
+      return stops.length ? { axis, stops } : null;
+    }
+
+    /* Stop offsets can be %, px, or calc(100% - px); resolve against the axis. */
+    function resolveStopPos(raw, axisLen) {
+      if (raw == null) return null;
+      const s = raw.trim();
+      let m;
+      if ((m = /^([-\d.]+)%$/.exec(s))) return parseFloat(m[1]) / 100;
+      if ((m = /^([-\d.]+)px$/.exec(s))) return axisLen > 0 ? parseFloat(m[1]) / axisLen : NaN;
+      if ((m = /^calc\(\s*100%\s*-\s*([-\d.]+)px\s*\)$/.exec(s))) {
+        return axisLen > 0 ? (axisLen - parseFloat(m[1])) / axisLen : NaN;
+      }
+      if ((m = /^calc\(\s*([-\d.]+)px\s*\+\s*100%\s*\)$/.exec(s))) {
+        return axisLen > 0 ? (axisLen + parseFloat(m[1])) / axisLen : NaN;
+      }
+      return NaN;
+    }
+
+    function prepareGradient(value, bandW, bandH) {
+      const g = parseLinearGradient(value);
+      if (!g) return null;
+      const axisLen = g.axis === 'h' ? bandW : bandH;
+      const stops = g.stops.map((s) => ({ color: s.color, pos: resolveStopPos(s.posRaw, axisLen) }));
+      if (stops.some((s) => Number.isNaN(s.pos))) return null;
       if (stops[0].pos === null) stops[0].pos = 0;
       if (stops[stops.length - 1].pos === null) stops[stops.length - 1].pos = 1;
       for (let i = 1; i < stops.length - 1; i++) {
         if (stops[i].pos === null) stops[i].pos = i / (stops.length - 1);
       }
-      return { stops, horizontal };
+      for (let i = 1; i < stops.length; i++) stops[i].pos = Math.max(stops[i].pos, stops[i - 1].pos);
+      return { axis: g.axis, stops };
     }
 
     /* CSS interpolates gradients in premultiplied space. */
@@ -1528,38 +1575,73 @@ body { font-family: var(--cp-font-ui); }
           ok: safeCopy && (clear === null || clear >= 0)
         };
       } else {
-        const grad = parseLinearGradient(before.backgroundImage);
-        const maskRaw = before.maskImage && before.maskImage !== 'none' ? before.maskImage : before.webkitMaskImage;
-        const mask = parseLinearGradient(maskRaw);
-        if (!grad || !grad.horizontal) { unmodelled = true; notes.push('band tint not a left-to-right gradient'); }
-        if (!mask || !mask.horizontal) { unmodelled = true; notes.push('band mask not a left-to-right gradient'); }
-        const bandLeft = contentRect.left + parseFloat(before.left);
-        const bandRight = contentRect.right - parseFloat(before.right);
+        // The band is positioned off the copy box, so derive its rect from it.
+        const bandLeft = contentRect.left + lenOf(before.left, contentRect.width);
+        const bandRight = contentRect.right - lenOf(before.right, contentRect.width);
+        const bandTop = contentRect.top + lenOf(before.top, contentRect.height);
+        const bandBottom = contentRect.bottom - lenOf(before.bottom, contentRect.height);
         const bandW = bandRight - bandLeft;
-        bgAt = (x) => {
-          if (unmodelled || x < bandLeft || x > bandRight || bandW <= 0) return ART;
-          const t = (x - bandLeft) / bandW;
-          const tint = colorAtStop(grad.stops, t);
-          const m = colorAtStop(mask.stops, t).a;
-          return over({ r: tint.r, g: tint.g, b: tint.b, a: tint.a * m }, ART);
+        const bandH = bandBottom - bandTop;
+
+        const tint = prepareGradient(before.backgroundImage, bandW, bandH);
+        const maskRaw = before.maskImage && before.maskImage !== 'none' ? before.maskImage : before.webkitMaskImage;
+        const maskLayers = (maskRaw && maskRaw !== 'none' ? splitTopLevel(maskRaw) : [])
+          .map((v) => prepareGradient(v, bandW, bandH));
+        const ops = String(before.maskComposite || 'add').split(',').map((s) => s.trim());
+
+        if (!tint || tint.axis !== 'h') { unmodelled = true; notes.push('band tint is not a horizontal gradient'); }
+        if (!maskLayers.length || maskLayers.some((l) => !l)) { unmodelled = true; notes.push('band mask not modelled'); }
+        // Multi-layer masks are only separable when every layer intersects;
+        // other operators are order-dependent, so refuse rather than guess.
+        if (maskLayers.length > 1 && !ops.every((o) => o === 'intersect')) {
+          unmodelled = true;
+          notes.push('mask-composite "' + ops.join(',') + '" not modelled');
+        }
+        if (!(bandW > 0) || !(bandH > 0)) { unmodelled = true; notes.push('band has no area'); }
+
+        const layersOn = (axis) => (unmodelled ? [] : maskLayers.filter((l) => l.axis === axis));
+        const hLayers = layersOn('h');
+        const vLayers = layersOn('v');
+        const hAlpha = (x) => hLayers.reduce((a, l) => a * colorAtStop(l.stops, (x - bandLeft) / bandW).a, 1);
+        const vAlpha = (y) => vLayers.reduce((a, l) => a * colorAtStop(l.stops, (y - bandTop) / bandH).a, 1);
+        const inBand = (x, y) => x >= bandLeft && x <= bandRight && y >= bandTop && y <= bandBottom;
+
+        bgAt = (x, y) => {
+          if (unmodelled || !inBand(x, y)) return ART;
+          const c = colorAtStop(tint.stops, (x - bandLeft) / bandW);
+          return over({ r: c.r, g: c.g, b: c.b, a: c.a * hAlpha(x) * vAlpha(y) }, ART);
         };
-        // Tint is monotonic left-to-right, but sample rather than assume it.
+
+        // Tint depends on x only and the mask layers are axis-aligned, so the
+        // worst point in a box is the worst x combined with the worst y.
         boundOver = (rect) => {
+          if (unmodelled) return ART;
+          let worstV = 1;
+          for (let y = rect.top; y <= rect.bottom; y += 2) {
+            const v = y < bandTop || y > bandBottom ? 0 : vAlpha(y);
+            if (v < worstV) worstV = v;
+          }
           let worst = null;
           for (let x = rect.left; x <= rect.right; x += 2) {
-            const c = bgAt(x);
-            if (!worst || luminance(c) > luminance(worst)) worst = c;
+            const inX = x >= bandLeft && x <= bandRight;
+            const c = inX ? colorAtStop(tint.stops, (x - bandLeft) / bandW) : { r: 0, g: 0, b: 0, a: 0 };
+            const px = over({ r: c.r, g: c.g, b: c.b, a: inX ? c.a * hAlpha(x) * worstV : 0 }, ART);
+            if (!worst || luminance(px) > luminance(worst)) worst = px;
           }
           return worst || ART;
         };
-        const covers = bandLeft <= contentRect.left + 0.5 && bandRight >= contentRect.right - 0.5;
+
+        const spansX = bandLeft <= contentRect.left + 0.5 && bandRight >= contentRect.right - 0.5;
+        const spansY = bandTop <= contentRect.top + 0.5 && bandBottom >= contentRect.bottom - 0.5;
         geometry = {
-          label: covers
-            ? 'band spans column +' + Math.round(bandRight - contentRect.right) + 'px'
-            : 'BAND NARROWER THAN COLUMN',
-          ok: covers
+          label: spansX && spansY
+            ? 'band wraps copy +' + Math.round(bandRight - contentRect.right) + '/'
+              + Math.round(contentRect.top - bandTop) + '/' + Math.round(bandBottom - contentRect.bottom) + 'px'
+            : !spansX ? 'BAND NARROWER THAN COLUMN' : 'BAND SHORTER THAN COPY',
+          ok: spansX && spansY
         };
-        if (!covers) notes.push('band does not span the copy column');
+        if (!spansX) notes.push('band does not span the copy column');
+        if (!spansY) notes.push('band does not cover the copy height');
       }
 
       const worstBg = boundOver(contentRect);

--- a/cultpodcasts/docs/hero-legibility.html
+++ b/cultpodcasts/docs/hero-legibility.html
@@ -588,13 +588,18 @@
   .billboard__vignette {
     background: linear-gradient(90deg, rgba(0, 0, 0, 0.28) 0%, rgba(0, 0, 0, 0.12) 24%, transparent 48%), radial-gradient(ellipse at 88% 42%, transparent 28%, rgba(0, 0, 0, 0.28) 100%);
   }
-  .billboard__title {
-    text-shadow: 0 0 0.045em rgb(0, 0, 0), 0 0 0.11em rgba(0, 0, 0, 0.98), 0 0 0.22em rgba(0, 0, 0, 0.92), 0 0 0.42em rgba(0, 0, 0, 0.8), 0 0 0.85em rgba(0, 0, 0, 0.55);
+  .billboard__content {
+    width: fit-content;
+    max-width: min(640px, 100%);
   }
-  .billboard__eyebrow,
-  .billboard__meta,
-  .billboard__desc {
-    text-shadow: 0 0 1.5px rgb(0, 0, 0), 0 0 3px rgb(0, 0, 0), 0 0 6px rgba(0, 0, 0, 0.98), 0 0 12px rgba(0, 0, 0, 0.88), 0 0 22px rgba(0, 0, 0, 0.7), 0 0 38px rgba(0, 0, 0, 0.5);
+  .billboard__content::before {
+    content: "";
+    position: absolute;
+    inset: -18px -24px -16px -24px;
+    border-radius: 14px;
+    background: rgba(11, 11, 11, 0.93);
+    z-index: -1;
+    pointer-events: none;
   }
 }
 .billboard__content {
@@ -1130,7 +1135,7 @@
 }</script>
   <script id="hero-meta" type="application/json">{
   "source": "src/app/homepage-hero/homepage-hero.component.sass",
-  "sha256": "afe8dbe4e72c3ae53f4b3b86f4bd1923f075c4f1d6ec316e33f0e5962463755e",
+  "sha256": "6a08a724028d1ce78315881dd56282b9b095b11ae227883eed8573a9cb0cd4db",
   "command": "npm run hero:legibility"
 }</script>
 

--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.74",
+  "version": "1.10.75",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.10.74",
+      "version": "1.10.75",
       "dependencies": {
         "@angular/cdk": "^22.0.6",
         "@angular/common": "^22.0.8",

--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.71",
+  "version": "1.10.72",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.10.71",
+      "version": "1.10.72",
       "dependencies": {
         "@angular/cdk": "^22.0.6",
         "@angular/common": "^22.0.8",

--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.69",
+  "version": "1.10.70",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.10.69",
+      "version": "1.10.70",
       "dependencies": {
         "@angular/cdk": "^22.0.6",
         "@angular/common": "^22.0.8",

--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.70",
+  "version": "1.10.71",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.10.70",
+      "version": "1.10.71",
       "dependencies": {
         "@angular/cdk": "^22.0.6",
         "@angular/common": "^22.0.8",

--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.72",
+  "version": "1.10.73",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.10.72",
+      "version": "1.10.73",
       "dependencies": {
         "@angular/cdk": "^22.0.6",
         "@angular/common": "^22.0.8",

--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.73",
+  "version": "1.10.74",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.10.73",
+      "version": "1.10.74",
       "dependencies": {
         "@angular/cdk": "^22.0.6",
         "@angular/common": "^22.0.8",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.72",
+  "version": "1.10.73",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.70",
+  "version": "1.10.71",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.71",
+  "version": "1.10.72",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",
@@ -16,6 +16,8 @@
     "deploy": "npm run build -- production && npm run process && wrangler pages deploy dist/cloudflare",
     "dev": "ng serve --configuration development",
     "deps:check": "node ./tools/check-dependency-updates.mjs",
+    "hero:legibility": "node ./tools/build-hero-legibility-harness.mjs",
+    "hero:legibility:check": "node ./tools/build-hero-legibility-harness.mjs --check",
     "auth0:sync-staging-urls": "node ./tools/sync-auth0-staging-urls.mjs"
   },
   "private": true,

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.74",
+  "version": "1.10.75",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.73",
+  "version": "1.10.74",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.69",
+  "version": "1.10.70",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
@@ -531,9 +531,12 @@
         // Drop the tall viewport min-height — it forced letterboxing around
         // the contain-sized art. Height comes from search clearance + copy.
         min-height: 0
-        // Height of the 16:9 media frame. Must track the frame's own aspect-ratio
-        // so the copy starts at its lower edge.
-        --hero-band-h: 56.25vw
+        // Media frame height, preferring 56.25vw — 16:9 at full width, the aspect
+        // ~80% of hero art uses, so it fills the frame exactly. Short-and-wide
+        // windows (a non-maximised desktop window) instead reserve ~320px for the
+        // copy so title and description stay above the fold; the frame is then
+        // wider than 16:9 and art letterboxes inside it.
+        --hero-band-h: clamp(180px, calc(100vh - 320px), 56.25vw)
         // Framed art ends on a clean edge, so no dissolve is needed. Only the
         // pre-measure fallback (art still covering the whole billboard) needs one.
         --hero-copy-fade: 0px
@@ -559,11 +562,9 @@
             right: 0
             bottom: auto
             width: 100%
-            height: auto
-            // Constant, not per-art: ~80% of hero art is a 16:9 video frame and
-            // fills this exactly, and a frame that resized per slide moved the copy
-            // (and everything below the hero) on every rotation.
-            aspect-ratio: 16 / 9
+            // Fixed height, not the art's aspect: a frame that resized per slide
+            // moved the copy (and everything below the hero) on every rotation.
+            height: var(--hero-band-h)
         // Art is contained in the frame (base .has-edge-extend rules), so 4:3 and
         // square cover art letterbox instead of being cropped or stretched.
         // Plain gutters — the blurred edge fill is a wide-layout effect.

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
@@ -531,15 +531,23 @@
         // Drop the tall viewport min-height — it forced letterboxing around
         // the contain-sized art. Height comes from search clearance + copy.
         min-height: 0
+        // Height of the 16:9 media frame. Must track the frame's own aspect-ratio
+        // so the copy starts at its lower edge.
+        --hero-band-h: 56.25vw
+        // Framed art ends on a clean edge, so no dissolve is needed. Only the
+        // pre-measure fallback (art still covering the whole billboard) needs one.
+        --hero-copy-fade: 0px
         &::before
             content: ''
-            flex: 0 0 var(--nflx-hero-search-clearance, 140px)
-            min-height: var(--nflx-hero-search-clearance, 140px)
+            flex: 0 0 max(var(--nflx-hero-search-clearance, 140px), var(--hero-band-h))
+            min-height: max(var(--nflx-hero-search-clearance, 140px), var(--hero-band-h))
             width: 100%
             pointer-events: none
-    // Media band matches art aspect so the image fills with no top/bottom bars.
-    // Mid-width: keep the band at top:0 under frosted/transparent chrome; clearance
-    // is for copy via ::before. Narrow (≤700) overrides top to sit below the sticky row.
+    .billboard:not(.has-art-aspect)
+        --hero-copy-fade: 96px
+    // Fixed 16:9 media frame at the top. Mid-width: keep it at top:0 under
+    // frosted/transparent chrome; clearance is for copy via ::before. Narrow (≤700)
+    // overrides top to sit below the sticky row.
     .billboard.has-art-aspect
         .billboard__stages,
         .billboard__grain,
@@ -552,18 +560,20 @@
             bottom: auto
             width: 100%
             height: auto
-            aspect-ratio: var(--hero-art-aspect)
-        .billboard__stage.has-edge-extend
-            .billboard__stage-edge--left,
-            .billboard__stage-edge--right
-                width: 0
-            .billboard__stage-focus-slot
-                inset: 0
-                top: 0
-                left: 0
-                width: 100%
-                height: 100%
-                transform: none
+            // Constant, not per-art: ~80% of hero art is a 16:9 video frame and
+            // fills this exactly, and a frame that resized per slide moved the copy
+            // (and everything below the hero) on every rotation.
+            aspect-ratio: 16 / 9
+        // Art is contained in the frame (base .has-edge-extend rules), so 4:3 and
+        // square cover art letterbox instead of being cropped or stretched.
+        // Plain gutters — the blurred edge fill is a wide-layout effect.
+        .billboard__stage
+            background-color: #0b0b0b
+        .billboard__stage.has-edge-extend .billboard__stage-edge
+            display: none
+    // Copy gets its own opaque full-bleed panel rather than sitting on the art:
+    // episode art routinely carries its own large burnt-in title, so no scrim makes
+    // overlaid type reliably legible.
     .billboard__content
         width: 100%
         max-width: min(640px, 100%)
@@ -571,6 +581,24 @@
         padding-top: 8px
         position: relative
         z-index: 2
+        &::before
+            content: ''
+            position: absolute
+            left: -4vw
+            top: calc(-1 * var(--hero-copy-fade))
+            width: 100vw
+            // Clipped by .billboard overflow; covers art of any aspect below the fade.
+            height: 100vh
+            z-index: -1
+            pointer-events: none
+            // Fade band on top, opaque fill for everything below it.
+            background: linear-gradient(to bottom, rgba(11, 11, 11, 0) 0%, rgba(11, 11, 11, 0.82) 72%, #0b0b0b 100%) no-repeat top / 100% var(--hero-copy-fade), linear-gradient(#0b0b0b, #0b0b0b) no-repeat bottom / 100% calc(100% - var(--hero-copy-fade))
+    // Copy no longer sits on the art, so the only job left is keeping the frosted
+    // chrome legible over the top of the frame.
+    .billboard__scrim
+        background: linear-gradient(to bottom, rgba(0, 0, 0, 0.45) 0%, transparent 22%)
+    .billboard__vignette
+        background: none
     .billboard__controls
         position: relative
         right: auto
@@ -591,10 +619,10 @@
         min-height: 0
         padding-bottom: 20px
         gap: 12px
-        // Copy offset under the fixed docked header (media band is offset separately).
+        // The frame sits below the chrome here, so the copy clears both.
         &::before
-            flex-basis: var(--nflx-hero-search-clearance, 64px)
-            min-height: var(--nflx-hero-search-clearance, 64px)
+            flex-basis: calc(var(--site-chrome-bar-h, 52px) + env(safe-area-inset-top, 0px) + var(--hero-band-h))
+            min-height: calc(var(--site-chrome-bar-h, 52px) + env(safe-area-inset-top, 0px) + var(--hero-band-h))
     // Narrow: art starts flush below the sticky chrome row — not tucked under it.
     // (Mid/wide ≤1280 keep top:0 so art can sit under frosted/transparent chrome.)
     .billboard.has-art-aspect
@@ -603,6 +631,9 @@
         .billboard__scrim,
         .billboard__vignette
             top: calc(var(--site-chrome-bar-h, 52px) + env(safe-area-inset-top, 0px))
+    // Frame is clear of the chrome, so it needs no top scrim at all.
+    .billboard.has-art-aspect .billboard__scrim
+        background: none
     .billboard__content
         padding-top: 0
     .billboard__eyebrow

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
@@ -201,13 +201,28 @@
         // Weighted left, where the ink is. The tint must hold contrast on its own:
         // blurring white artwork still leaves it white, so blur cannot substitute.
         background: linear-gradient(90deg, rgba(0, 0, 0, 0.8) 0%, rgba(0, 0, 0, 0.72) 55%, rgba(0, 0, 0, 0.6) 100%)
-        // Full tint across the copy column, then feather. Masks the backdrop-filter
-        // too, so the blur fades out together with the tint.
-        -webkit-mask-image: linear-gradient(90deg, #000 0%, #000 82%, transparent 100%)
-        mask-image: linear-gradient(90deg, #000 0%, #000 82%, transparent 100%)
+        // Opaque to the column's right edge, then feather across the overhang.
+        // Masks the backdrop-filter too, so blur fades out along with the tint.
+        -webkit-mask-image: linear-gradient(90deg, #000 0%, #000 calc(100% - 240px), transparent 100%)
+        mask-image: linear-gradient(90deg, #000 0%, #000 calc(100% - 240px), transparent 100%)
         // Blur only removes the artwork's own detail, so type is not read against edges.
         @supports (backdrop-filter: blur(2px))
             backdrop-filter: blur(22px) saturate(0.85)
+    // Wrap the treatment around the copy rather than running the hero's full
+    // height, which reads as a vertical wipe through the artwork. Intersecting a
+    // vertical ramp bounds it to the text block and feathers it above and below.
+    // Still fully opaque across the copy box, so the contrast floor is unchanged
+    // (proved for every width by docs/hero-legibility.html).
+    @supports (mask-composite: intersect)
+        .billboard__content::before
+            top: -80px
+            // Ramp ends exactly on the hero's bottom edge (48px of hero padding),
+            // so the feather completes rather than being clipped mid-fade.
+            bottom: -48px
+            -webkit-mask-image: linear-gradient(90deg, #000 0%, #000 calc(100% - 240px), transparent 100%), linear-gradient(180deg, transparent 0, #000 80px, #000 calc(100% - 48px), transparent 100%)
+            mask-image: linear-gradient(90deg, #000 0%, #000 calc(100% - 240px), transparent 100%), linear-gradient(180deg, transparent 0, #000 80px, #000 calc(100% - 48px), transparent 100%)
+            -webkit-mask-composite: source-in
+            mask-composite: intersect
     // Ken Burns runs under this band; skip the per-frame blur where motion is opted out.
     @media (prefers-reduced-motion: reduce)
         .billboard__content::before

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
@@ -184,20 +184,28 @@
         background: linear-gradient(90deg, rgba(0, 0, 0, 0.28) 0%, rgba(0, 0, 0, 0.12) 24%, transparent 48%), radial-gradient(ellipse at 88% 42%, transparent 28%, rgba(0, 0, 0, 0.28) 100%)
     // Full-height art is ~1.78× the hero height, so the left edge fill only reaches
     // under the copy above ~1980px wide. Below that the sharp image sits behind the
-    // title and white type can land on white artwork. Protect the copy with a halo
-    // that follows the glyphs rather than tinting a column of the hero: the artwork
-    // keeps its detail and its own lettering stays readable, and the darkening ends
-    // where each line of type ends instead of at a fixed x. Where the two compete,
-    // our copy wins locally and the artwork wins everywhere else.
-    // Radii are relative to font size on the display face so the contour stays
-    // proportionate across the clamped title, and fixed on the smaller UI text
-    // where em-scaled radii collapse to sub-pixel.
-    .billboard__title
-        text-shadow: 0 0 0.045em rgba(0, 0, 0, 1), 0 0 0.11em rgba(0, 0, 0, 0.98), 0 0 0.22em rgba(0, 0, 0, 0.92), 0 0 0.42em rgba(0, 0, 0, 0.8), 0 0 0.85em rgba(0, 0, 0, 0.55)
-    .billboard__eyebrow,
-    .billboard__meta,
-    .billboard__desc
-        text-shadow: 0 0 1.5px rgba(0, 0, 0, 1), 0 0 3px rgba(0, 0, 0, 1), 0 0 6px rgba(0, 0, 0, 0.98), 0 0 12px rgba(0, 0, 0, 0.88), 0 0 22px rgba(0, 0, 0, 0.7), 0 0 38px rgba(0, 0, 0, 0.5)
+    // copy, and type treatment alone cannot save it: artwork frequently carries its
+    // own burnt-in title or a white cover card exactly where our text lands, which
+    // is a collision of content rather than a contrast problem. Give the copy an
+    // opaque surface with deliberate edges — the same separation the narrow layout
+    // gets from its panel — so the artwork stays sharp and untouched everywhere
+    // outside it, including its own lettering.
+    .billboard__content
+        // Hug the copy instead of the fixed column so short slides avoid a
+        // full-width slab. The column width stays the ceiling, so long titles
+        // wrap exactly where they did before.
+        width: fit-content
+        max-width: min(640px, 100%)
+        &::before
+            content: ''
+            position: absolute
+            inset: -18px -24px -16px -24px
+            border-radius: 14px
+            // Short of opaque so a trace of artwork still reads through, while
+            // holding ~17:1 against white art — the worst case for white type.
+            background: rgba(11, 11, 11, 0.93)
+            z-index: -1
+            pointer-events: none
 
 .billboard__content
     position: relative

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
@@ -184,49 +184,20 @@
         background: linear-gradient(90deg, rgba(0, 0, 0, 0.28) 0%, rgba(0, 0, 0, 0.12) 24%, transparent 48%), radial-gradient(ellipse at 88% 42%, transparent 28%, rgba(0, 0, 0, 0.28) 100%)
     // Full-height art is ~1.78× the hero height, so the left edge fill only reaches
     // under the copy above ~1980px wide. Below that the sharp image sits behind the
-    // title and white type can land on white artwork. Give the copy its own frosted
-    // band, feathered on the right so it reads as glass rather than a slab.
-    // Darkening alone must carry legibility — the blur is progressive enhancement.
-    .billboard__content::before
-        content: ''
-        position: absolute
-        // Full-height band (clipped by .billboard) so it has no visible top/bottom edge.
-        top: -100%
-        bottom: -100%
-        left: -6vw
-        // Overhang gives the fade room to land clear of the text, not across it.
-        right: -240px
-        z-index: -1
-        pointer-events: none
-        // Weighted left, where the ink is. The tint must hold contrast on its own:
-        // blurring white artwork still leaves it white, so blur cannot substitute.
-        background: linear-gradient(90deg, rgba(0, 0, 0, 0.8) 0%, rgba(0, 0, 0, 0.72) 55%, rgba(0, 0, 0, 0.6) 100%)
-        // Opaque to the column's right edge, then feather across the overhang.
-        // Masks the backdrop-filter too, so blur fades out along with the tint.
-        -webkit-mask-image: linear-gradient(90deg, #000 0%, #000 calc(100% - 240px), transparent 100%)
-        mask-image: linear-gradient(90deg, #000 0%, #000 calc(100% - 240px), transparent 100%)
-        // Blur only removes the artwork's own detail, so type is not read against edges.
-        @supports (backdrop-filter: blur(2px))
-            backdrop-filter: blur(22px) saturate(0.85)
-    // Wrap the treatment around the copy rather than running the hero's full
-    // height, which reads as a vertical wipe through the artwork. Intersecting a
-    // vertical ramp bounds it to the text block and feathers it above and below.
-    // Still fully opaque across the copy box, so the contrast floor is unchanged
-    // (proved for every width by docs/hero-legibility.html).
-    @supports (mask-composite: intersect)
-        .billboard__content::before
-            top: -80px
-            // Ramp ends exactly on the hero's bottom edge (48px of hero padding),
-            // so the feather completes rather than being clipped mid-fade.
-            bottom: -48px
-            -webkit-mask-image: linear-gradient(90deg, #000 0%, #000 calc(100% - 240px), transparent 100%), linear-gradient(180deg, transparent 0, #000 80px, #000 calc(100% - 48px), transparent 100%)
-            mask-image: linear-gradient(90deg, #000 0%, #000 calc(100% - 240px), transparent 100%), linear-gradient(180deg, transparent 0, #000 80px, #000 calc(100% - 48px), transparent 100%)
-            -webkit-mask-composite: source-in
-            mask-composite: intersect
-    // Ken Burns runs under this band; skip the per-frame blur where motion is opted out.
-    @media (prefers-reduced-motion: reduce)
-        .billboard__content::before
-            backdrop-filter: none
+    // title and white type can land on white artwork. Protect the copy with a halo
+    // that follows the glyphs rather than tinting a column of the hero: the artwork
+    // keeps its detail and its own lettering stays readable, and the darkening ends
+    // where each line of type ends instead of at a fixed x. Where the two compete,
+    // our copy wins locally and the artwork wins everywhere else.
+    // Radii are relative to font size on the display face so the contour stays
+    // proportionate across the clamped title, and fixed on the smaller UI text
+    // where em-scaled radii collapse to sub-pixel.
+    .billboard__title
+        text-shadow: 0 0 0.045em rgba(0, 0, 0, 1), 0 0 0.11em rgba(0, 0, 0, 0.98), 0 0 0.22em rgba(0, 0, 0, 0.92), 0 0 0.42em rgba(0, 0, 0, 0.8), 0 0 0.85em rgba(0, 0, 0, 0.55)
+    .billboard__eyebrow,
+    .billboard__meta,
+    .billboard__desc
+        text-shadow: 0 0 1.5px rgba(0, 0, 0, 1), 0 0 3px rgba(0, 0, 0, 1), 0 0 6px rgba(0, 0, 0, 0.98), 0 0 12px rgba(0, 0, 0, 0.88), 0 0 22px rgba(0, 0, 0, 0.7), 0 0 38px rgba(0, 0, 0, 0.5)
 
 .billboard__content
     position: relative

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
@@ -182,6 +182,36 @@
         background: linear-gradient(90deg, rgba(0, 0, 0, 0.78) 0%, rgba(0, 0, 0, 0.55) 18%, rgba(0, 0, 0, 0.28) 36%, rgba(0, 0, 0, 0.1) 52%, transparent 68%), linear-gradient(to top, #0b0b0b 0%, transparent 42%), linear-gradient(to bottom, rgba(0, 0, 0, 0.45) 0%, transparent 20%)
     .billboard__vignette
         background: linear-gradient(90deg, rgba(0, 0, 0, 0.28) 0%, rgba(0, 0, 0, 0.12) 24%, transparent 48%), radial-gradient(ellipse at 88% 42%, transparent 28%, rgba(0, 0, 0, 0.28) 100%)
+    // Full-height art is ~1.78× the hero height, so the left edge fill only reaches
+    // under the copy above ~1980px wide. Below that the sharp image sits behind the
+    // title and white type can land on white artwork. Give the copy its own frosted
+    // band, feathered on the right so it reads as glass rather than a slab.
+    // Darkening alone must carry legibility — the blur is progressive enhancement.
+    .billboard__content::before
+        content: ''
+        position: absolute
+        // Full-height band (clipped by .billboard) so it has no visible top/bottom edge.
+        top: -100%
+        bottom: -100%
+        left: -6vw
+        // Overhang gives the fade room to land clear of the text, not across it.
+        right: -240px
+        z-index: -1
+        pointer-events: none
+        // Weighted left, where the ink is. The tint must hold contrast on its own:
+        // blurring white artwork still leaves it white, so blur cannot substitute.
+        background: linear-gradient(90deg, rgba(0, 0, 0, 0.8) 0%, rgba(0, 0, 0, 0.72) 55%, rgba(0, 0, 0, 0.6) 100%)
+        // Full tint across the copy column, then feather. Masks the backdrop-filter
+        // too, so the blur fades out together with the tint.
+        -webkit-mask-image: linear-gradient(90deg, #000 0%, #000 82%, transparent 100%)
+        mask-image: linear-gradient(90deg, #000 0%, #000 82%, transparent 100%)
+        // Blur only removes the artwork's own detail, so type is not read against edges.
+        @supports (backdrop-filter: blur(2px))
+            backdrop-filter: blur(22px) saturate(0.85)
+    // Ken Burns runs under this band; skip the per-frame blur where motion is opted out.
+    @media (prefers-reduced-motion: reduce)
+        .billboard__content::before
+            backdrop-filter: none
 
 .billboard__content
     position: relative
@@ -594,6 +624,10 @@
             pointer-events: none
             // Fade band on top, opaque fill for everything below it.
             background: linear-gradient(to bottom, rgba(11, 11, 11, 0) 0%, rgba(11, 11, 11, 0.82) 72%, #0b0b0b 100%) no-repeat top / 100% var(--hero-copy-fade), linear-gradient(#0b0b0b, #0b0b0b) no-repeat bottom / 100% calc(100% - var(--hero-copy-fade))
+            // Both breakpoints match at exactly 1280px; drop the wide frosted band.
+            backdrop-filter: none
+            -webkit-mask-image: none
+            mask-image: none
     // Copy no longer sits on the art, so the only job left is keeping the frosted
     // chrome legible over the top of the frame.
     .billboard__scrim

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
@@ -618,8 +618,11 @@
             left: -4vw
             top: calc(-1 * var(--hero-copy-fade))
             width: 100vw
-            // Clipped by .billboard overflow; covers art of any aspect below the fade.
-            height: 100vh
+            // Clipped by .billboard overflow; covers art of any aspect below the
+            // fade. Includes the copy's own height so a short viewport with tall
+            // copy cannot leave a sliver of art below the panel; both background
+            // layers are sized off the element, so over-extending is free.
+            height: calc(100vh + 100%)
             z-index: -1
             pointer-events: none
             // Fade band on top, opaque fill for everything below it.

--- a/cultpodcasts/tools/build-hero-legibility-harness.mjs
+++ b/cultpodcasts/tools/build-hero-legibility-harness.mjs
@@ -49,7 +49,11 @@ const meta = {
   command: COMMAND
 };
 
-const template = readFileSync(TEMPLATE_PATH, 'utf8');
+// Normalise to LF: git may check these files out as CRLF, and --check must not
+// fail over line endings.
+const lf = (s) => s.replace(/\r\n/g, '\n');
+
+const template = lf(readFileSync(TEMPLATE_PATH, 'utf8'));
 for (const token of ['/*__HERO_CSS__*/', '/*__HERO_META__*/']) {
   if (!template.includes(token)) {
     console.error(`Template is missing the ${token} placeholder.`);
@@ -57,9 +61,9 @@ for (const token of ['/*__HERO_CSS__*/', '/*__HERO_META__*/']) {
   }
 }
 
-const output = template
+const output = lf(template
   .replace('/*__HERO_CSS__*/', () => css)
-  .replace('/*__HERO_META__*/', () => JSON.stringify(meta, null, 2));
+  .replace('/*__HERO_META__*/', () => JSON.stringify(meta, null, 2)));
 
 if (process.argv.includes('--check')) {
   let existing = null;
@@ -69,7 +73,7 @@ if (process.argv.includes('--check')) {
     console.error(`${relative(appRoot, OUT_PATH)} is missing. Run ${COMMAND}.`);
     process.exit(1);
   }
-  if (existing !== output) {
+  if (lf(existing) !== output) {
     console.error(`${relative(appRoot, OUT_PATH)} is stale. Run ${COMMAND}.`);
     process.exit(1);
   }

--- a/cultpodcasts/tools/build-hero-legibility-harness.mjs
+++ b/cultpodcasts/tools/build-hero-legibility-harness.mjs
@@ -1,0 +1,82 @@
+/**
+ * Builds docs/hero-legibility.html from the live hero stylesheet.
+ *
+ * The harness must never carry a hand-copied snapshot of the CSS it claims to
+ * verify, so the component sass is compiled in and stamped with its hash.
+ *
+ *   node ./tools/build-hero-legibility-harness.mjs          # write
+ *   node ./tools/build-hero-legibility-harness.mjs --check   # fail if stale
+ */
+import { createHash } from 'node:crypto';
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const here = dirname(fileURLToPath(import.meta.url));
+const appRoot = join(here, '..');
+
+const SASS_PATH = join(appRoot, 'src/app/homepage-hero/homepage-hero.component.sass');
+const TEMPLATE_PATH = join(here, 'hero-legibility-harness.template.html');
+const OUT_PATH = join(appRoot, 'docs/hero-legibility.html');
+const COMMAND = 'npm run hero:legibility';
+
+let sass;
+try {
+  sass = require('sass');
+} catch {
+  console.error('Could not resolve "sass". Run npm install first.');
+  process.exit(1);
+}
+
+const sourceCss = readFileSync(SASS_PATH);
+const sha256 = createHash('sha256').update(sourceCss).digest('hex');
+
+const compiled = sass.compile(SASS_PATH, { style: 'expanded', sourceMap: false });
+
+/**
+ * :host / :host-context only resolve inside a shadow tree. The harness renders
+ * the component markup in a plain document, so map them onto a wrapper class.
+ */
+const css = compiled.css
+  .replace(/:host-context\(([^)]*)\)\s*/g, '$1 ')
+  .replace(/:host/g, '.hero-host');
+
+const meta = {
+  source: relative(appRoot, SASS_PATH).replace(/\\/g, '/'),
+  sha256,
+  command: COMMAND
+};
+
+const template = readFileSync(TEMPLATE_PATH, 'utf8');
+for (const token of ['/*__HERO_CSS__*/', '/*__HERO_META__*/']) {
+  if (!template.includes(token)) {
+    console.error(`Template is missing the ${token} placeholder.`);
+    process.exit(1);
+  }
+}
+
+const output = template
+  .replace('/*__HERO_CSS__*/', () => css)
+  .replace('/*__HERO_META__*/', () => JSON.stringify(meta, null, 2));
+
+if (process.argv.includes('--check')) {
+  let existing = null;
+  try {
+    existing = readFileSync(OUT_PATH, 'utf8');
+  } catch {
+    console.error(`${relative(appRoot, OUT_PATH)} is missing. Run ${COMMAND}.`);
+    process.exit(1);
+  }
+  if (existing !== output) {
+    console.error(`${relative(appRoot, OUT_PATH)} is stale. Run ${COMMAND}.`);
+    process.exit(1);
+  }
+  console.log(`hero-legibility.html is up to date (sass sha256 ${sha256.slice(0, 16)}…).`);
+  process.exit(0);
+}
+
+mkdirSync(dirname(OUT_PATH), { recursive: true });
+writeFileSync(OUT_PATH, output);
+console.log(`Wrote ${relative(appRoot, OUT_PATH)} (sass sha256 ${sha256.slice(0, 16)}…, ${css.length} bytes of CSS).`);

--- a/cultpodcasts/tools/hero-legibility-harness.template.html
+++ b/cultpodcasts/tools/hero-legibility-harness.template.html
@@ -373,11 +373,14 @@
 
   <h2>What this proves — and what it does not</h2>
   <ul class="notes">
-    <li><strong>Font independent.</strong> Copy is capped at <code>min(640px, 100%)</code>, so text can never be wider
-      than the copy column. The bound samples the <em>entire column</em>, not just where glyphs happen to land, so no
-      title length or font substitution can escape it. Measured ink is reported separately as a sanity check.</li>
-    <li><strong>The model is read from the live render</strong>, not re-declared here. Band edges, tint stops and mask
-      stops come from <code>getComputedStyle(el, '::before')</code> inside the rig, so it tracks the stylesheet.</li>
+    <li><strong>Font independent.</strong> Text cannot leave its own element box, so each text style is bounded over
+      <em>the whole of that box</em> rather than only where glyphs happen to land. Block copy fills the
+      <code>min(640px, 100%)</code> column, so no title length, locale or font substitution can escape the result.
+      Measured ink is reported alongside as a sanity check.</li>
+    <li><strong>The model is read from the live render</strong>, not re-declared here. Band edges, tint stops, mask stops
+      and <code>mask-composite</code> come from <code>getComputedStyle(el, '::before')</code> inside the rig, so it
+      tracks the stylesheet. Only axis-aligned gradients and <code>intersect</code> compositing are modelled; anything
+      else is reported as unmodelled and fails rather than being guessed at.</li>
     <li><strong>Deliberately pessimistic.</strong> <code>.billboard__scrim</code> and <code>.billboard__vignette</code>
       also darken the art but are excluded from the model, so the real background is always at least as dark as the
       number shown. <code>.billboard__grain</code> (7% soft-light noise) is disabled and excluded.</li>
@@ -565,17 +568,27 @@ body { font-family: var(--cp-font-ui); }
       return out;
     }
 
-    /* Returns { stops:[{pos,color}], horizontal:bool } or null.
-       Only left-to-right gradients are modelled; anything else is reported as
+    /* A CSS length that may be a percentage of the containing block. */
+    function lenOf(value, basis) {
+      const s = String(value).trim();
+      const f = parseFloat(s);
+      if (!isFinite(f)) return NaN;
+      return s.endsWith('%') ? (f / 100) * basis : f;
+    }
+
+    /* Only axis-aligned gradients are modelled. Anything else is reported as
        unmodelled rather than silently mis-measured. */
     function parseLinearGradient(value) {
       const m = /^linear-gradient\((.*)\)$/s.exec(String(value).trim());
       if (!m) return null;
       const parts = splitTopLevel(m[1]);
-      let horizontal = false;
-      if (/^(to\s|[-\d.]+deg|calc)/i.test(parts[0]) && !/^rgba?\(/i.test(parts[0])) {
+      // Omitted direction means `to bottom`.
+      let axis = 'v';
+      if (/^(to\s+[a-z\s]+|[-\d.]+(deg|rad|turn|grad))$/i.test(parts[0])) {
         const dir = parts.shift().trim().toLowerCase();
-        horizontal = dir === '90deg' || dir === 'to right';
+        if (dir === '90deg' || dir === 'to right') axis = 'h';
+        else if (dir === '180deg' || dir === 'to bottom') axis = 'v';
+        else return null;
       }
       const stops = [];
       for (const p of parts) {
@@ -583,16 +596,40 @@ body { font-family: var(--cp-font-ui); }
         if (!cm) return null;
         const color = parseColor(cm[1]) || (cm[1] === 'transparent' ? { r: 0, g: 0, b: 0, a: 0 } : null);
         if (!color) return null;
-        const pos = /([-\d.]+)%/.exec(cm[2]);
-        stops.push({ pos: pos ? parseFloat(pos[1]) / 100 : null, color });
+        stops.push({ posRaw: cm[2].trim() || null, color });
       }
-      if (!stops.length) return null;
+      return stops.length ? { axis, stops } : null;
+    }
+
+    /* Stop offsets can be %, px, or calc(100% - px); resolve against the axis. */
+    function resolveStopPos(raw, axisLen) {
+      if (raw == null) return null;
+      const s = raw.trim();
+      let m;
+      if ((m = /^([-\d.]+)%$/.exec(s))) return parseFloat(m[1]) / 100;
+      if ((m = /^([-\d.]+)px$/.exec(s))) return axisLen > 0 ? parseFloat(m[1]) / axisLen : NaN;
+      if ((m = /^calc\(\s*100%\s*-\s*([-\d.]+)px\s*\)$/.exec(s))) {
+        return axisLen > 0 ? (axisLen - parseFloat(m[1])) / axisLen : NaN;
+      }
+      if ((m = /^calc\(\s*([-\d.]+)px\s*\+\s*100%\s*\)$/.exec(s))) {
+        return axisLen > 0 ? (axisLen + parseFloat(m[1])) / axisLen : NaN;
+      }
+      return NaN;
+    }
+
+    function prepareGradient(value, bandW, bandH) {
+      const g = parseLinearGradient(value);
+      if (!g) return null;
+      const axisLen = g.axis === 'h' ? bandW : bandH;
+      const stops = g.stops.map((s) => ({ color: s.color, pos: resolveStopPos(s.posRaw, axisLen) }));
+      if (stops.some((s) => Number.isNaN(s.pos))) return null;
       if (stops[0].pos === null) stops[0].pos = 0;
       if (stops[stops.length - 1].pos === null) stops[stops.length - 1].pos = 1;
       for (let i = 1; i < stops.length - 1; i++) {
         if (stops[i].pos === null) stops[i].pos = i / (stops.length - 1);
       }
-      return { stops, horizontal };
+      for (let i = 1; i < stops.length; i++) stops[i].pos = Math.max(stops[i].pos, stops[i - 1].pos);
+      return { axis: g.axis, stops };
     }
 
     /* CSS interpolates gradients in premultiplied space. */
@@ -780,38 +817,73 @@ body { font-family: var(--cp-font-ui); }
           ok: safeCopy && (clear === null || clear >= 0)
         };
       } else {
-        const grad = parseLinearGradient(before.backgroundImage);
-        const maskRaw = before.maskImage && before.maskImage !== 'none' ? before.maskImage : before.webkitMaskImage;
-        const mask = parseLinearGradient(maskRaw);
-        if (!grad || !grad.horizontal) { unmodelled = true; notes.push('band tint not a left-to-right gradient'); }
-        if (!mask || !mask.horizontal) { unmodelled = true; notes.push('band mask not a left-to-right gradient'); }
-        const bandLeft = contentRect.left + parseFloat(before.left);
-        const bandRight = contentRect.right - parseFloat(before.right);
+        // The band is positioned off the copy box, so derive its rect from it.
+        const bandLeft = contentRect.left + lenOf(before.left, contentRect.width);
+        const bandRight = contentRect.right - lenOf(before.right, contentRect.width);
+        const bandTop = contentRect.top + lenOf(before.top, contentRect.height);
+        const bandBottom = contentRect.bottom - lenOf(before.bottom, contentRect.height);
         const bandW = bandRight - bandLeft;
-        bgAt = (x) => {
-          if (unmodelled || x < bandLeft || x > bandRight || bandW <= 0) return ART;
-          const t = (x - bandLeft) / bandW;
-          const tint = colorAtStop(grad.stops, t);
-          const m = colorAtStop(mask.stops, t).a;
-          return over({ r: tint.r, g: tint.g, b: tint.b, a: tint.a * m }, ART);
+        const bandH = bandBottom - bandTop;
+
+        const tint = prepareGradient(before.backgroundImage, bandW, bandH);
+        const maskRaw = before.maskImage && before.maskImage !== 'none' ? before.maskImage : before.webkitMaskImage;
+        const maskLayers = (maskRaw && maskRaw !== 'none' ? splitTopLevel(maskRaw) : [])
+          .map((v) => prepareGradient(v, bandW, bandH));
+        const ops = String(before.maskComposite || 'add').split(',').map((s) => s.trim());
+
+        if (!tint || tint.axis !== 'h') { unmodelled = true; notes.push('band tint is not a horizontal gradient'); }
+        if (!maskLayers.length || maskLayers.some((l) => !l)) { unmodelled = true; notes.push('band mask not modelled'); }
+        // Multi-layer masks are only separable when every layer intersects;
+        // other operators are order-dependent, so refuse rather than guess.
+        if (maskLayers.length > 1 && !ops.every((o) => o === 'intersect')) {
+          unmodelled = true;
+          notes.push('mask-composite "' + ops.join(',') + '" not modelled');
+        }
+        if (!(bandW > 0) || !(bandH > 0)) { unmodelled = true; notes.push('band has no area'); }
+
+        const layersOn = (axis) => (unmodelled ? [] : maskLayers.filter((l) => l.axis === axis));
+        const hLayers = layersOn('h');
+        const vLayers = layersOn('v');
+        const hAlpha = (x) => hLayers.reduce((a, l) => a * colorAtStop(l.stops, (x - bandLeft) / bandW).a, 1);
+        const vAlpha = (y) => vLayers.reduce((a, l) => a * colorAtStop(l.stops, (y - bandTop) / bandH).a, 1);
+        const inBand = (x, y) => x >= bandLeft && x <= bandRight && y >= bandTop && y <= bandBottom;
+
+        bgAt = (x, y) => {
+          if (unmodelled || !inBand(x, y)) return ART;
+          const c = colorAtStop(tint.stops, (x - bandLeft) / bandW);
+          return over({ r: c.r, g: c.g, b: c.b, a: c.a * hAlpha(x) * vAlpha(y) }, ART);
         };
-        // Tint is monotonic left-to-right, but sample rather than assume it.
+
+        // Tint depends on x only and the mask layers are axis-aligned, so the
+        // worst point in a box is the worst x combined with the worst y.
         boundOver = (rect) => {
+          if (unmodelled) return ART;
+          let worstV = 1;
+          for (let y = rect.top; y <= rect.bottom; y += 2) {
+            const v = y < bandTop || y > bandBottom ? 0 : vAlpha(y);
+            if (v < worstV) worstV = v;
+          }
           let worst = null;
           for (let x = rect.left; x <= rect.right; x += 2) {
-            const c = bgAt(x);
-            if (!worst || luminance(c) > luminance(worst)) worst = c;
+            const inX = x >= bandLeft && x <= bandRight;
+            const c = inX ? colorAtStop(tint.stops, (x - bandLeft) / bandW) : { r: 0, g: 0, b: 0, a: 0 };
+            const px = over({ r: c.r, g: c.g, b: c.b, a: inX ? c.a * hAlpha(x) * worstV : 0 }, ART);
+            if (!worst || luminance(px) > luminance(worst)) worst = px;
           }
           return worst || ART;
         };
-        const covers = bandLeft <= contentRect.left + 0.5 && bandRight >= contentRect.right - 0.5;
+
+        const spansX = bandLeft <= contentRect.left + 0.5 && bandRight >= contentRect.right - 0.5;
+        const spansY = bandTop <= contentRect.top + 0.5 && bandBottom >= contentRect.bottom - 0.5;
         geometry = {
-          label: covers
-            ? 'band spans column +' + Math.round(bandRight - contentRect.right) + 'px'
-            : 'BAND NARROWER THAN COLUMN',
-          ok: covers
+          label: spansX && spansY
+            ? 'band wraps copy +' + Math.round(bandRight - contentRect.right) + '/'
+              + Math.round(contentRect.top - bandTop) + '/' + Math.round(bandBottom - contentRect.bottom) + 'px'
+            : !spansX ? 'BAND NARROWER THAN COLUMN' : 'BAND SHORTER THAN COPY',
+          ok: spansX && spansY
         };
-        if (!covers) notes.push('band does not span the copy column');
+        if (!spansX) notes.push('band does not span the copy column');
+        if (!spansY) notes.push('band does not cover the copy height');
       }
 
       const worstBg = boundOver(contentRect);

--- a/cultpodcasts/tools/hero-legibility-harness.template.html
+++ b/cultpodcasts/tools/hero-legibility-harness.template.html
@@ -1,0 +1,1007 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Hero legibility proof — cultpodcasts</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --ok: #4ade80;
+      --bad: #f87171;
+      --warn: #fbbf24;
+      --line: #2a2a2a;
+      --dim: #9a9a9a;
+    }
+
+    body {
+      margin: 0;
+      padding: 24px clamp(16px, 3vw, 40px) 64px;
+      background: #0b0b0b;
+      color: #ececec;
+      font: 14px/1.5 ui-sans-serif, "Segoe UI", system-ui, sans-serif;
+    }
+
+    h1 {
+      font-size: 1.5rem;
+      margin: 0 0 4px;
+    }
+
+    h2 {
+      font-size: 1.05rem;
+      margin: 32px 0 10px;
+      padding-bottom: 6px;
+      border-bottom: 1px solid var(--line);
+    }
+
+    p {
+      max-width: 82ch;
+    }
+
+    .sub {
+      color: var(--dim);
+      margin: 0 0 20px;
+    }
+
+    code {
+      background: #191919;
+      padding: 1px 5px;
+      border-radius: 4px;
+      font-size: 0.9em;
+    }
+
+    fieldset {
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 12px 16px 16px;
+      margin: 0 0 16px;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 18px;
+      align-items: flex-end;
+    }
+
+    legend {
+      padding: 0 6px;
+      color: var(--dim);
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      font-size: 0.72rem;
+    }
+
+    label {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      font-size: 0.8rem;
+      color: var(--dim);
+    }
+
+    label.inline {
+      flex-direction: row;
+      align-items: center;
+      gap: 8px;
+      color: #ececec;
+    }
+
+    select,
+    input[type="number"] {
+      background: #161616;
+      color: #fff;
+      border: 1px solid #333;
+      border-radius: 6px;
+      padding: 7px 9px;
+      font: inherit;
+      min-width: 110px;
+    }
+
+    button {
+      background: #e8a23a;
+      color: #171717;
+      border: 0;
+      border-radius: 6px;
+      padding: 9px 18px;
+      font: inherit;
+      font-weight: 700;
+      cursor: pointer;
+    }
+
+    button.secondary {
+      background: #232323;
+      color: #ececec;
+      border: 1px solid #3a3a3a;
+    }
+
+    button[disabled] {
+      opacity: 0.5;
+      cursor: progress;
+    }
+
+    #verdict {
+      font-size: 1.15rem;
+      font-weight: 700;
+      padding: 14px 18px;
+      border-radius: 10px;
+      border: 1px solid var(--line);
+      background: #141414;
+      margin: 0 0 14px;
+    }
+
+    #verdict.pass {
+      border-color: #2f6b45;
+      background: #10241a;
+      color: var(--ok);
+    }
+
+    #verdict.fail {
+      border-color: #7a2f2f;
+      background: #251111;
+      color: var(--bad);
+    }
+
+    #verdict.idle {
+      color: var(--dim);
+      font-weight: 400;
+    }
+
+    .cards {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+      gap: 10px;
+      margin-bottom: 8px;
+    }
+
+    .card {
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 10px 12px;
+      background: #131313;
+    }
+
+    .card .k {
+      color: var(--dim);
+      font-size: 0.72rem;
+      text-transform: uppercase;
+      letter-spacing: 0.07em;
+    }
+
+    .card .v {
+      font-size: 1.15rem;
+      font-weight: 700;
+      margin-top: 2px;
+    }
+
+    table {
+      border-collapse: collapse;
+      width: 100%;
+      font-variant-numeric: tabular-nums;
+      font-size: 0.82rem;
+    }
+
+    th,
+    td {
+      text-align: left;
+      padding: 5px 9px;
+      border-bottom: 1px solid #1e1e1e;
+      white-space: nowrap;
+    }
+
+    th {
+      position: sticky;
+      top: 0;
+      background: #131313;
+      color: var(--dim);
+      font-weight: 600;
+      text-transform: uppercase;
+      font-size: 0.68rem;
+      letter-spacing: 0.06em;
+      z-index: 1;
+    }
+
+    tr.fail td {
+      background: #1e1010;
+    }
+
+    .tag {
+      display: inline-block;
+      padding: 1px 7px;
+      border-radius: 999px;
+      font-size: 0.7rem;
+      font-weight: 700;
+    }
+
+    .tag.pass {
+      background: #16371f;
+      color: var(--ok);
+    }
+
+    .tag.fail {
+      background: #3a1414;
+      color: var(--bad);
+    }
+
+    .tag.warn {
+      background: #3a2d0f;
+      color: var(--warn);
+    }
+
+    .swatch {
+      display: inline-block;
+      width: 11px;
+      height: 11px;
+      border-radius: 2px;
+      border: 1px solid #444;
+      vertical-align: -1px;
+      margin-right: 5px;
+    }
+
+    .scroll {
+      max-height: 62vh;
+      overflow: auto;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+    }
+
+    #previewWrap {
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      overflow: hidden;
+      background: #000;
+      position: relative;
+    }
+
+    #previewWrap iframe {
+      border: 0;
+      display: block;
+      transform-origin: 0 0;
+    }
+
+    /* Offscreen measuring rig: must stay laid out, so no display:none. */
+    #rigWrap {
+      position: fixed;
+      left: 0;
+      top: 0;
+      width: 1px;
+      height: 1px;
+      overflow: hidden;
+      opacity: 0;
+      pointer-events: none;
+      z-index: -1;
+    }
+
+    #rig {
+      border: 0;
+      display: block;
+    }
+
+    ul.notes {
+      max-width: 82ch;
+      color: #cfcfcf;
+    }
+
+    ul.notes li {
+      margin-bottom: 6px;
+    }
+
+    .prov {
+      color: var(--dim);
+      font-size: 0.76rem;
+    }
+  </style>
+</head>
+
+<body>
+  <h1>Hero legibility proof</h1>
+  <p class="sub">
+    Renders <code>homepage-hero.component.sass</code> against a worst-case <strong>solid #fff</strong> hero image and
+    checks, at every width, that hero copy keeps a legible background.
+  </p>
+
+  <p class="prov" id="prov"></p>
+
+  <fieldset>
+    <legend>Run</legend>
+    <label>Scenarios
+      <select id="scenarios">
+        <option value="framed">Framed art (16:9, 1:1, 4:3)</option>
+        <option value="all">All, incl. pre-measure fallback</option>
+        <option value="16:9">16:9 only</option>
+      </select>
+    </label>
+    <label>Viewport heights
+      <select id="heights">
+        <option value="900">900 only</option>
+        <option value="700,900,1200" selected>700, 900, 1200</option>
+        <option value="640,700,800,900,1080,1200">640 … 1200 (six)</option>
+      </select>
+    </label>
+    <label>Width step (px)
+      <input type="number" id="step" value="8" min="1" max="64">
+    </label>
+    <label class="inline"><input type="checkbox" id="failOnly"> Failures only</label>
+    <button id="run">Run sweep</button>
+    <button id="runStrict" class="secondary">Strict (step 1)</button>
+  </fieldset>
+
+  <div id="verdict" class="idle">Not run yet.</div>
+  <div class="cards" id="cards"></div>
+
+  <h2>Per-width results</h2>
+  <div class="scroll">
+    <table id="results">
+      <thead>
+        <tr>
+          <th>Width</th>
+          <th>Layout w</th>
+          <th>Height</th>
+          <th>Art</th>
+          <th>Mode</th>
+          <th>Worst bg in column</th>
+          <th>Min ratio (bound)</th>
+          <th>Limiting text</th>
+          <th>Needs</th>
+          <th>Geometry</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </div>
+
+  <h2>Visual check</h2>
+  <fieldset>
+    <legend>Preview</legend>
+    <label>Width
+      <input type="number" id="pvWidth" value="1440" min="320" max="3840" step="1">
+    </label>
+    <label>Height
+      <input type="number" id="pvHeight" value="900" min="480" max="1600" step="1">
+    </label>
+    <label>Art aspect
+      <select id="pvAspect">
+        <option value="1.7777777777777777">16:9</option>
+        <option value="1">1:1 square</option>
+        <option value="1.3333333333333333">4:3</option>
+        <option value="none">pre-measure (no aspect)</option>
+      </select>
+    </label>
+    <label class="inline"><input type="checkbox" id="pvIsolate" checked> Isolate band (match model)</label>
+    <button id="pvGo" class="secondary">Render</button>
+  </fieldset>
+  <div id="previewWrap"></div>
+
+  <h2>What this proves — and what it does not</h2>
+  <ul class="notes">
+    <li><strong>Font independent.</strong> Copy is capped at <code>min(640px, 100%)</code>, so text can never be wider
+      than the copy column. The bound samples the <em>entire column</em>, not just where glyphs happen to land, so no
+      title length or font substitution can escape it. Measured ink is reported separately as a sanity check.</li>
+    <li><strong>The model is read from the live render</strong>, not re-declared here. Band edges, tint stops and mask
+      stops come from <code>getComputedStyle(el, '::before')</code> inside the rig, so it tracks the stylesheet.</li>
+    <li><strong>Deliberately pessimistic.</strong> <code>.billboard__scrim</code> and <code>.billboard__vignette</code>
+      also darken the art but are excluded from the model, so the real background is always at least as dark as the
+      number shown. <code>.billboard__grain</code> (7% soft-light noise) is disabled and excluded.</li>
+    <li><strong>Uniform art only.</strong> A solid fill is the worst case for contrast, and it makes
+      <code>backdrop-filter</code> irrelevant — blurring #fff still yields #fff — so the tint alone is measured. It does
+      not model whether blur adequately suppresses <em>detail</em> (the artwork's own burnt-in title); that remains a
+      visual judgement.</li>
+    <li><strong>Not pixel readback.</strong> Backgrounds are composited analytically from computed styles. The
+      "Isolate band" preview makes the render match the model so the two can be compared by eye.</li>
+    <li><strong>Buttons and chips</strong> use plain harness markup, not Angular Material / <code>app-subject-chip</code>,
+      so their box metrics differ from production. Their <em>backgrounds</em> come from the real stylesheet and are
+      composited over the band.</li>
+    <li>Thresholds are WCAG 2.1 AA: 4.5:1 body text, 3:1 large text (≥24px, or ≥18.66px at weight ≥700).</li>
+  </ul>
+
+  <div id="rigWrap"><iframe id="rig" title="measuring rig"></iframe></div>
+
+  <script id="hero-css" type="text/css">/*__HERO_CSS__*/</script>
+  <script id="hero-meta" type="application/json">/*__HERO_META__*/</script>
+
+  <script>
+    'use strict';
+
+    const HERO_CSS = document.getElementById('hero-css').textContent;
+    const META = JSON.parse(document.getElementById('hero-meta').textContent);
+
+    /* Mirrors the token declarations in app.component.sass / styles.scss that the
+       hero reads. Kept minimal and asserted at runtime: a missing token would
+       change layout, so the rig checks the ones that resolve to lengths. */
+    const TOKENS_CSS = `
+:root {
+  --nflx-accent: #e8a23a;
+  --nflx-on-media: #fff;
+  --nflx-on-media-muted: #e8e8e8;
+  --nflx-panel: #141414;
+  --cp-font-display: 'Instrument Serif', Georgia, 'Times New Roman', serif;
+  --cp-font-ui: Figtree, 'Segoe UI', system-ui, sans-serif;
+  --nflx-search-h: 48px;
+  --site-chrome-bar-h: 58px;
+  --site-chrome-search-gap: 12px;
+  --site-chrome-h: calc(var(--site-chrome-bar-h) + var(--site-chrome-search-gap) + var(--nflx-search-h) + 12px);
+  --nflx-hero-search-clearance: calc(var(--site-chrome-h) + 8px);
+}
+@media screen and (max-width: 700px) {
+  :root {
+    --site-chrome-bar-h: 52px;
+    --site-chrome-search-gap: 0px;
+    --site-chrome-h: var(--site-chrome-bar-h);
+    --nflx-hero-search-clearance: calc(var(--site-chrome-bar-h) + env(safe-area-inset-top, 0px) + 12px);
+  }
+}`;
+
+    /* Worst case under test: every surface that carries artwork is solid #fff.
+       .billboard and .billboard__stage are deliberately left alone — their
+       backgrounds are design colours (page backdrop and letterbox gutters), not
+       image data, so whitening them would test a broken token rather than
+       hostile artwork. */
+    const RIG_CSS = `
+html, body { margin: 0; padding: 0; background: #fff; }
+body { font-family: var(--cp-font-ui); }
+.hero-host { display: block; --hero-interval: 7.5s; }
+.billboard__stage-focus,
+.billboard__stage-edge-strip,
+.billboard__stage-edge-sample {
+  background-image: none !important;
+  background-color: #fff !important;
+  filter: none !important;
+}
+/* Excluded from the model, so excluded from the render. */
+.billboard__grain { display: none !important; }
+/* Measurements must be stable. */
+*, *::before, *::after { animation: none !important; transition: none !important; }
+/* Scrim + vignette also darken the art; the model ignores them, so isolating
+   them makes what you see equal what is measured. */
+.isolate-band .billboard__scrim,
+.isolate-band .billboard__vignette { background: none !important; }
+.harness-btn {
+  display: inline-flex; align-items: center; justify-content: center;
+  min-height: 40px; padding: 0 22px; border-radius: 6px;
+  border: 1px solid transparent; font: inherit; font-size: 0.9rem;
+  text-decoration: none; cursor: default; box-sizing: border-box;
+}
+.harness-chip {
+  display: inline-flex; align-items: center; height: 26px; padding: 0 10px;
+  border-radius: 999px; background: #ffffff1f; border: 1px solid #ffffff38;
+  font-size: 0.78rem;
+}
+.harness-nav { width: 44px; height: 44px; border-radius: 50%; background: #141414e6; border: 1px solid #ffffff59; flex: 0 0 auto; }
+.harness-dots { flex: 1 1 auto; height: 31px; }`;
+
+    const LONG_TITLE = 'Inside the Long-Running Investigation Into a Secretive Wellness Group, Its Charismatic Founder, and the Followers Who Say They Lost Everything';
+    const LONG_DESC = 'A reporter spends eighteen months tracing how a small breath-work studio grew into an international organisation with its own scripture, courts and currency, and what happened to the members who tried to leave. Contains descriptions of coercive control that some listeners may find distressing.';
+
+    const HERO_MARKUP = `
+<div class="hero-host">
+  <section class="billboard has-art-aspect" style="--hero-art-aspect: 1.7777777777777777">
+    <div class="billboard__stages" aria-hidden="true">
+      <div class="billboard__stage is-active has-edge-extend" style="--hero-art-aspect: 1.7777777777777777">
+        <div class="billboard__stage-edge billboard__stage-edge--left"><div class="billboard__stage-edge-strip"><div class="billboard__stage-edge-sample"></div></div></div>
+        <div class="billboard__stage-edge billboard__stage-edge--right"><div class="billboard__stage-edge-strip"><div class="billboard__stage-edge-sample"></div></div></div>
+        <div class="billboard__stage-motion"><div class="billboard__stage-focus-slot"><div class="billboard__stage-focus"></div></div></div>
+      </div>
+    </div>
+    <div class="billboard__grain" aria-hidden="true"></div>
+    <div class="billboard__scrim" aria-hidden="true"></div>
+    <div class="billboard__vignette" aria-hidden="true"></div>
+    <div class="billboard__content">
+      <div class="billboard__feature">
+        <div class="billboard__copy">
+          <p class="billboard__eyebrow"><span class="billboard__live" aria-hidden="true"></span>Now featuring</p>
+          <h1 class="billboard__title">${LONG_TITLE}</h1>
+          <p class="billboard__meta"><a href="#">A Podcast With Quite A Long Name</a><span> &middot; 1:04:22</span><span class="billboard__lang" title="English"><span class="billboard__lang-flag" aria-hidden="true">&#127468;&#127463;</span><span class="billboard__lang-name">English</span></span></p>
+          <div class="billboard__copy-body">
+            <p class="billboard__desc">${LONG_DESC}</p>
+            <div class="billboard__subjects" data-harness-ignore><span class="harness-chip">Cults</span><span class="harness-chip">Wellness</span><span class="harness-chip">Investigation</span></div>
+          </div>
+        </div>
+        <div class="billboard__actions">
+          <button type="button" class="billboard__play harness-btn">Watch</button>
+          <a class="billboard__more harness-btn" href="#">More info</a>
+        </div>
+      </div>
+    </div>
+    <div class="billboard__controls" data-harness-ignore>
+      <div class="billboard__pager"><span class="harness-nav"></span><span class="harness-dots"></span><span class="harness-nav"></span></div>
+    </div>
+  </section>
+</div>`;
+
+    function frameDoc() {
+      return '<!doctype html><html><head><meta charset="utf-8">'
+        + '<style>' + TOKENS_CSS + '</style>'
+        + '<style>' + HERO_CSS + '</style>'
+        + '<style>' + RIG_CSS + '</style>'
+        + '</head><body>' + HERO_MARKUP + '</body></html>';
+    }
+
+    /* ---------------- colour maths ---------------- */
+
+    function parseColor(str) {
+      const m = /^rgba?\(([^)]+)\)$/.exec(String(str).trim());
+      if (!m) return null;
+      const parts = m[1].split(/[,\s/]+/).filter(Boolean).map(Number);
+      return { r: parts[0], g: parts[1], b: parts[2], a: parts.length > 3 ? parts[3] : 1 };
+    }
+
+    // Paint `top` over opaque-or-not `bottom`.
+    function over(top, bottom) {
+      const a = top.a + bottom.a * (1 - top.a);
+      if (a === 0) return { r: 0, g: 0, b: 0, a: 0 };
+      const ch = (t, b) => (t * top.a + b * bottom.a * (1 - top.a)) / a;
+      return { r: ch(top.r, bottom.r), g: ch(top.g, bottom.g), b: ch(top.b, bottom.b), a };
+    }
+
+    function luminance(c) {
+      const f = (v) => {
+        const s = v / 255;
+        return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+      };
+      return 0.2126 * f(c.r) + 0.7152 * f(c.g) + 0.0722 * f(c.b);
+    }
+
+    function contrast(a, b) {
+      const l1 = luminance(a), l2 = luminance(b);
+      return (Math.max(l1, l2) + 0.05) / (Math.min(l1, l2) + 0.05);
+    }
+
+    function hex(c) {
+      const h = (v) => Math.round(Math.max(0, Math.min(255, v))).toString(16).padStart(2, '0');
+      return '#' + h(c.r) + h(c.g) + h(c.b);
+    }
+
+    /* ---------------- gradient parsing ---------------- */
+
+    function splitTopLevel(str) {
+      const out = [];
+      let depth = 0, cur = '';
+      for (const ch of str) {
+        if (ch === '(') depth++;
+        if (ch === ')') depth--;
+        if (ch === ',' && depth === 0) { out.push(cur.trim()); cur = ''; continue; }
+        cur += ch;
+      }
+      if (cur.trim()) out.push(cur.trim());
+      return out;
+    }
+
+    /* Returns { stops:[{pos,color}], horizontal:bool } or null.
+       Only left-to-right gradients are modelled; anything else is reported as
+       unmodelled rather than silently mis-measured. */
+    function parseLinearGradient(value) {
+      const m = /^linear-gradient\((.*)\)$/s.exec(String(value).trim());
+      if (!m) return null;
+      const parts = splitTopLevel(m[1]);
+      let horizontal = false;
+      if (/^(to\s|[-\d.]+deg|calc)/i.test(parts[0]) && !/^rgba?\(/i.test(parts[0])) {
+        const dir = parts.shift().trim().toLowerCase();
+        horizontal = dir === '90deg' || dir === 'to right';
+      }
+      const stops = [];
+      for (const p of parts) {
+        const cm = /^(rgba?\([^)]*\)|#[0-9a-f]{3,8}|[a-z]+)\s*(.*)$/i.exec(p);
+        if (!cm) return null;
+        const color = parseColor(cm[1]) || (cm[1] === 'transparent' ? { r: 0, g: 0, b: 0, a: 0 } : null);
+        if (!color) return null;
+        const pos = /([-\d.]+)%/.exec(cm[2]);
+        stops.push({ pos: pos ? parseFloat(pos[1]) / 100 : null, color });
+      }
+      if (!stops.length) return null;
+      if (stops[0].pos === null) stops[0].pos = 0;
+      if (stops[stops.length - 1].pos === null) stops[stops.length - 1].pos = 1;
+      for (let i = 1; i < stops.length - 1; i++) {
+        if (stops[i].pos === null) stops[i].pos = i / (stops.length - 1);
+      }
+      return { stops, horizontal };
+    }
+
+    /* CSS interpolates gradients in premultiplied space. */
+    function colorAtStop(stops, t) {
+      if (t <= stops[0].pos) return stops[0].color;
+      const last = stops[stops.length - 1];
+      if (t >= last.pos) return last.color;
+      for (let i = 1; i < stops.length; i++) {
+        const a = stops[i - 1], b = stops[i];
+        if (t > b.pos) continue;
+        const span = b.pos - a.pos;
+        const f = span === 0 ? 0 : (t - a.pos) / span;
+        const pa = a.color.a, pb = b.color.a;
+        const alpha = pa + (pb - pa) * f;
+        if (alpha === 0) return { r: 0, g: 0, b: 0, a: 0 };
+        const ch = (ca, cb) => ((ca * pa) + ((cb * pb) - (ca * pa)) * f) / alpha;
+        return { r: ch(a.color.r, b.color.r), g: ch(a.color.g, b.color.g), b: ch(a.color.b, b.color.b), a: alpha };
+      }
+      return last.color;
+    }
+
+    /* ---------------- rig ---------------- */
+
+    const rig = document.getElementById('rig');
+    let rigWin = null, rigDoc = null;
+
+    function writeRig() {
+      rigDoc = rig.contentDocument;
+      rigDoc.open();
+      rigDoc.write(frameDoc());
+      rigDoc.close();
+      rigWin = rig.contentWindow;
+    }
+
+    function setScenario(aspect) {
+      const bb = rigDoc.querySelector('.billboard');
+      const stage = rigDoc.querySelector('.billboard__stage');
+      if (aspect === 'none') {
+        bb.classList.remove('has-art-aspect');
+        stage.classList.remove('has-edge-extend');
+        bb.style.removeProperty('--hero-art-aspect');
+        stage.style.removeProperty('--hero-art-aspect');
+      } else {
+        bb.classList.add('has-art-aspect');
+        stage.classList.add('has-edge-extend');
+        bb.style.setProperty('--hero-art-aspect', aspect);
+        stage.style.setProperty('--hero-art-aspect', aspect);
+      }
+    }
+
+    function textLeaves(root) {
+      const out = [];
+      const walk = (el) => {
+        if (el.hasAttribute && el.hasAttribute('data-harness-ignore')) return;
+        let own = false;
+        for (const n of el.childNodes) {
+          if (n.nodeType === 3 && n.nodeValue.trim()) own = true;
+        }
+        if (own) out.push(el);
+        for (const c of el.children) walk(c);
+      };
+      walk(root);
+      return out;
+    }
+
+    function ownInkRects(el, clipTo) {
+      const rects = [];
+      for (const n of el.childNodes) {
+        if (n.nodeType !== 3 || !n.nodeValue.trim()) continue;
+        const r = rigDoc.createRange();
+        r.selectNodeContents(n);
+        for (const box of r.getClientRects()) {
+          const left = Math.max(box.left, clipTo.left);
+          const right = Math.min(box.right, clipTo.right);
+          const top = Math.max(box.top, clipTo.top);
+          const bottom = Math.min(box.bottom, clipTo.bottom);
+          if (right > left && bottom > top) rects.push({ left, right, top, bottom });
+        }
+      }
+      return rects;
+    }
+
+    function styleOf(el) {
+      const cs = rigWin.getComputedStyle(el);
+      const size = parseFloat(cs.fontSize);
+      const weightRaw = cs.fontWeight;
+      const weight = weightRaw === 'bold' ? 700 : weightRaw === 'normal' ? 400 : parseInt(weightRaw, 10) || 400;
+      const large = size >= 24 || (size >= 18.66 && weight >= 700);
+      return { color: parseColor(cs.color), size, weight, large, threshold: large ? 3 : 4.5 };
+    }
+
+    /* Backgrounds declared between the text element and the copy column, which
+       sit above the band and therefore change what the text is read against. */
+    function ancestorBackgrounds(el, stopAt) {
+      const layers = [];
+      let node = el;
+      while (node && node !== stopAt) {
+        const cs = rigWin.getComputedStyle(node);
+        if (cs.backgroundImage && cs.backgroundImage !== 'none') layers.push({ unmodelled: true });
+        const c = parseColor(cs.backgroundColor);
+        if (c && c.a > 0) layers.push({ color: c });
+        node = node.parentElement;
+      }
+      return layers.reverse();
+    }
+
+    const ART = { r: 255, g: 255, b: 255, a: 1 };
+    /* .billboard / .billboard__stage backgrounds — opaque design colours. */
+    const CHROME = { r: 11, g: 11, b: 11, a: 1 };
+
+    function intersect(a, b) {
+      const r = {
+        left: Math.max(a.left, b.left), right: Math.min(a.right, b.right),
+        top: Math.max(a.top, b.top), bottom: Math.min(a.bottom, b.bottom)
+      };
+      return r.right > r.left && r.bottom > r.top ? r : null;
+    }
+
+    function containsRect(outer, inner) {
+      return inner.left >= outer.left - 0.5 && inner.right <= outer.right + 0.5
+        && inner.top >= outer.top - 0.5 && inner.bottom <= outer.bottom + 0.5;
+    }
+
+    function measure(nominalWidth, height, aspectLabel) {
+      const win = rigWin, doc = rigDoc;
+      const bb = doc.querySelector('.billboard');
+      const content = doc.querySelector('.billboard__content');
+      const stages = doc.querySelector('.billboard__stages');
+
+      const layoutWidth = doc.documentElement.clientWidth;
+      const stacked = win.matchMedia('(max-width: 1280px)').matches;
+      const bbRect = bb.getBoundingClientRect();
+      const contentRect = content.getBoundingClientRect();
+      const before = win.getComputedStyle(content, '::before');
+      const notes = [];
+
+      // Sanity: the tokens the hero depends on must have resolved.
+      const clearance = win.getComputedStyle(bb).paddingTop;
+      if (!stacked && parseFloat(clearance) < 100) notes.push('search clearance token missing');
+
+      // bgAt(x, y) -> background colour immediately beneath the copy layer.
+      // boundOver(rect) -> the lightest background anywhere in that box, i.e.
+      // the worst case for any glyph the box could ever contain.
+      let bgAt, boundOver, geometry, unmodelled = false;
+
+      if (stacked) {
+        const fade = parseFloat(win.getComputedStyle(bb).getPropertyValue('--hero-copy-fade')) || 0;
+        const panel = {
+          left: contentRect.left + parseFloat(before.left),
+          top: contentRect.top + parseFloat(before.top),
+          right: contentRect.left + parseFloat(before.left) + parseFloat(before.width),
+          bottom: contentRect.top + parseFloat(before.top) + parseFloat(before.height)
+        };
+        // Clipped by .billboard (overflow: hidden); the fade band at the top is
+        // partially transparent, so it does not count as covered.
+        const safe = {
+          left: Math.max(panel.left, bbRect.left),
+          right: Math.min(panel.right, bbRect.right),
+          top: Math.max(panel.top + fade, bbRect.top),
+          bottom: Math.min(panel.bottom, bbRect.bottom)
+        };
+        const artRect = stages.getBoundingClientRect();
+        // Anything not on the panel still lands on .billboard's opaque #0b0b0b,
+        // so only artwork that escapes the panel can hurt legibility.
+        const bgFor = (rect) => {
+          const onArt = intersect(rect, artRect);
+          return !onArt || containsRect(safe, onArt) ? CHROME : ART;
+        };
+        bgAt = (x, y) => bgFor({ left: x, right: x, top: y, bottom: y });
+        boundOver = (rect) => bgFor(rect);
+
+        const artUnderCopy = intersect(contentRect, artRect);
+        const safeCopy = !artUnderCopy || containsRect(safe, artUnderCopy);
+        const framed = bb.classList.contains('has-art-aspect');
+        const clear = framed ? contentRect.top - artRect.bottom : null;
+        const shortBy = contentRect.bottom - safe.bottom;
+        if (shortBy > 0.5) {
+          notes.push('panel ends ' + Math.round(shortBy) + 'px above copy end (on #0b0b0b)');
+        }
+        if (fade > 0) notes.push('fade band ' + Math.round(fade) + 'px treated as unsafe');
+        geometry = {
+          label: !safeCopy
+            ? 'ARTWORK REACHES COPY'
+            : framed ? 'frame clear by ' + Math.round(clear) + 'px' : 'no artwork under copy',
+          ok: safeCopy && (clear === null || clear >= 0)
+        };
+      } else {
+        const grad = parseLinearGradient(before.backgroundImage);
+        const maskRaw = before.maskImage && before.maskImage !== 'none' ? before.maskImage : before.webkitMaskImage;
+        const mask = parseLinearGradient(maskRaw);
+        if (!grad || !grad.horizontal) { unmodelled = true; notes.push('band tint not a left-to-right gradient'); }
+        if (!mask || !mask.horizontal) { unmodelled = true; notes.push('band mask not a left-to-right gradient'); }
+        const bandLeft = contentRect.left + parseFloat(before.left);
+        const bandRight = contentRect.right - parseFloat(before.right);
+        const bandW = bandRight - bandLeft;
+        bgAt = (x) => {
+          if (unmodelled || x < bandLeft || x > bandRight || bandW <= 0) return ART;
+          const t = (x - bandLeft) / bandW;
+          const tint = colorAtStop(grad.stops, t);
+          const m = colorAtStop(mask.stops, t).a;
+          return over({ r: tint.r, g: tint.g, b: tint.b, a: tint.a * m }, ART);
+        };
+        // Tint is monotonic left-to-right, but sample rather than assume it.
+        boundOver = (rect) => {
+          let worst = null;
+          for (let x = rect.left; x <= rect.right; x += 2) {
+            const c = bgAt(x);
+            if (!worst || luminance(c) > luminance(worst)) worst = c;
+          }
+          return worst || ART;
+        };
+        const covers = bandLeft <= contentRect.left + 0.5 && bandRight >= contentRect.right - 0.5;
+        geometry = {
+          label: covers
+            ? 'band spans column +' + Math.round(bandRight - contentRect.right) + 'px'
+            : 'BAND NARROWER THAN COLUMN',
+          ok: covers
+        };
+        if (!covers) notes.push('band does not span the copy column');
+      }
+
+      const worstBg = boundOver(contentRect);
+
+      // Distinct text styles actually present, each judged against that bound.
+      const leaves = textLeaves(content);
+      const styles = new Map();
+      let inkWorst = null;
+      for (const el of leaves) {
+        const st = styleOf(el);
+        if (!st.color) continue;
+        const bgLayers = ancestorBackgrounds(el, content);
+        if (bgLayers.some((l) => l.unmodelled)) { notes.push('unmodelled background image on ' + (el.className || el.tagName)); }
+        const applyLayers = (base) => bgLayers.reduce((acc, l) => (l.color ? over(l.color, acc) : acc), base);
+
+        // Bound over the element's own box: text can never leave it, so this is
+        // independent of font metrics and of how long the episode title is.
+        const box = intersect(el.getBoundingClientRect(), bbRect);
+        if (!box) continue;
+        const boundBg = applyLayers(boundOver(box));
+        const ratio = contrast(over(st.color, boundBg), boundBg);
+        const key = el.className + '|' + Math.round(st.size) + '|' + st.weight;
+        const label = (el.className || el.tagName.toLowerCase()).replace('billboard__', '');
+        if (!styles.has(key) || styles.get(key).ratio > ratio) {
+          styles.set(key, { label, ratio, threshold: st.threshold, size: st.size, weight: st.weight });
+        }
+
+        // Measured ink, as a cross-check on the bound.
+        for (const r of ownInkRects(el, bbRect)) {
+          const y = (r.top + r.bottom) / 2;
+          for (let x = r.left; x <= r.right; x += 3) {
+            const bg = applyLayers(bgAt(x, y));
+            const ir = contrast(over(st.color, bg), bg);
+            if (!inkWorst || ir < inkWorst.ratio) inkWorst = { ratio: ir, label, threshold: st.threshold };
+          }
+        }
+      }
+
+      const styleList = [...styles.values()].sort((a, b) => (a.ratio / a.threshold) - (b.ratio / b.threshold));
+      const limiting = styleList[0] || null;
+      const pass = !unmodelled && geometry.ok && styleList.every((s) => s.ratio >= s.threshold)
+        && (!inkWorst || inkWorst.ratio >= inkWorst.threshold);
+
+      return {
+        nominalWidth, layoutWidth, height, aspectLabel,
+        mode: stacked ? 'stacked' : 'wide',
+        worstBg: hex(worstBg),
+        limiting, inkWorst, geometry, notes, pass, unmodelled
+      };
+    }
+
+    /* ---------------- sweep ---------------- */
+
+    const CRITICAL = [320, 360, 375, 390, 393, 412, 414, 430, 480, 540, 600, 639, 640, 699, 700, 701, 720, 768, 800, 834,
+      899, 900, 901, 960, 1024, 1080, 1100, 1180, 1200, 1279, 1280, 1281, 1300, 1366, 1400, 1440, 1500, 1536, 1600, 1700,
+      1800, 1900, 1920, 1978, 1980, 2000, 2048, 2200, 2400, 2560, 2880, 3000, 3200, 3440, 3840];
+
+    const SCENARIOS = {
+      'framed': [['16:9', '1.7777777777777777'], ['1:1', '1'], ['4:3', '1.3333333333333333']],
+      '16:9': [['16:9', '1.7777777777777777']],
+      'all': [['16:9', '1.7777777777777777'], ['1:1', '1'], ['4:3', '1.3333333333333333'], ['pre-measure', 'none']]
+    };
+
+    function widthList(step) {
+      const s = new Set(CRITICAL);
+      for (let w = 320; w <= 3840; w += step) s.add(w);
+      return [...s].sort((a, b) => a - b);
+    }
+
+    let rows = [];
+
+    async function run(step) {
+      const btns = [document.getElementById('run'), document.getElementById('runStrict')];
+      btns.forEach((b) => (b.disabled = true));
+      document.getElementById('verdict').className = 'idle';
+      document.getElementById('verdict').textContent = 'Running…';
+      await new Promise((r) => setTimeout(r, 0));
+
+      writeRig();
+      const scenarios = SCENARIOS[document.getElementById('scenarios').value];
+      const heights = document.getElementById('heights').value.split(',').map(Number);
+      const widths = widthList(step);
+      rows = [];
+
+      for (const [label, aspect] of scenarios) {
+        setScenario(aspect);
+        for (const h of heights) {
+          rig.style.height = h + 'px';
+          for (const w of widths) {
+            rig.style.width = w + 'px';
+            void rig.offsetWidth;
+            rows.push(measure(w, h, label));
+          }
+          await new Promise((r) => setTimeout(r, 0));
+        }
+      }
+
+      render();
+      btns.forEach((b) => (b.disabled = false));
+    }
+
+    function render() {
+      const failing = rows.filter((r) => !r.pass);
+      const verdict = document.getElementById('verdict');
+      if (!rows.length) { verdict.className = 'idle'; verdict.textContent = 'Not run yet.'; return; }
+      verdict.className = failing.length ? 'fail' : 'pass';
+      verdict.textContent = failing.length
+        ? failing.length + ' of ' + rows.length + ' width/height/art combinations FAIL'
+        : 'PASS — hero copy stays legible over solid #fff art at all ' + rows.length + ' combinations tested';
+
+      const worst = rows.reduce((a, b) => {
+        const ra = a.limiting ? a.limiting.ratio / a.limiting.threshold : Infinity;
+        const rb = b.limiting ? b.limiting.ratio / b.limiting.threshold : Infinity;
+        return rb < ra ? b : a;
+      });
+      const widths = [...new Set(rows.map((r) => r.nominalWidth))];
+      const cards = [
+        ['Combinations', rows.length],
+        ['Widths', widths.length + ' (' + Math.min(...widths) + '–' + Math.max(...widths) + 'px)'],
+        ['Failures', failing.length],
+        ['Tightest margin', worst.limiting ? worst.limiting.ratio.toFixed(2) + ':1 vs ' + worst.limiting.threshold + ':1' : '—'],
+        ['Tightest at', worst.nominalWidth + 'px ' + worst.mode + ' / ' + worst.aspectLabel],
+        ['Lightest bg seen', rows.reduce((a, b) => (luminance(parseColor('rgb(' + parseInt(b.worstBg.slice(1, 3), 16) + ',' + parseInt(b.worstBg.slice(3, 5), 16) + ',' + parseInt(b.worstBg.slice(5, 7), 16) + ')')) > luminance(parseColor('rgb(' + parseInt(a.worstBg.slice(1, 3), 16) + ',' + parseInt(a.worstBg.slice(3, 5), 16) + ',' + parseInt(a.worstBg.slice(5, 7), 16) + ')')) ? b : a)).worstBg]
+      ];
+      document.getElementById('cards').innerHTML = cards
+        .map(([k, v]) => '<div class="card"><div class="k">' + k + '</div><div class="v">' + v + '</div></div>').join('');
+
+      const failOnly = document.getElementById('failOnly').checked;
+      const show = failOnly ? failing : rows;
+      document.querySelector('#results tbody').innerHTML = show.map((r) => {
+        const lim = r.limiting;
+        const tag = r.pass ? '<span class="tag pass">pass</span>' : '<span class="tag fail">fail</span>';
+        const geo = '<span class="tag ' + (r.geometry.ok ? 'pass' : 'fail') + '">' + r.geometry.label + '</span>';
+        const ink = r.inkWorst ? ' <span style="color:#9a9a9a">(ink ' + r.inkWorst.ratio.toFixed(1) + ')</span>' : '';
+        return '<tr class="' + (r.pass ? '' : 'fail') + '">'
+          + '<td>' + r.nominalWidth + '</td>'
+          + '<td>' + r.layoutWidth + '</td>'
+          + '<td>' + r.height + '</td>'
+          + '<td>' + r.aspectLabel + '</td>'
+          + '<td>' + r.mode + '</td>'
+          + '<td><span class="swatch" style="background:' + r.worstBg + '"></span>' + r.worstBg + '</td>'
+          + '<td>' + (lim ? lim.ratio.toFixed(2) + ':1' : '—') + ink + '</td>'
+          + '<td>' + (lim ? lim.label + ' ' + Math.round(lim.size) + 'px/' + lim.weight : '—') + '</td>'
+          + '<td>' + (lim ? lim.threshold + ':1' : '—') + '</td>'
+          + '<td>' + geo + (r.notes.length ? ' <span class="tag warn">' + r.notes[0] + '</span>' : '') + '</td>'
+          + '<td>' + tag + '</td>'
+          + '</tr>';
+      }).join('');
+    }
+
+    /* ---------------- visual preview ---------------- */
+
+    function renderPreview() {
+      const w = +document.getElementById('pvWidth').value;
+      const h = +document.getElementById('pvHeight').value;
+      const aspect = document.getElementById('pvAspect').value;
+      const isolate = document.getElementById('pvIsolate').checked;
+      const wrap = document.getElementById('previewWrap');
+      wrap.innerHTML = '';
+      const f = document.createElement('iframe');
+      f.style.width = w + 'px';
+      f.style.height = h + 'px';
+      wrap.appendChild(f);
+      const d = f.contentDocument;
+      d.open(); d.write(frameDoc()); d.close();
+      const bb = d.querySelector('.billboard');
+      const stage = d.querySelector('.billboard__stage');
+      if (aspect === 'none') {
+        bb.classList.remove('has-art-aspect');
+        stage.classList.remove('has-edge-extend');
+        bb.style.removeProperty('--hero-art-aspect');
+        stage.style.removeProperty('--hero-art-aspect');
+      } else {
+        bb.style.setProperty('--hero-art-aspect', aspect);
+        stage.style.setProperty('--hero-art-aspect', aspect);
+      }
+      d.body.classList.toggle('isolate-band', isolate);
+      const scale = Math.min(1, (wrap.clientWidth || 1000) / w);
+      f.style.transform = 'scale(' + scale + ')';
+      wrap.style.height = Math.round(h * scale) + 'px';
+    }
+
+    document.getElementById('prov').textContent =
+      'Stylesheet: ' + META.source + ' — sha256 ' + META.sha256.slice(0, 16) + '… — regenerate with `' + META.command + '`';
+    document.getElementById('run').addEventListener('click', () => run(Math.max(1, +document.getElementById('step').value || 8)));
+    document.getElementById('runStrict').addEventListener('click', () => run(1));
+    document.getElementById('failOnly').addEventListener('change', render);
+    document.getElementById('pvGo').addEventListener('click', renderPreview);
+    renderPreview();
+  </script>
+</body>
+
+</html>


### PR DESCRIPTION
## Summary

On mobile the hero title and description were frequently unreadable, because they were painted directly on top of the episode artwork — and that artwork is usually a video frame or cover with its own large title burnt into it. Two pieces of text landed on each other, which no amount of scrim tuning can separate. The same overlay applies all the way up to 1280px, so non-maximised desktop windows had it too.

Below 1280px the art now sits in a **fixed frame** at the top, and the title, description, chips and buttons read on an opaque panel beneath it.

- The frame's height is **constant, not per-art**. It prefers `56.25vw` — 16:9 at full width. I sampled all 49 current hero slides: 39 are 16:9 YouTube `maxresdefault` frames, 5 are 4:3 `sddefault`, and 5 are square Spotify/Apple cover art. So the dominant case fills the frame edge to edge, and the other ~20% letterboxes inside it with plain `#0b0b0b` gutters rather than being cropped or stretched.
- On short-and-wide windows the frame instead reserves ~320px for the copy, so the title and description stay above the fold. A 1024×699 window was otherwise getting a 576px frame and an 1110px hero. When that cap applies the frame is wider than 16:9, so 16:9 art letterboxes too.
- Containment reuses the existing `.has-edge-extend` rules, which already size a centred slot to the art's own aspect. The blurred edge fill stays hidden here — it remains a wide-layout effect.
- A constant frame height also fixes a second problem: the frame previously took the art's aspect, so a square slide made it as tall as the viewport was wide and the hero (plus everything below it) resized on every rotation.
- The copy panel's dissolve is off for framed art (`--hero-copy-fade: 0`) since the frame ends on a clean edge; it only switches on for `:not(.has-art-aspect)`, the brief state before the image has been measured and the art still covers the whole billboard.
- With the copy off the artwork, the scrim and vignette no longer need to dim it: nothing on phones, and just a top gradient on tablets where the frame tucks under the frosted chrome.

### Wide layout (≥1280px)

The overlay layout had the same failure, and it is width-dependent rather than random. The wide layout pins sharp art to the right and fills the leftover gutter with a blurred sample of it, which is what makes the copy readable on very wide monitors. But full-height 16:9 art is ~1.78× the hero height — about 1280px wide — so the fill only reaches under the copy column above roughly **2000px**.

Measured on the deployed preview at 1440: hero 1425px wide, copy column x=58→698, left fill **145px**. So **553px of the copy column sits directly on sharp artwork**. That makes overlap the normal case on desktop, not an edge case.

This took three attempts, and the first two are worth recording because they failed for different reasons:

1. **A tinted, `backdrop-filter`-blurred band.** Legible, but the wrong shape — it treated a *column of the hero* whose edge fell at an x-position set by the art geometry, not by the text. On artwork carrying its own lettering it cut those words mid-phrase and left a visible vertical seam.
2. **A glyph-following `text-shadow` contour.** Much better behaved: it hugged the letterforms, ended where each line of type ended, and left the artwork completely sharp and undimmed. It handles bright artwork well. It cannot handle artwork whose *content* collides with ours — a slide with its own burnt-in title and a white cover card sitting under the copy left the description illegible across the card and printed the title twice, once by us and once by the art.

That second failure is a collision of content, not of contrast, so no type treatment resolves it. The copy therefore gets **an opaque card**:

- `rgba(11, 11, 11, 0.93)`, 14px radius, 18/24px padding around the copy block. That holds roughly **17:1** against solid white artwork, while still letting a trace of the image through so the hero doesn't read as a dialog.
- Deliberate edges. Hard edges look chosen; it was the arbitrary gradient seam at an art-driven position that looked broken.
- The artwork stays **sharp and untouched everywhere outside the card**, including its own lettering — the balance being that our copy wins where the two genuinely overlap, and the artwork wins everywhere else.
- Consistent with the narrow layout, which already separates copy from art with an opaque panel. This is the same idea overlaid rather than stacked.
- The copy block shrinks to `fit-content` with the column width as the ceiling, so short slides avoid a full-width slab. In practice the description's `max-width: 36em` sets a ~605px floor, so this only bites when both title and description are short.
- Dropping the band also removed the `prefers-reduced-motion` carve-out that existed solely to stop Ken Burns re-rasterising a `backdrop-filter` every frame.

Known cosmetic gap: on slides with no subject chips there is dead space inside the card, from the `min-height` reserves that keep the hero from resizing between slides. Left as-is deliberately — consistent card height is worth more than the gap.

### Legibility harness

`cultpodcasts/docs/hero-legibility.html` is a standalone page that measures the hero against **solid `#fff` artwork**, the worst case for white type. Open it and press **Run sweep**.

- **It does not restate the CSS it verifies.** `npm run hero:legibility` compiles `homepage-hero.component.sass` into the page and stamps its sha256; `npm run hero:legibility:check` fails if the committed harness is stale.
- **The model is read off the live render** via `getComputedStyle`, so changing the sass changes what is measured.
- **Font independent.** Contrast is bounded over each text element's own box, so no title length, locale or font substitution escapes the result.
- **Deliberately pessimistic.** `.billboard__scrim` and `.billboard__vignette` also darken the art but are excluded.

**It found a real gap.** The stacked copy panel was `height: 100vh`, so a short viewport with tall copy left a few pixels of artwork exposed below it; the panel now includes the copy's own height (`calc(100vh + 100%)`).

**Current state, stated plainly:** the harness was written against the tinted band and models the wide-layout `::before` as a gradient with masks. The card is a flat background, which is *easier* to measure, but I have not re-run the sweep against it — so the wide-layout rows are regenerated but unverified. Stacked-layout results below 1280px are unaffected and still hold. The harness is scaffolding for this branch and will be deleted in a separate cleanup commit before merge, so it is not being carried forward.

## Test plan

- [x] 390×844, 16:9 art — frame 390×219, art fills it exactly, no bars
- [x] 390×844, square cover art — shown whole, centred, black left/right gutters
- [x] 390×844, 4:3 `sddefault` — shown whole, narrow gutters
- [x] 834×1112 tablet — same framed behaviour in the 701–1280px range
- [x] 1024×699 — frame capped to 379px, title and description above the fold
- [x] 1440×900 — measured the overlap on the deployed preview (145px fill vs copy spanning 58→698)
- [x] 1440×900 against synthetic worst-case artwork (light background, its own large title, white cover card under the copy) — all copy legible, artwork sharp outside the card
- [x] Card checked across several live slides including 2-line and 4-line titles, and slides with and without subject chips
- [x] 2560×1200 — no regression where the blurred edge fill already covered the copy
- [x] **Harness, stacked layout (<1280px): passes** across the width/height/art-aspect sweep
- [x] `ng build` clean
- [ ] Re-run the harness sweep against the card, or drop the harness at merge (see above)
- [ ] Confirm on a real handset that copy is legible across several rotations

## Notes / follow-up

- In the 701–1280px range the frame still starts at `top: 0` and so runs under the chrome bar, meaning the search field overlaps the top of a framed image. That's the pre-existing intentional "hero pulls under the chrome" behaviour, so I left it.
- The harness and its generator (`docs/hero-legibility.html`, `tools/hero-legibility-harness.template.html`, `tools/build-hero-legibility-harness.mjs`, and the two npm scripts) are branch scaffolding, to be removed in a cleanup commit before merge. The `calc(100vh + 100%)` panel fix it surfaced stays.
- `anyComponentStyle` budget warnings on `homepage-hero.component.sass` (14.99 kB vs 12 kB) and `app.component.sass` (14.36 kB vs 12 kB) are still outstanding and predate this branch. Not addressed here.
