### PR TITLE
fix(ui): language flags, ISO code badges, single English filter

### DIFF
--- a/cultpodcasts/src/app/episode-form.util.spec.ts
+++ b/cultpodcasts/src/app/episode-form.util.spec.ts
@@ -115,7 +115,7 @@ describe('episode-form.util', () => {
     const form = buildEpisodeForm(episode);
     expect(form.controls.title.value).toBe('Title');
     expect(form.controls.blueskyPosted.value).toBe(true);
-    expect(form.controls.lang.value).toBe('en');
+    expect(form.controls.lang.value).toBe('unset');
     expect(form.controls.spotify.value?.toString()).toBe('https://open.spotify.com/episode/x');
     expect(form.controls.spotifyImage.value?.toString()).toBe('https://img.example/spotify.jpg');
     expect(form.controls.guests.value).toEqual(['Alice']);
@@ -124,6 +124,11 @@ describe('episode-form.util', () => {
   it('buildEpisodeForm defaults bluesky null to false and lang to unset', () => {
     const form = buildEpisodeForm(baseEpisode({ bluesky: null, lang: null }));
     expect(form.controls.blueskyPosted.value).toBe(false);
+    expect(form.controls.lang.value).toBe('unset');
+  });
+
+  it('buildEpisodeForm maps stored en to unset (English)', () => {
+    const form = buildEpisodeForm(baseEpisode({ lang: 'en-GB' }));
     expect(form.controls.lang.value).toBe('unset');
   });
 

--- a/cultpodcasts/src/app/episode-form.util.ts
+++ b/cultpodcasts/src/app/episode-form.util.ts
@@ -2,6 +2,7 @@ import { FormControl, FormGroup } from '@angular/forms';
 import { ApiEpisode } from './api-episode.interface';
 import { EpisodeForm } from './episode-form.interface';
 import { EpisodePost } from './episode-post.interface';
+import { episodeLanguageFormValue } from './language-options.util';
 import { Person } from './person.interface';
 import { Subject } from './subject.interface';
 import { filterKeepingSelectedInOrder } from './subject-filter.util';
@@ -74,7 +75,7 @@ export function buildEpisodeForm(episode: ApiEpisode): FormGroup<EpisodeForm> {
     internetArchive: new FormControl(episode.urls.internetArchive || null),
     subjects: new FormControl(episode.subjects, { nonNullable: true }),
     searchTerms: new FormControl(episode.searchTerms || null),
-    lang: new FormControl(episode.lang || 'unset'),
+    lang: new FormControl(episodeLanguageFormValue(episode.lang)),
     guests: new FormControl<string[]>(episode.guests ?? [], { nonNullable: true })
   });
 }
@@ -227,7 +228,10 @@ export function getEpisodeChanges(prev: ApiEpisode, now: ApiEpisode): EpisodePos
   if (!areEqualUrlValue(prev.images?.spotify, now.images?.spotify)) changes.images!.spotify = now.images?.spotify ?? '';
   if (!areEqualUrlValue(prev.images?.youtube, now.images?.youtube)) changes.images!.youtube = now.images?.youtube ?? '';
   if (!areEqualUrlValue(prev.images?.other, now.images?.other)) changes.images!.other = now.images?.other ?? '';
-  if (!areEqualUrlValue(prev.lang ?? 'unset', now.lang ?? 'unset')) changes.lang = now.lang == 'unset' ? '' : now.lang ?? '';
+  if (!areEqualUrlValue(prev.lang ?? 'unset', now.lang ?? 'unset')) {
+    const next = episodeLanguageFormValue(now.lang);
+    changes.lang = next === 'unset' ? '' : next;
+  }
   if (!isSameStringArray(prev.guests, now.guests)) changes.guests = now.guests;
   return changes;
 }

--- a/cultpodcasts/src/app/episode-player/episode-player.component.html
+++ b/cultpodcasts/src/app/episode-player/episode-player.component.html
@@ -38,7 +38,8 @@
       <p class="stage__show-row">
         <a class="stage__show" [routerLink]="['/podcast', ep.podcastName, ep.id]">{{ displayCatalogName(ep.podcastName) }}</a>
         @if (languageFlag(); as lang) {
-        <span class="stage__lang" [attr.title]="lang.label" [attr.aria-label]="lang.label">{{ lang.flag }}</span>
+        <span class="stage__lang" [class.stage__lang--code]="lang.isCode" [attr.title]="lang.label"
+          [attr.aria-label]="lang.label">{{ lang.flag }}</span>
         }
       </p>
     </div>

--- a/cultpodcasts/src/app/episode-player/episode-player.component.sass
+++ b/cultpodcasts/src/app/episode-player/episode-player.component.sass
@@ -198,6 +198,12 @@
     line-height: 1
     font-family: 'Twemoji Country Flags', var(--cp-font-ui)
 
+.stage__lang--code
+    font-size: 0.68rem
+    font-weight: 700
+    letter-spacing: 0.04em
+    font-family: var(--cp-font-ui)
+
 .stage__services
     display: inline-flex
     gap: 2px

--- a/cultpodcasts/src/app/episode-poster/episode-poster.component.html
+++ b/cultpodcasts/src/app/episode-poster/episode-poster.component.html
@@ -54,7 +54,8 @@
   @if (languageBadge() || duration() || (showRelease() && releaseLabel())) {
   <div class="episode-poster__meta-badges">
     @if (languageBadge(); as lang) {
-    <span class="episode-poster__badge episode-poster__badge--lang" [attr.title]="lang.label"
+    <span class="episode-poster__badge episode-poster__badge--lang"
+      [class.episode-poster__badge--lang-code]="lang.isCode" [attr.title]="lang.label"
       [attr.aria-label]="lang.label">{{ lang.flag }}</span>
     }
     @if (showRelease() && releaseLabel(); as release) {

--- a/cultpodcasts/src/app/episode-poster/episode-poster.component.sass
+++ b/cultpodcasts/src/app/episode-poster/episode-poster.component.sass
@@ -166,6 +166,15 @@
     background: transparent
     font-family: 'Twemoji Country Flags', var(--cp-font-ui)
 
+.episode-poster__badge--lang-code
+    padding: 3px 5px
+    font-size: 0.65rem
+    font-weight: 700
+    letter-spacing: 0.04em
+    border-radius: 4px
+    background: rgba(255, 255, 255, 0.14)
+    font-family: var(--cp-font-ui)
+
 .episode-poster__badge--release
     font-weight: 600
     color: var(--nflx-muted, #b3b3b3)

--- a/cultpodcasts/src/app/episodes-api/episodes-api.component.html
+++ b/cultpodcasts/src/app/episodes-api/episodes-api.component.html
@@ -103,7 +103,8 @@
                         <span>{{result.release | date:'d MMM yyyy H:mm'}}
                             [{{result.duration.startsWith("0")?result.duration.split(".")[0].substring(1):result.duration.split(".")[0]}}]</span>
                         @if (languageBadge(result); as lang) {
-                        <span class="curator-card__lang" [attr.title]="lang.label"
+                        <span class="curator-card__lang" [class.curator-card__lang--code]="lang.isCode"
+                            [attr.title]="lang.label"
                             [attr.aria-label]="lang.label">{{lang.flag}}</span>
                         }
                     </mat-card-subtitle>

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.html
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.html
@@ -79,7 +79,8 @@
           <span>{{ durationLabel(feature.duration) }}</span>
           @if (languageFlag(feature); as lang) {
           <span class="billboard__lang" [attr.title]="lang.label" [attr.aria-label]="lang.label">
-            <span class="billboard__lang-flag" aria-hidden="true">{{ lang.flag }}</span>
+            <span class="billboard__lang-flag" [class.billboard__lang-flag--code]="lang.isCode"
+              aria-hidden="true">{{ lang.flag }}</span>
             <span class="billboard__lang-name">{{ lang.label }}</span>
           </span>
           }

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
@@ -282,6 +282,12 @@
     font-weight: 400
     font-family: 'Twemoji Country Flags', var(--cp-font-ui)
 
+.billboard__lang-flag--code
+    font-size: 0.72rem
+    font-weight: 700
+    letter-spacing: 0.04em
+    font-family: var(--cp-font-ui)
+
 .billboard__lang-name
     line-height: 1.2
 

--- a/cultpodcasts/src/app/language-flag.spec.ts
+++ b/cultpodcasts/src/app/language-flag.spec.ts
@@ -12,6 +12,35 @@ describe('language-flag', () => {
     expect(languageFlagBadge('pt-BR')?.flag).toBe('🇧🇷');
   });
 
+  it('maps Filipino and Tagalog to the Philippines', () => {
+    expect(languageFlagBadge('fil')?.flag).toBe('🇵🇭');
+    expect(languageFlagBadge('tl')?.flag).toBe('🇵🇭');
+    expect(languageFlagBadge('fil')?.label).toContain('Filipino');
+  });
+
+  it('maps Baltic, Balkan, and South Asian codes that have a clear country', () => {
+    expect(languageFlagBadge('lt')?.flag).toBe('🇱🇹');
+    expect(languageFlagBadge('lv')?.flag).toBe('🇱🇻');
+    expect(languageFlagBadge('et')?.flag).toBe('🇪🇪');
+    expect(languageFlagBadge('bs')?.flag).toBe('🇧🇦');
+    expect(languageFlagBadge('mk')?.flag).toBe('🇲🇰');
+    expect(languageFlagBadge('si')?.flag).toBe('🇱🇰');
+    expect(languageFlagBadge('te')?.flag).toBe('🇮🇳');
+    expect(languageFlagBadge('mr')?.flag).toBe('🇮🇳');
+  });
+
+  it('shows uppercase ISO codes for Punjabi and Yiddish (no country flag)', () => {
+    const punjabi = languageFlagBadge('pa');
+    expect(punjabi?.flag).toBe('PA');
+    expect(punjabi?.isCode).toBe(true);
+    expect(punjabi?.label).toContain('Punjabi');
+
+    const yiddish = languageFlagBadge('yi');
+    expect(yiddish?.flag).toBe('YI');
+    expect(yiddish?.isCode).toBe(true);
+    expect(yiddish?.label).toContain('Yiddish');
+  });
+
   it('omits English and empty codes', () => {
     expect(languageFlagBadge('en')).toBeUndefined();
     expect(languageFlagBadge('en-GB')).toBeUndefined();

--- a/cultpodcasts/src/app/language-flag.ts
+++ b/cultpodcasts/src/app/language-flag.ts
@@ -72,6 +72,22 @@ const LANGUAGE_FLAG_BY_CODE: Record<string, string> = {
   id: '🇮🇩',
   ms: '🇲🇾',
 
+  // Southeast Asia / Pacific
+  fil: '🇵🇭',
+  tl: '🇵🇭',
+
+  // South Asia (India / Sri Lanka — no dedicated Punjab Unicode flag)
+  te: '🇮🇳',
+  mr: '🇮🇳',
+  si: '🇱🇰',
+
+  // Baltic / Balkans
+  lt: '🇱🇹',
+  lv: '🇱🇻',
+  et: '🇪🇪',
+  bs: '🇧🇦',
+  mk: '🇲🇰',
+
   // African
   af: '🇿🇦',
   sw: '🇰🇪',
@@ -80,10 +96,15 @@ const LANGUAGE_FLAG_BY_CODE: Record<string, string> = {
 export interface LanguageFlagBadge {
   /** IETF-ish code as stored on the episode. */
   code: string;
-  /** Flag emoji for a well-known country associated with the language. */
+  /**
+   * Flag emoji for a well-known country, or the uppercase ISO language code
+   * when no honest country flag exists (e.g. Punjabi, Yiddish).
+   */
   flag: string;
   /** Human-readable language name for tooltips / a11y. */
   label: string;
+  /** True when `flag` is a language-code fallback rather than a country flag. */
+  isCode: boolean;
 }
 
 export function isEnglishLanguageCode(code: string | null | undefined): boolean {
@@ -105,8 +126,8 @@ export function episodeLanguageCode(episode: {
 }
 
 /**
- * Non-English language badge with flag + label. Undefined when missing/English
- * or when no representative flag is known for the code.
+ * Non-English language badge with flag (or ISO code fallback) + label.
+ * Undefined when missing/English.
  */
 export function languageFlagBadge(
   code: string | null | undefined
@@ -114,17 +135,29 @@ export function languageFlagBadge(
   if (!code?.trim() || isEnglishLanguageCode(code)) {
     return undefined;
   }
-  const normalized = code.trim().toLowerCase().replace('_', '-');
+  const trimmed = code.trim();
+  const normalized = trimmed.toLowerCase().replace('_', '-');
+  const base = normalized.split('-')[0];
   const flag =
     LANGUAGE_FLAG_BY_CODE[normalized] ??
-    LANGUAGE_FLAG_BY_CODE[normalized.split('-')[0]];
-  if (!flag) {
+    LANGUAGE_FLAG_BY_CODE[base];
+  if (flag) {
+    return {
+      code: trimmed,
+      flag,
+      label: languageLabel(trimmed),
+      isCode: false
+    };
+  }
+  // No country flag (Punjabi, Yiddish, …): show the uppercase ISO base code.
+  if (!base) {
     return undefined;
   }
   return {
-    code: code.trim(),
-    flag,
-    label: languageLabel(code.trim())
+    code: trimmed,
+    flag: base.toUpperCase(),
+    label: languageLabel(trimmed),
+    isCode: true
   };
 }
 

--- a/cultpodcasts/src/app/language-options.util.ts
+++ b/cultpodcasts/src/app/language-options.util.ts
@@ -1,13 +1,34 @@
-export const PODCAST_DEFAULT_LANGUAGE_EXCLUDED_CODES = ['en'] as const;
+/** English is represented as unset/null — never store or offer an `en` code. */
+export const ENGLISH_LANGUAGE_EXCLUDED_CODES = ['en'] as const;
 
-export function buildEpisodeLanguageOptions(languages: Record<string, string>): Record<string, string> {
-  return { unset: 'No Language', ...languages };
+/** @deprecated Prefer ENGLISH_LANGUAGE_EXCLUDED_CODES */
+export const PODCAST_DEFAULT_LANGUAGE_EXCLUDED_CODES = ENGLISH_LANGUAGE_EXCLUDED_CODES;
+
+function withoutEnglishCodes(languages: Record<string, string>): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(languages).filter(([code]) =>
+      !ENGLISH_LANGUAGE_EXCLUDED_CODES.includes(code as typeof ENGLISH_LANGUAGE_EXCLUDED_CODES[number]))
+  );
 }
 
+/** Episode picker: unset = English (stored as null). */
+export function buildEpisodeLanguageOptions(languages: Record<string, string>): Record<string, string> {
+  return { unset: 'English', ...withoutEnglishCodes(languages) };
+}
+
+/** Podcast default language: unset = no default. English is never a podcast default code. */
 export function buildPodcastLanguageOptions(languages: Record<string, string>): Record<string, string> {
-  const filtered = Object.fromEntries(
-    Object.entries(languages).filter(([code]) =>
-      !PODCAST_DEFAULT_LANGUAGE_EXCLUDED_CODES.includes(code as typeof PODCAST_DEFAULT_LANGUAGE_EXCLUDED_CODES[number]))
-  );
-  return { unset: 'No Language', ...filtered };
+  return { unset: 'No Language', ...withoutEnglishCodes(languages) };
+}
+
+/** Form value for an episode language code (English / empty / en* → unset). */
+export function episodeLanguageFormValue(lang: string | null | undefined): string {
+  if (!lang?.trim()) {
+    return 'unset';
+  }
+  const lower = lang.trim().toLowerCase().replace('_', '-');
+  if (lower === 'en' || lower.startsWith('en-')) {
+    return 'unset';
+  }
+  return lang;
 }

--- a/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.html
+++ b/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.html
@@ -124,7 +124,8 @@
                         <span>{{result.release | date:'d MMM yyyy H:mm'}}
                             [{{result.duration.startsWith("0")?result.duration.split(".")[0].substring(1):result.duration.split(".")[0]}}]</span>
                         @if (languageBadge(result); as lang) {
-                        <span class="curator-card__lang" [attr.title]="lang.label"
+                        <span class="curator-card__lang" [class.curator-card__lang--code]="lang.isCode"
+                            [attr.title]="lang.label"
                             [attr.aria-label]="lang.label">{{lang.flag}}</span>
                         }
                     </mat-card-subtitle>

--- a/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.sass
+++ b/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.sass
@@ -67,6 +67,12 @@
     line-height: 1
     font-family: 'Twemoji Country Flags', var(--cp-font-ui)
 
+.curator-card__lang--code
+    font-size: 0.72rem
+    font-weight: 700
+    letter-spacing: 0.04em
+    font-family: var(--cp-font-ui)
+
 button.selected
     span
         font-weight: bold

--- a/cultpodcasts/src/app/podcast-episode/podcast-episode.component.html
+++ b/cultpodcasts/src/app/podcast-episode/podcast-episode.component.html
@@ -69,7 +69,8 @@
         <span>{{ duration() }}</span>
         @if (languageFlag(); as lang) {
         <span class="episode-hero__lang" [attr.title]="lang.label" [attr.aria-label]="lang.label">
-          <span class="episode-hero__lang-flag" aria-hidden="true">{{ lang.flag }}</span>
+          <span class="episode-hero__lang-flag" [class.episode-hero__lang-flag--code]="lang.isCode"
+            aria-hidden="true">{{ lang.flag }}</span>
           <span>{{ lang.label }}</span>
         </span>
         }

--- a/cultpodcasts/src/app/podcast-episode/podcast-episode.component.sass
+++ b/cultpodcasts/src/app/podcast-episode/podcast-episode.component.sass
@@ -299,6 +299,12 @@
     font-weight: 400
     font-family: 'Twemoji Country Flags', var(--cp-font-ui)
 
+.episode-hero__lang-flag--code
+    font-size: 0.75rem
+    font-weight: 700
+    letter-spacing: 0.04em
+    font-family: var(--cp-font-ui)
+
 .episode-hero__desc
     margin: 0 0 18px
     max-width: 42em

--- a/cultpodcasts/src/app/subject-language-filter.spec.ts
+++ b/cultpodcasts/src/app/subject-language-filter.spec.ts
@@ -13,8 +13,9 @@ import {
 } from "./subject-language-filter";
 
 describe("subject-language-filter", () => {
-  it("defaults English to lang eq null", () => {
-    expect(buildSubjectLangFilter({ mode: "english" })).toBe(" and lang eq null");
+  it("defaults English to null plus legacy en codes", () => {
+    expect(buildSubjectLangFilter({ mode: "english" }))
+      .toBe(" and (lang eq null or lang eq 'en' or startswith(lang, 'en-'))");
     expect(selectionFromChipValues([])).toEqual({ mode: "english" });
     expect(selectionFromChipValues([ENGLISH_LANGUAGE_VALUE])).toEqual({ mode: "english" });
   });
@@ -27,7 +28,7 @@ describe("subject-language-filter", () => {
 
   it("supports English plus other codes and all-languages", () => {
     expect(buildSubjectLangFilter({ mode: "englishAndCodes", codes: ["es"] }))
-      .toBe(" and (lang eq null or search.in(lang, 'es', ','))");
+      .toBe(" and ((lang eq null or lang eq 'en' or startswith(lang, 'en-')) or search.in(lang, 'es', ','))");
     expect(buildSubjectLangFilter({ mode: "all" })).toBe("");
     expect(selectionFromChipValues([ALL_LANGUAGES_VALUE])).toEqual({ mode: "all" });
   });
@@ -44,6 +45,10 @@ describe("subject-language-filter", () => {
     expect(englishFacetCount(100, [{ value: "es", count: 30 }, { value: "fr", count: 20 }])).toBe(50);
   });
 
+  it("folds legacy en facet counts into the English bucket", () => {
+    expect(englishFacetCount(100, [{ value: "en", count: 10 }, { value: "fil", count: 40 }])).toBe(60);
+  });
+
   describe("availableLanguageChipValues", () => {
     it("includes English when null-lang episodes remain after non-English facets", () => {
       expect(availableLanguageChipValues(100, [{ value: "fr", count: 40 }]))
@@ -56,6 +61,11 @@ describe("subject-language-filter", () => {
 
     it("returns only English when there are no non-English facet buckets", () => {
       expect(availableLanguageChipValues(25, [])).toEqual([ENGLISH_LANGUAGE_VALUE]);
+    });
+
+    it("does not surface a second English chip for legacy en facets", () => {
+      expect(availableLanguageChipValues(20, [{ value: "en", count: 5 }, { value: "fil", count: 8 }]))
+        .toEqual([ENGLISH_LANGUAGE_VALUE, "fil"]);
     });
   });
 
@@ -155,6 +165,12 @@ describe("subject-language-filter", () => {
       expect(displayedLanguageOptions(
         [{ value: "es", count: 3 }, { value: "fr", count: 0 }],
         { mode: "english" })).toEqual([{ value: "es", count: 3 }]);
+    });
+
+    it("hides legacy en facet buckets so English is not duplicated", () => {
+      expect(displayedLanguageOptions(
+        [{ value: "en", count: 2 }, { value: "fil", count: 5 }],
+        { mode: "english" })).toEqual([{ value: "fil", count: 5 }]);
     });
 
     it("keeps actively selected codes visible when missing from facets", () => {

--- a/cultpodcasts/src/app/subject-language-filter.spec.ts
+++ b/cultpodcasts/src/app/subject-language-filter.spec.ts
@@ -13,9 +13,9 @@ import {
 } from "./subject-language-filter";
 
 describe("subject-language-filter", () => {
-  it("defaults English to null plus legacy en codes", () => {
+  it("defaults English to null plus exact legacy en (no startswith — Azure Search OData)", () => {
     expect(buildSubjectLangFilter({ mode: "english" }))
-      .toBe(" and (lang eq null or lang eq 'en' or startswith(lang, 'en-'))");
+      .toBe(" and (lang eq null or lang eq 'en')");
     expect(selectionFromChipValues([])).toEqual({ mode: "english" });
     expect(selectionFromChipValues([ENGLISH_LANGUAGE_VALUE])).toEqual({ mode: "english" });
   });
@@ -28,7 +28,7 @@ describe("subject-language-filter", () => {
 
   it("supports English plus other codes and all-languages", () => {
     expect(buildSubjectLangFilter({ mode: "englishAndCodes", codes: ["es"] }))
-      .toBe(" and ((lang eq null or lang eq 'en' or startswith(lang, 'en-')) or search.in(lang, 'es', ','))");
+      .toBe(" and ((lang eq null or lang eq 'en') or search.in(lang, 'es', ','))");
     expect(buildSubjectLangFilter({ mode: "all" })).toBe("");
     expect(selectionFromChipValues([ALL_LANGUAGES_VALUE])).toEqual({ mode: "all" });
   });

--- a/cultpodcasts/src/app/subject-language-filter.ts
+++ b/cultpodcasts/src/app/subject-language-filter.ts
@@ -19,9 +19,12 @@ export function isEnglishLanguageFacetCode(code: string | null | undefined): boo
   return lower === "en" || lower.startsWith("en-");
 }
 
-/** OData clause matching product English: null plus any legacy explicit English codes. */
-const ENGLISH_LANG_ODATA =
-  "(lang eq null or lang eq 'en' or startswith(lang, 'en-'))";
+/**
+ * OData clause matching product English: null (default) plus exact legacy `en`.
+ * Azure AI Search does not support OData `startswith`; do not use prefix matching here.
+ * Facet UI still folds any `en-*` buckets into the English chip via isEnglishLanguageFacetCode.
+ */
+const ENGLISH_LANG_ODATA = "(lang eq null or lang eq 'en')";
 
 export function buildSubjectLangFilter(selection: SubjectLanguageSelection): string {
   if (selection.mode === "all") {

--- a/cultpodcasts/src/app/subject-language-filter.ts
+++ b/cultpodcasts/src/app/subject-language-filter.ts
@@ -10,24 +10,37 @@ export type SubjectLanguageSelection =
   | { mode: "codes"; codes: string[] }
   | { mode: "englishAndCodes"; codes: string[] };
 
+/** Explicit `en` / `en-*` facets are English (legacy); fold into the synthetic English chip. */
+export function isEnglishLanguageFacetCode(code: string | null | undefined): boolean {
+  if (!code?.trim()) {
+    return false;
+  }
+  const lower = code.trim().toLowerCase().replace("_", "-");
+  return lower === "en" || lower.startsWith("en-");
+}
+
+/** OData clause matching product English: null plus any legacy explicit English codes. */
+const ENGLISH_LANG_ODATA =
+  "(lang eq null or lang eq 'en' or startswith(lang, 'en-'))";
+
 export function buildSubjectLangFilter(selection: SubjectLanguageSelection): string {
   if (selection.mode === "all") {
     return "";
   }
   if (selection.mode === "english") {
-    return " and lang eq null";
+    return ` and ${ENGLISH_LANG_ODATA}`;
   }
 
-  const codes = uniqueCodes(selection.codes);
+  const codes = uniqueCodes(selection.codes).filter(code => !isEnglishLanguageFacetCode(code));
   if (!codes.length) {
-    return " and lang eq null";
+    return ` and ${ENGLISH_LANG_ODATA}`;
   }
 
   const delimiter = ",";
   const list = codes.map(escapeODataString).join(delimiter);
   const codesFilter = `search.in(lang, '${list}', '${delimiter}')`;
   if (selection.mode === "englishAndCodes") {
-    return ` and (lang eq null or ${codesFilter})`;
+    return ` and (${ENGLISH_LANG_ODATA} or ${codesFilter})`;
   }
   if (codes.length === 1) {
     return ` and lang eq '${escapeODataString(codes[0])}'`;
@@ -46,7 +59,8 @@ export function selectionFromChipValues(values: string[]): SubjectLanguageSelect
 
   const includeEnglish = selected.has(ENGLISH_LANGUAGE_VALUE);
   const codes = [...selected]
-    .filter(value => value !== ENGLISH_LANGUAGE_VALUE && value !== ALL_LANGUAGES_VALUE);
+    .filter(value => value !== ENGLISH_LANGUAGE_VALUE && value !== ALL_LANGUAGES_VALUE)
+    .filter(value => !isEnglishLanguageFacetCode(value));
 
   if (includeEnglish && codes.length) {
     return { mode: "englishAndCodes", codes };
@@ -64,8 +78,10 @@ export function englishFacetCount(
   subjectTotal: number,
   langFacets: SearchResultFacet[] | undefined
 ): number {
-  const nonNull = (langFacets ?? []).reduce((sum, facet) => sum + (facet.count ?? 0), 0);
-  return Math.max(0, subjectTotal - nonNull);
+  const nonEnglish = (langFacets ?? [])
+    .filter(facet => facet.value && !isEnglishLanguageFacetCode(facet.value))
+    .reduce((sum, facet) => sum + (facet.count ?? 0), 0);
+  return Math.max(0, subjectTotal - nonEnglish);
 }
 
 /** Chip values that have episodes under the current subject (+ optional show) filter. */
@@ -78,7 +94,7 @@ export function availableLanguageChipValues(
     chips.push(ENGLISH_LANGUAGE_VALUE);
   }
   for (const facet of langFacets ?? []) {
-    if (facet.value && (facet.count ?? 0) > 0) {
+    if (facet.value && (facet.count ?? 0) > 0 && !isEnglishLanguageFacetCode(facet.value)) {
       chips.push(facet.value);
     }
   }
@@ -127,7 +143,8 @@ export function reconcileLanguageChipsForPodcasts(
 }
 
 export function hasNonEnglishFacets(langFacets: SearchResultFacet[] | undefined): boolean {
-  return (langFacets ?? []).some(facet => !!facet.value && (facet.count ?? 0) > 0);
+  return (langFacets ?? []).some(
+    facet => !!facet.value && (facet.count ?? 0) > 0 && !isEnglishLanguageFacetCode(facet.value));
 }
 
 // The Languages panel is pointless when a subject only has English/default
@@ -146,9 +163,10 @@ export function displayedLanguageOptions(
   langFacets: SearchResultFacet[] | undefined,
   selection: SubjectLanguageSelection
 ): SearchResultFacet[] {
-  const facets = (langFacets ?? []).filter(facet => !!facet.value && (facet.count ?? 0) > 0);
+  const facets = (langFacets ?? []).filter(
+    facet => !!facet.value && (facet.count ?? 0) > 0 && !isEnglishLanguageFacetCode(facet.value));
   const selectedCodes = selection.mode === "codes" || selection.mode === "englishAndCodes"
-    ? selection.codes
+    ? selection.codes.filter(code => !isEnglishLanguageFacetCode(code))
     : [];
   const missing = uniqueCodes(selectedCodes)
     .filter(code => !facets.some(facet => facet.value === code))

--- a/cultpodcasts/src/styles.scss
+++ b/cultpodcasts/src/styles.scss
@@ -60,6 +60,17 @@ body {
   font-family: 'Twemoji Country Flags', var(--cp-font-ui);
 }
 
+.episode-poster__badge--lang-code,
+.billboard__lang-flag--code,
+.episode-hero__lang-flag--code,
+.stage__lang--code,
+.curator-card__lang--code {
+  font-family: var(--cp-font-ui);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
 /* Hero copy shared by the homepage billboard and the episode page: a podcast
    pill above the title, then a date/duration meta line. Global rather than
    per-component so the two heroes cannot drift apart. */


### PR DESCRIPTION
## Summary
- Add country flags for Filipino and other mapped languages; show uppercase ISO codes (e.g. PA, YI) when there is no honest flag.
- Episode language picker uses English (stored as null); subject filters fold legacy `en` facets into one English chip.
- Style code badges across poster, hero, player, and curator cards.

## Test plan
- [ ] Subject with mixed Filipino / English / explicit `en` shows one English chip (no duplicate)
- [ ] Filipino episodes show PH flag; Punjabi/Yiddish show PA/YI code badges
- [ ] Edit episode language to English → request sends empty lang; form shows English selected
- [ ] `npm test -- --include=src/app/language-flag.spec.ts --include=src/app/subject-language-filter.spec.ts --include=src/app/episode-form.util.spec.ts`
