### PR TITLE
docs: preview/production secrets parity guardrail

### DIFF
--- a/.cursor/rules/preview-production-secrets-parity.mdc
+++ b/.cursor/rules/preview-production-secrets-parity.mdc
@@ -1,0 +1,55 @@
+---
+description: New preview/staging Pages or client secrets MUST be named in the PR and mirrored to production at deploy
+alwaysApply: true
+---
+
+# Preview ↔ production secrets parity (HARD GUARDRAIL)
+
+**Incident context (Aug 2026):** API Worker secrets set only on preview / wrong env left production admin routes 500ing. The same class of miss applies to Cloudflare Pages Preview vs Production env vars and any staging-only client config.
+
+## When this applies
+
+Any change that introduces or requires a **new** secret, Cloudflare Pages environment variable, or Auth0 / build-time config for:
+
+- Preview / staging website (Pages **Preview** env, `environment.staging.ts`, `.env.staging`, preview Auth0)
+- Production website (Pages **Production** env, `environment.prod.ts`, production Auth0)
+
+Also when a website PR depends on a **new Api Worker secret** (document it and ensure the Api PR/deploy covers production).
+
+## Forbidden
+
+| NEVER | Why |
+|-------|-----|
+| Configure Preview only and leave Production unset | Breaks apex / production releases |
+| Commit secret **values** | Use Cloudflare dashboard / `wrangler pages secret` / gitignored env files |
+| Open/merge a PR that needs new config without naming keys | Deployers cannot find what to set |
+
+## Required on every such PR
+
+1. **Document key names (not values)** in the PR body under **`## Config / secrets`**, e.g.:
+
+   ```markdown
+   ## Config / secrets
+   - [ ] Pages Preview: `AUTH0_CLIENT_ID` (or N/A)
+   - [ ] Pages Production: `AUTH0_CLIENT_ID` (same names as needed)
+   - [ ] Related Api Worker secrets (if any): `secureExampleEndpoint` on `api-preview` + top-level `api`
+   ```
+
+2. **Keep parity of intent**: if Preview needs a key for the feature to work, Production must get the same key name (values may differ for staging vs prod Auth0/Search/etc.).
+
+3. **At deploy / release time**:
+   - Open the merged PR(s) and read **`## Config / secrets`**
+   - Set each named key on **Preview and Production** (Pages + Api as listed)
+   - Do **not** treat “preview URL works” as production-ready until production config is confirmed
+
+## Related
+
+- Api Worker secrets: sibling repo `Api` — `docs/worker-secrets.md`, live production is top-level Worker `api` (not `--env production`)
+- Auth0 preview hosts: `cultpodcasts/docs/auth0-preview-hosts.md`
+- Website notes: `cultpodcasts/docs/preview-production-secrets.md`
+
+## Checklist
+
+- [ ] New secret / env **names** in PR `## Config / secrets` for preview **and** production
+- [ ] Deploy plan sets those keys on both environments before calling the release done
+- [ ] Values never committed

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+## Summary
+
+<!-- 1–3 bullets: what and why -->
+
+## Config / secrets
+
+<!-- Required when this PR adds or depends on new Pages env vars, Auth0/build secrets,
+     or Api Worker secrets. List **names only** (never values). -->
+
+- [ ] No new secrets / env keys
+- [ ] **Or** new key **names** (preview + production):
+  - Pages Preview: `<!-- e.g. AUTH0_CLIENT_ID -->`
+  - Pages Production: `<!-- same names as needed -->`
+  - Related Api Worker secrets (if any): `<!-- e.g. secureExampleEndpoint on api-preview + top-level api -->`
+
+At deploy time: read this section and set every named key on **both** environments before calling the release done.
+
+## Test plan
+
+- [ ]

--- a/cultpodcasts/AGENTS.md
+++ b/cultpodcasts/AGENTS.md
@@ -2,6 +2,13 @@
 
 Angular PWA / Bubblewrap client for [cultpodcasts.com](https://cultpodcasts.com). It consumes the Cult Podcasts API (`api-infra`) via the Cloudflare API worker.
 
+## Preview ↔ production secrets (HARD)
+
+Any new Pages / Auth0 / build secret for preview/staging **must** also be planned for production. PR body **must** include `## Config / secrets` with **key names** (never values). At deploy, read that section and set both environments.
+
+- Rule: [`../.cursor/rules/preview-production-secrets-parity.mdc`](../.cursor/rules/preview-production-secrets-parity.mdc)
+- Docs: [`docs/preview-production-secrets.md`](docs/preview-production-secrets.md)
+
 ## Repository layout
 
 - **Git root:** `~\source\repos\website` (parent of this folder). Run `git` commands from the parent repo or paths relative to it.

--- a/cultpodcasts/docs/preview-production-secrets.md
+++ b/cultpodcasts/docs/preview-production-secrets.md
@@ -1,0 +1,30 @@
+# Preview ↔ production secrets (website)
+
+New Cloudflare Pages env vars, Auth0/build secrets, or dependent Api Worker secrets added for **preview/staging** must also be planned for **production**.
+
+## Why
+
+Preview-only configuration has repeatedly been forgotten at release time, breaking production. Agents and humans must treat “works on `*.pages.dev`” as incomplete until production keys are set.
+
+## PR requirement
+
+Every PR that adds or depends on new config must include:
+
+```markdown
+## Config / secrets
+- [ ] Pages Preview: `KEY_NAME`
+- [ ] Pages Production: `KEY_NAME`
+- [ ] Related Api Worker secrets (if any): `secureExampleEndpoint` on api-preview + top-level api
+```
+
+List **names only** — never values.
+
+## Deploy
+
+1. Open the merged PR and read **`## Config / secrets`**.
+2. Set each named key on Preview **and** Production (Pages dashboard / wrangler; Api via Api repo set-secrets scripts).
+3. Only then treat the release as complete.
+
+## Agent rule
+
+See [`.cursor/rules/preview-production-secrets-parity.mdc`](../../.cursor/rules/preview-production-secrets-parity.mdc) (repo root: `website/.cursor/rules/`).


### PR DESCRIPTION
## Summary
- Always-on Cursor rule requiring new Pages/Auth0/build (and related Api) secret **names** in PR `## Config / secrets` for preview **and** production
- PR template + docs/`AGENTS.md` so deployers can read the PR and set both environments

## Config / secrets
- [x] No new secrets / env keys

## Test plan
- [ ] Confirm PR template shows Config / secrets section on GitHub
- [ ] Spot-check rule applies from `website/.cursor/rules/preview-production-secrets-parity.mdc`

Made with [Cursor](https://cursor.com)