### PR TITLE
fix(ui): show all homepage hero subject chips

### DIFF
--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
@@ -224,7 +224,8 @@
 .billboard__feature
     display: flex
     flex-direction: column
-    gap: 0
+    // Keep Listen / More info below every subject chip row.
+    gap: 14px
     opacity: 1
     transition: opacity 0.55s cubic-bezier(0.33, 0.1, 0.25, 1)
     &.is-hidden
@@ -327,15 +328,16 @@
     flex-wrap: wrap
     gap: 8px
     margin: 0 0 8px
-    max-height: 2.4rem
-    overflow: hidden
+    flex: 0 0 auto
 
 .billboard__actions
     display: flex
     flex-wrap: wrap
     gap: 12px
-    margin-top: auto
+    margin-top: 0
     flex: 0 0 auto
+    position: relative
+    z-index: 1
 
 .billboard__play
     background: #fff !important
@@ -738,7 +740,6 @@
         flex-direction: column
         align-items: stretch
         width: 100%
-        margin-top: 12px
     .billboard__admin
         // Keep each control on its own hit target; wrapping pills must not stack.
         display: grid

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
@@ -268,7 +268,8 @@
     font-family: var(--cp-font-display)
     font-size: clamp(2.3rem, 6.5vw, 3.85rem)
     font-weight: 400
-    line-height: 1.02
+    // >1 so display-serif descenders (g, y, p) survive line-clamp + overflow:hidden.
+    line-height: 1.12
     letter-spacing: -0.025em
     color: var(--nflx-on-media, #fff)
     text-shadow: 0 4px 40px #000000bf
@@ -279,6 +280,8 @@
     -webkit-line-clamp: 3
     line-clamp: 3
     overflow: hidden
+    // Extra room under the last clamped line — webkit otherwise shears descenders.
+    padding-bottom: 0.08em
 
 .billboard__lang
     display: inline-flex
@@ -679,7 +682,7 @@
     // Stacked: details panel is in document flow under a fixed art frame. Title
     // line-count used to resize the panel (~125px between 1- and 3-line titles).
     .billboard__title
-        min-height: calc(1.02em * 3)
+        min-height: calc(1.12em * 3)
     // Copy no longer sits on the art, so the only job left is keeping the frosted
     // chrome legible over the top of the frame.
     .billboard__scrim

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.spec.ts
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.spec.ts
@@ -111,6 +111,22 @@ describe('HomepageHeroComponent', () => {
     expect(meta.textContent?.replace(/\s+/g, ' ').trim()).toBe('1:00:00');
   });
 
+  it('shows every public subject chip without capping count', () => {
+    const many = Array.from({ length: 12 }, (_, i) => `Topic ${i + 1}`);
+    fixture.componentRef.setInput('slides', [
+      ep('a', { subjects: ['_internal', ...many] }),
+      ep('b'),
+      ep('c'),
+    ]);
+    fixture.detectChanges();
+
+    expect(component['featuredSubjects']()).toEqual(many);
+    const chips = fixture.nativeElement.querySelectorAll(
+      '.billboard__subjects app-subject-chip'
+    );
+    expect(chips.length).toBe(12);
+  });
+
   it('jumps to a slide when its hero dash is clicked', () => {
     component['reduceMotion'] = true;
     fixture.detectChanges();

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.ts
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.ts
@@ -111,7 +111,8 @@ export class HomepageHeroComponent {
 
   protected readonly featuredSubjects = computed(() => {
     const subjects = this.featured()?.subjects ?? [];
-    return subjects.filter((s) => !s.startsWith('_')).slice(0, 4);
+    // Show every public subject — do not cap rows/count in the hero.
+    return subjects.filter((s) => !s.startsWith('_'));
   });
 
   private heroTimer: ReturnType<typeof setInterval> | undefined;


### PR DESCRIPTION
## Summary
- Hero was capping subjects at **4** in TS and clipping with CSS `max-height` (2.4rem / proposed 2 rows)
- Show every public subject (`_`-prefixed still hidden); let the chip wrap grow with the details card
- Keep a gap so Listen / More info stay below the chip stack

Supersedes #467 (two-row cap was the wrong product call).

## Config / secrets
- [x] No new secrets / env keys

## Test plan
- [x] `ng test` homepage-hero spec (21 passed), including uncapped subjects
- [x] Prod build under 16 kB hero style error budget (15.34 kB)
- [ ] Hero slide with many subjects: all chips visible above Listen
- [ ] Underscore-prefixed subjects still omitted

Made with [Cursor](https://cursor.com)