### PR TITLE
fix(homepage): show all day rails on first paint

### DIFF
--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.82",
+  "version": "1.10.85",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.10.82",
+      "version": "1.10.85",
       "dependencies": {
         "@angular/cdk": "22.1.0",
         "@angular/common": "22.1.0",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.82",
+  "version": "1.10.85",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/src/app/homepage-api/homepage-api.component.spec.ts
+++ b/cultpodcasts/src/app/homepage-api/homepage-api.component.spec.ts
@@ -169,7 +169,7 @@ describe('HomepageApiComponent', () => {
   }): void {
     component['curatedEpisodeIds'].set(curation?.episodeIds ?? []);
     component['curatedRailSubjects'].set(curation?.railSubjects ?? []);
-    component['applyHomepage'](homepageWith(episodes), { resetScrollProgress: true });
+    component['applyHomepage'](homepageWith(episodes));
   }
 
   it('prunes stale curated episode ids for local display only', () => {
@@ -203,24 +203,22 @@ describe('HomepageApiComponent', () => {
     expect(component['curatedEpisodeIds']()).toEqual([]);
   });
 
-  it('loads the initial progressive block then grows on loadMoreEpisodes', () => {
-    const episodes = Array.from({ length: 120 }, (_, i) => ep(`e${i}`, { daysAgo: i % 6 }));
-    apply(episodes);
-    const initial = Object.values(component['grouped']()).flat().length;
-    expect(initial).toBe(component.renderConfig.initialBlockSize);
+  it('shows every week day rail on first paint without scrolling', () => {
+    // Enough episodes that a progressive 40-episode window would omit older days.
+    const newest = Array.from({ length: 35 }, (_, i) => ep(`n${i}`, { daysAgo: 0 }));
+    const mid = Array.from({ length: 35 }, (_, i) => ep(`m${i}`, { daysAgo: 1 }));
+    const older = Array.from({ length: 35 }, (_, i) => ep(`o${i}`, { daysAgo: 3 }));
+    apply([...newest, ...mid, ...older]);
 
-    component['loadMoreEpisodes'](component.renderConfig.firstScrollBlockSize);
-    const after = Object.values(component['grouped']()).flat().length;
-    expect(after).toBe(
-      component.renderConfig.initialBlockSize + component.renderConfig.firstScrollBlockSize
-    );
+    const dayRails = component['rails']().filter((r) => r.id.startsWith('day:'));
+    expect(dayRails).toHaveLength(3);
+    expect(dayRails.map((r) => r.episodes.length)).toEqual([35, 35, 35]);
   });
 
-  it('background refresh keeps the current visible count', async () => {
+  it('background refresh replaces the week without progressive scroll state', async () => {
     const episodes = Array.from({ length: 100 }, (_, i) => ep(`e${i}`, { daysAgo: i % 5 }));
     apply(episodes);
-    component['loadMoreEpisodes'](component.renderConfig.firstScrollBlockSize);
-    const visibleBefore = component['visibleCount'];
+    const dayCountBefore = component['rails']().filter((r) => r.id.startsWith('day:')).length;
 
     const homepageService = TestBed.inject(HomepageService) as unknown as {
       getHomepageFromApi: ReturnType<typeof vi.fn>;
@@ -232,7 +230,9 @@ describe('HomepageApiComponent', () => {
       updatedAt: null,
     });
     await component['refreshHomepageInBackground']();
-    expect(component['visibleCount']).toBe(visibleBefore);
+    const dayCountAfter = component['rails']().filter((r) => r.id.startsWith('day:')).length;
+    expect(dayCountAfter).toBe(dayCountBefore);
+    expect(dayCountAfter).toBe(5);
   });
 
   it('interleaves newest day, then pinned subject rails, then remaining days by default', () => {

--- a/cultpodcasts/src/app/homepage-api/homepage-api.component.ts
+++ b/cultpodcasts/src/app/homepage-api/homepage-api.component.ts
@@ -87,10 +87,19 @@ export class HomepageApiComponent {
   /** Floor between any two fetches (interval or visibility-triggered) so a tab-switch flurry can't spam the API. */
   private static readonly minBackgroundRefreshGapMs = 5 * 60 * 1000;
 
-  protected grouped = signal<{ [key: string]: HomepageEpisode[] }>({});
   private allEpisodes = signal<HomepageEpisode[]>([]);
-  private visibleCount: number = 0;
-  private hasStartedScrolling: boolean = false;
+  /** Full week grouped by date key — day rails read this so every day appears on first paint. */
+  protected readonly grouped = computed(() => {
+    const group: { [key: string]: HomepageEpisode[] } = {};
+    for (const item of this.allEpisodes()) {
+      const releaseDateKey = dateKey(item.release as Date);
+      if (!group[releaseDateKey]) {
+        group[releaseDateKey] = [];
+      }
+      group[releaseDateKey].push(item);
+    }
+    return group;
+  });
   protected weekEpisodeCount = signal<number | undefined>(undefined);
   protected isLoading = signal<boolean>(true);
   protected isInError = signal<boolean>(false);
@@ -119,12 +128,6 @@ export class HomepageApiComponent {
   protected isSignedIn = toSignal(this.auth.isSignedIn, { initialValue: false });
   protected authRoles = toSignal(this.auth.roles, { initialValue: [] as string[] });
   protected readonly isCurator = computed(() => this.authRoles().includes('Curator'));
-  readonly renderConfig = {
-    initialBlockSize: 40,
-    firstScrollBlockSize: 80,
-    nearEndBlockSize: 80,
-    nearEndThresholdPixels: 1200,
-  };
 
   /** Ordered episode IDs from the hero-curation API (may include stale ids). */
   protected readonly curatedEpisodeIds = signal<string[]>([]);
@@ -195,6 +198,8 @@ export class HomepageApiComponent {
   );
 
   protected readonly rails = computed((): EpisodeRail[] => {
+    // Day rails use the full week so every date slot appears on first paint.
+    // Poster DOM cost is deferred per-rail via episode-rail [deferPosters].
     const g = this.grouped();
     const weekKeys = this.weekDayKeysNewestFirst();
     const dayRails = weekKeys.map((key) => {
@@ -206,7 +211,7 @@ export class HomepageApiComponent {
       return {
         id: `day:${key}`,
         title: `${this.Weekday[d.getDay()]} ${d.getDate()} ${this.Month[d.getMonth()]}`,
-        // Day rails have no "Browse all" destination — show the full progressive window.
+        // Day rails have no "Browse all" destination — show the full day.
         episodes,
       } satisfies EpisodeRail;
     });
@@ -268,22 +273,6 @@ export class HomepageApiComponent {
       this.maybeBackgroundRefresh();
     }
   };
-  private scrollFrame = 0;
-  /**
-   * Bound outside Angular's event manager on purpose: in a zoneless app every listener
-   * invocation schedules a change-detection pass, so a `@HostListener` here would run one
-   * per scroll event. Only `loadMoreEpisodes` writes signals, so CD now runs when the
-   * visible set actually grows.
-   */
-  private readonly onScrollEvent = (): void => {
-    if (this.scrollFrame) {
-      return;
-    }
-    this.scrollFrame = requestAnimationFrame(() => {
-      this.scrollFrame = 0;
-      this.onWindowScroll();
-    });
-  };
 
   ngOnInit() {
     this.siteService.homepageRefresh$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
@@ -293,31 +282,9 @@ export class HomepageApiComponent {
 
     if (isPlatformBrowser(this.platformId)) {
       this.startBackgroundRefresh();
-      this.startScrollWatch();
       this.destroyRef.onDestroy(() => {
         this.stopBackgroundRefresh();
-        this.stopScrollWatch();
       });
-    }
-  }
-
-  onWindowScroll(): void {
-    if (!this.homepage() || this.isLoading() || this.isInError() || this.allEpisodes().length === 0) {
-      return;
-    }
-
-    if (!this.hasStartedScrolling && window.scrollY > 0) {
-      this.hasStartedScrolling = true;
-      this.loadMoreEpisodes(this.renderConfig.firstScrollBlockSize);
-      return;
-    }
-
-    const currentBottom = window.innerHeight + window.scrollY;
-    const documentHeight = document.documentElement.scrollHeight;
-    const isNearEnd = currentBottom >= documentHeight - this.renderConfig.nearEndThresholdPixels;
-
-    if (isNearEnd) {
-      this.loadMoreEpisodes(this.renderConfig.nearEndBlockSize);
     }
   }
 
@@ -615,7 +582,7 @@ export class HomepageApiComponent {
     }
 
     if (homepageContent) {
-      this.applyHomepage(homepageContent, { resetScrollProgress: true });
+      this.applyHomepage(homepageContent);
       this.isLoading.set(false);
       this.isInError.set(false);
     } else {
@@ -644,21 +611,14 @@ export class HomepageApiComponent {
     if (!homepageContent) {
       return;
     }
-    this.applyHomepage(homepageContent, { resetScrollProgress: false });
+    this.applyHomepage(homepageContent);
   }
 
-  private applyHomepage(
-    homepageContent: Homepage,
-    options: { resetScrollProgress: boolean }
-  ): void {
+  private applyHomepage(homepageContent: Homepage): void {
     this.homepage.set(homepageContent);
     this.episodeCount.set(homepageContent.episodeCount);
     this.totalDurationDays.set(homepageContent.totalDuration.split('.')[0]);
     this.weekEpisodeCount.set(homepageContent.recentEpisodes.length);
-    if (options.resetScrollProgress) {
-      this.hasStartedScrolling = false;
-      this.visibleCount = 0;
-    }
     this.allEpisodes.set(
       homepageContent.recentEpisodes.map((item) => ({
         ...item,
@@ -668,27 +628,6 @@ export class HomepageApiComponent {
     // Week-window drop: curated picks that left recentEpisodes fall out locally
     // (and persist when a Curator is signed in).
     this.pruneCurationToCurrentWeek();
-    if (options.resetScrollProgress) {
-      this.loadMoreEpisodes(this.renderConfig.initialBlockSize);
-    } else if (this.visibleCount > 0) {
-      const keep = this.visibleCount;
-      this.visibleCount = 0;
-      this.loadMoreEpisodes(keep);
-    } else {
-      this.loadMoreEpisodes(this.renderConfig.initialBlockSize);
-    }
-  }
-
-  private startScrollWatch(): void {
-    window.addEventListener('scroll', this.onScrollEvent, { passive: true });
-  }
-
-  private stopScrollWatch(): void {
-    window.removeEventListener('scroll', this.onScrollEvent);
-    if (this.scrollFrame) {
-      cancelAnimationFrame(this.scrollFrame);
-      this.scrollFrame = 0;
-    }
   }
 
   private startBackgroundRefresh(): void {
@@ -721,28 +660,6 @@ export class HomepageApiComponent {
 
   private static heroTimeBucket(now: Date = new Date()): number {
     return Math.floor(now.getTime() / HomepageApiComponent.heroBucketMs);
-  }
-
-  private loadMoreEpisodes(count: number): void {
-    const episodes = this.allEpisodes();
-    const nextVisibleCount = Math.min(this.visibleCount + count, episodes.length);
-    if (nextVisibleCount === this.visibleCount) {
-      return;
-    }
-
-    this.visibleCount = nextVisibleCount;
-    const visibleEpisodes = episodes.slice(0, this.visibleCount);
-    this.grouped.set(
-      visibleEpisodes.reduce((group: { [key: string]: HomepageEpisode[] }, item) => {
-        const releaseDate = item.release as Date;
-        const releaseDateKey = dateKey(releaseDate);
-        if (!group[releaseDateKey]) {
-          group[releaseDateKey] = [];
-        }
-        group[releaseDateKey].push(item);
-        return group;
-      }, {})
-    );
   }
 
   ToDate = (key: string) => dateFromKey(key);


### PR DESCRIPTION
## Summary
- Day rails were built from a progressive 40-episode window, so older dates were skipped until scroll loaded more episodes into `grouped`.
- Group the full week up front so every day rail appears interleaved with subject rails on first paint.
- Remove scroll-gated progressive episode loading; day-rail poster DOM still uses `[deferPosters]`.

## Test plan
- [ ] Load homepage — day rails (e.g. Thursday 6 August) appear without scrolling
- [ ] Day rails remain interleaved with subject rails per curation order
- [ ] Scroll still feels fine (deferred posters for day rails)
- [ ] `npm test -- --include=src/app/homepage-api/homepage-api.component.spec.ts`
