### PR TITLE
fix(ui): keep hero subject chips clear of Listen CTA

### DIFF
--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
@@ -224,7 +224,8 @@
 .billboard__feature
     display: flex
     flex-direction: column
-    gap: 0
+    // Keep subject chips and Listen / More info from colliding when chips wrap.
+    gap: 14px
     opacity: 1
     transition: opacity 0.55s cubic-bezier(0.33, 0.1, 0.25, 1)
     &.is-hidden
@@ -240,7 +241,7 @@
     display: flex
     flex-direction: column
     min-height: calc(1.45em * 3 + 44px)
-    margin-bottom: 4px
+    margin-bottom: 0
 
 .billboard__eyebrow
     // Sits directly above the podcast pill — the pill carries the gap to the title.
@@ -326,16 +327,20 @@
     display: flex
     flex-wrap: wrap
     gap: 8px
-    margin: 0 0 8px
-    max-height: 2.4rem
+    margin: 0
+    // Two hero-chip rows (was 2.4rem — second row peeked under Listen).
+    max-height: 5.2rem
     overflow: hidden
+    flex: 0 0 auto
 
 .billboard__actions
     display: flex
     flex-wrap: wrap
     gap: 12px
-    margin-top: auto
+    margin-top: 0
     flex: 0 0 auto
+    position: relative
+    z-index: 1
 
 .billboard__play
     background: #fff !important
@@ -738,7 +743,6 @@
         flex-direction: column
         align-items: stretch
         width: 100%
-        margin-top: 12px
     .billboard__admin
         // Keep each control on its own hit target; wrapping pills must not stack.
         display: grid


### PR DESCRIPTION
## Summary
- Subject chips were wrapping into a second row that peeked under the Listen button (`max-height: 2.4rem` was too tight for hero chips)
- Allow two chip rows, add a fixed gap between copy and actions, and keep CTAs above chips in the stack

## Config / secrets
- [x] No new secrets / env keys

## Test plan
- [ ] Homepage hero with many/long subjects (e.g. FLDS + Peoples Temple + long church name): chips fully visible above Listen
- [ ] Slide with a wrapped second-row subject (e.g. Psychology): no overlap onto Listen
- [ ] Wide and narrow layouts: Listen / More info still usable
- [ ] `ng build` stays under the 16 kB hero style error budget

Made with [Cursor](https://cursor.com)