### PR TITLE
fix(ui): disable Bluesky checkbox on edit-episode

### DIFF
--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.83",
+  "version": "1.10.84",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.10.83",
+      "version": "1.10.84",
       "dependencies": {
         "@angular/cdk": "22.1.0",
         "@angular/common": "22.1.0",

--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.82",
+  "version": "1.10.83",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.10.82",
+      "version": "1.10.83",
       "dependencies": {
         "@angular/cdk": "22.1.0",
         "@angular/common": "22.1.0",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.83",
+  "version": "1.10.84",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.82",
+  "version": "1.10.83",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/src/app/add-episode-dialog/add-episode-dialog.component.ts
+++ b/cultpodcasts/src/app/add-episode-dialog/add-episode-dialog.component.ts
@@ -145,6 +145,9 @@ export class AddEpisodeDialogComponent {
       this.podcastName = podcast?.name;
 
       this.form.set(buildEpisodeForm(resp.episode));
+      // Bluesky state is set by a real network post (or cleared via un-post elsewhere),
+      // not by flipping this form flag.
+      this.form()!.controls.blueskyPosted.disable({ emitEvent: false });
       this.allPeople = resp.people.sort(comparePeopleBySortKey);
       this.guestSuggestions.set(resp.episode.guestSuggestions ?? []);
       this.regroupGuests(resp.episode.guests ?? []);
@@ -182,7 +185,6 @@ export class AddEpisodeDialogComponent {
         description: form.controls.description.value,
         posted: form.controls.posted.value,
         tweeted: form.controls.tweeted.value,
-        bluesky: form.controls.blueskyPosted.value,
         ignored: form.controls.ignored.value,
         removed: form.controls.removed.value,
         explicit: form.controls.explicit.value,

--- a/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.ts
+++ b/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.ts
@@ -178,7 +178,6 @@ export class EditEpisodeDialogComponent {
         description: form.controls.description.value,
         posted: form.controls.posted.value,
         tweeted: form.controls.tweeted.value,
-        bluesky: form.controls.blueskyPosted.value,
         ignored: form.controls.ignored.value,
         removed: form.controls.removed.value,
         explicit: form.controls.explicit.value,

--- a/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.ts
+++ b/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.ts
@@ -145,6 +145,9 @@ export class EditEpisodeDialogComponent {
       this.podcastId = podcast.id!;
 
       this.form.set(buildEpisodeForm(resp.episode));
+      // Bluesky state is set by a real network post (or cleared via un-post elsewhere),
+      // not by flipping this edit-form flag.
+      this.form()!.controls.blueskyPosted.disable({ emitEvent: false });
       this.allPeople = resp.people.sort(comparePeopleBySortKey);
       this.guestSuggestions.set(resp.episode.guestSuggestions ?? []);
       this.regroupGuests(resp.episode.guests ?? []);

--- a/cultpodcasts/src/app/episode-form.util.ts
+++ b/cultpodcasts/src/app/episode-form.util.ts
@@ -198,7 +198,6 @@ export function getEpisodeChanges(prev: ApiEpisode, now: ApiEpisode): EpisodePos
   if (prev.ignored != now.ignored) changes.ignored = now.ignored;
   if (prev.posted != now.posted) changes.posted = now.posted;
   if (prev.tweeted != now.tweeted) changes.tweeted = now.tweeted;
-  if ((prev.bluesky ?? false) != (now.bluesky ?? false)) changes.bluesky = now.bluesky ?? false;
   if (prev.release.toISOString() != nowReleaseDate) changes.release = nowReleaseDate;
   if (prev.removed != now.removed) changes.removed = now.removed;
   if (prev.searchTerms != now.searchTerms) changes.searchTerms = now.searchTerms;

--- a/cultpodcasts/src/app/episode-post.interface.ts
+++ b/cultpodcasts/src/app/episode-post.interface.ts
@@ -5,7 +5,8 @@ export interface EpisodePost {
     description?: string;
     posted?: boolean;
     tweeted?: boolean;
-    bluesky?: boolean;
+    /** When true, clear Bluesky post state and delete the remote post. */
+    unBluesky?: boolean;
     ignored?: boolean;
     removed?: boolean;
     explicit?: boolean;

--- a/cultpodcasts/src/app/episode-update.service.ts
+++ b/cultpodcasts/src/app/episode-update.service.ts
@@ -122,7 +122,7 @@ export class EpisodeUpdateService {
   }
 
   async unpostBluesky(episode: ApiEpisode): Promise<ApiEpisode> {
-    return this.applyAndRefresh(episode, { bluesky: false });
+    return this.applyAndRefresh(episode, { unBluesky: true });
   }
 
   async toggleBluesky(episode: ApiEpisode): Promise<ApiEpisode> {


### PR DESCRIPTION
## Summary
- Disable the Bluesky Post checkbox on edit-episode so curators cannot flip posted state without a network post.
- Checkbox still shows current posted state; real post/un-post remains on publish and status-toggle flows.
- Bump website to 1.10.83.

## Test plan
- [ ] Open edit-episode for a posted and unposted episode — Bluesky checkbox is disabled but reflects state
- [ ] Saving other edit-episode fields does not send a `bluesky` change
- [ ] Publish / status-toggle Bluesky post and un-post still work
