### PR TITLE
fix(ui): edit-episode Bluesky unpost, URL/image actions, day rails

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Runs all cultpodcasts unit + Playwright e2e before push.
+# Emergency skip: SKIP_CLIENT_TESTS=1 git push
+
+if [ "${SKIP_CLIENT_TESTS:-}" = "1" ]; then
+  echo "SKIP_CLIENT_TESTS=1 — skipping cultpodcasts test:all"
+  exit 0
+fi
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT/cultpodcasts" || exit 1
+
+echo "pre-push: npm run test:all (cultpodcasts)"
+npm run test:all

--- a/.github/workflows/cultpodcasts-tests.yml
+++ b/.github/workflows/cultpodcasts-tests.yml
@@ -1,0 +1,36 @@
+name: Cultpodcasts tests
+
+on:
+  pull_request:
+    paths:
+      - "cultpodcasts/**"
+      - ".github/workflows/cultpodcasts-tests.yml"
+
+env:
+  NODE_VERSION: "22"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: cultpodcasts
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: cultpodcasts/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Unit + e2e
+        run: npm run test:all

--- a/cultpodcasts/.gitignore
+++ b/cultpodcasts/.gitignore
@@ -47,6 +47,9 @@ yarn-error.log
 /libpeerconnection.log
 testem.log
 /typings
+/test-results
+/playwright-report
+/blob-report
 
 # System files
 .DS_Store

--- a/cultpodcasts/AGENTS.md
+++ b/cultpodcasts/AGENTS.md
@@ -29,6 +29,7 @@ Before changing `src/app/homepage-hero/**`, `hero-slides.ts`, or homepage CSS th
 
 - Read [docs/homepage-hero.md](docs/homepage-hero.md) — `HERO-*` requirements, failure modes, regression checklist.
 - Keep `homepage-hero.component.spec.ts` green (specs are tagged with the same `HERO-*` ids).
+- For layout blank-space / viewport regressions, run `npm run test:e2e:hero-layout` (Playwright geometry harness).
 
 Curation KV deploy notes only: [docs/flix-prototype.md](docs/flix-prototype.md).
 

--- a/cultpodcasts/AGENTS.md
+++ b/cultpodcasts/AGENTS.md
@@ -23,6 +23,15 @@ Auth0 requires hostname **`local.cultpodcasts.com`** (hosts → `127.0.0.1`). De
 
 `environment.api` always points at **`https://local.cultpodcasts.com:8787`** (the API worker, not the website port).
 
+## Homepage hero (HARD for related changes)
+
+Before changing `src/app/homepage-hero/**`, `hero-slides.ts`, or homepage CSS that affects billboard copy height / scroll:
+
+- Read [docs/homepage-hero.md](docs/homepage-hero.md) — `HERO-*` requirements, failure modes, regression checklist.
+- Keep `homepage-hero.component.spec.ts` green (specs are tagged with the same `HERO-*` ids).
+
+Curation KV deploy notes only: [docs/flix-prototype.md](docs/flix-prototype.md).
+
 ## Discovery curation
 
 - **GET/POST** `/discovery-curation` on the API worker (8787) → proxies to `func` `DiscoveryCuration` on 7071.

--- a/cultpodcasts/AGENTS.md
+++ b/cultpodcasts/AGENTS.md
@@ -23,6 +23,23 @@ Auth0 requires hostname **`local.cultpodcasts.com`** (hosts → `127.0.0.1`). De
 
 `environment.api` always points at **`https://local.cultpodcasts.com:8787`** (the API worker, not the website port).
 
+## Tests (HARD before push)
+
+From `website/cultpodcasts/`:
+
+```bash
+npm run test:all
+```
+
+Runs **all** Vitest unit tests and **all** Playwright e2e (including hero layout geometry).
+
+- **Pre-push:** repo `.githooks/pre-push` runs `test:all` (enabled by `npm install` / `prepare` → `core.hooksPath=.githooks`).
+- **CI:** `.github/workflows/cultpodcasts-tests.yml` on PRs touching `cultpodcasts/**`.
+- **Do not** `git push --no-verify` / `-n` to skip (Cursor hook blocks that for agents).
+- Emergency only: `SKIP_CLIENT_TESTS=1 git push`.
+
+During a development cycle, prefer `npm run test:watch` while iterating, then `npm run test:all` before every push.
+
 ## Homepage hero (HARD for related changes)
 
 Before changing `src/app/homepage-hero/**`, `hero-slides.ts`, or homepage CSS that affects billboard copy height / scroll:

--- a/cultpodcasts/docs/homepage-hero.md
+++ b/cultpodcasts/docs/homepage-hero.md
@@ -8,6 +8,30 @@ Curation storage / KV API: [flix-prototype.md](./flix-prototype.md) — **out of
 
 Full-bleed featured-episode carousel: backdrop crossfade, Ken Burns (desktop), dwell auto-advance, curator controls, pager dashes, touch swipe (mobile).
 
+## Design tensions (read first)
+
+These two goals fight each other. **Both are required.** Fixes that only optimize one side regress the other.
+
+| Goal | Why | Wrong “fix” |
+|------|-----|----------------|
+| **Stable height when copy exists** (HERO-SCR-002) | Short vs long descriptions (1–3 lines) must not collapse the panel or yank scroll mid-autoplay | Always reserve 3 lines of desc height on every slide |
+| **No blank band when copy is absent** (HERO-SCR-004) | Clips / short episodes often have **empty** `episodeDescription` and no subjects — mobile then shows a large black gap between meta and Watch | Leave an empty `<p class="billboard__desc">` with `min-height`, or put `min-height` on `.billboard__copy-body` unconditionally |
+
+**Correct pattern**
+
+1. Render `.billboard__desc` **only** when `hasFeaturedDesc` (trimmed text length > 0).
+2. Render `.billboard__copy-body` **only** when there is a description **or** at least one public subject (`hasCopyBody`).
+3. Apply reserved min-height **only** under `.billboard__copy-body.has-desc` (and `.billboard__desc` itself) — never on a body with no description.
+4. Keep `overflow-anchor: none` on `.billboard` so slides that flip between “has desc” and “no desc” still do not yank `scrollY` (HERO-SCR-001 / 003).
+
+**How to notice HERO-SCR-004 in review / QA**
+
+- Pick a hero slide with **no** description and **no** subject chips (common for short YouTube clips).
+- On a narrow viewport: meta (date · duration) should sit close above Watch / More info — **not** a multi-line empty band.
+- Automated: specs tagged `HERO-SCR-004` (omit empty desc/copy-body; `has-desc` only when text exists).
+
+If you “fix scroll jump” by re-adding unconditional `min-height` on `.billboard__copy-body` or always rendering an empty desc paragraph, you will recreate the mobile blank-space bug.
+
 ## Key files
 
 | Path | Role |
@@ -21,15 +45,16 @@ Full-bleed featured-episode carousel: backdrop crossfade, Ken Burns (desktop), d
 
 ## Requirements (stable IDs)
 
-Use these IDs in PR notes and test `DisplayName`-style descriptions.
+Use these IDs in PR notes and test descriptions.
 
 | ID | Requirement | Automated? |
 |----|-------------|------------|
 | **HERO-SUB-001** | Every public subject (not `_`-prefixed) renders as a chip; no count/row cap in TS, template, or CSS | Yes |
 | **HERO-SUB-002** | Watch/Listen + More info stay **below** the subject chip block | Yes (DOM order) |
 | **HERO-SCR-001** | `.billboard` (and dots viewport) set `overflow-anchor: none` | Yes (Sass contract) |
-| **HERO-SCR-002** | Title and description are 3-line clamped; description and `.billboard__copy-body` reserve min-height so short copy does not collapse the panel | Yes (Sass contract) |
+| **HERO-SCR-002** | When a description exists: title/desc are 3-line clamped; `.billboard__desc` and `.billboard__copy-body.has-desc` reserve min-height so **short** copy does not collapse the panel | Yes (Sass contract) |
 | **HERO-SCR-003** | Changing slide while the page is scrolled must not yank `window.scrollY` | Manual |
+| **HERO-SCR-004** | No description: omit empty desc; omit copy-body when no desc and no subjects; **never** reserve desc `min-height` without `.has-desc` — mobile must not show a blank band above Watch | Yes |
 | **HERO-CTL-001** | Stage / grain / scrim / vignette use `pointer-events: none` so pager stays clickable | Yes (Sass contract) |
 | **HERO-CTL-002** | Touch swipe ignores links, buttons, pager, admin, actions | Yes |
 | **HERO-SWP-001** | Touch horizontal swipe ≥48px → `prevHero` / `nextHero` (existing transition; no drag animation); mouse ignored; `touch-action: pan-y` on billboard | Yes |
@@ -72,19 +97,26 @@ Constants (`HomepageHeroComponent`):
 - `.billboard__subjects`: wrapping flex; **no** `overflow: hidden`, fixed `max-height`, or line-clamp.
 - Actions (`.billboard__actions`) follow subjects in the DOM.
 
-### Scroll stability (HERO-SCR-*)
+### Scroll stability vs empty copy (HERO-SCR-*)
 
-When the user has scrolled (or mid-autoplay while scrolled), slide copy height changes must **not** move `window.scrollY`.
+See **Design tensions** above. Summary:
 
 | Mechanism | Selector / rule |
 |-----------|-----------------|
 | `overflow-anchor: none` | `.billboard`, `.billboard__dots-viewport` |
 | Title clamp 3 | `.billboard__title` |
-| Desc clamp 3 + `min-height: calc(1.45em * 3)` | `.billboard__desc` |
-| Reserved copy-body | `.billboard__copy-body` min-height includes desc + chip band |
+| Desc clamp 3 + min-height | `.billboard__desc` — **only when rendered** |
+| Reserved copy-body | `.billboard__copy-body.has-desc` only — **not** bare `.billboard__copy-body` |
+| Empty slide | No `.billboard__desc`; no `.billboard__copy-body` if no subjects either |
 | Wide absolute docking / narrow stacked band | media queries in the same Sass file |
 
-Unit tests assert the Sass still contains these contracts. **HERO-SCR-003** remains a scrolled visual check.
+**Forbidden regressions**
+
+- Unconditional `min-height` on `.billboard__copy-body` (breaks HERO-SCR-004).
+- Always rendering `<p class="billboard__desc">{{ featuredDesc() }}</p>` when the string is empty (empty paragraph still consumes reserved height if min-height is on the element or parent).
+- “Fixing” blank space by removing `.has-desc` min-height while a description **is** present (breaks HERO-SCR-002 for short text).
+
+Unit tests assert Sass contracts + HERO-SCR-004 DOM behaviour. **HERO-SCR-003** remains a scrolled visual check.
 
 ### Controls & swipe (HERO-CTL-*, HERO-SWP-*)
 
@@ -94,7 +126,9 @@ Unit tests assert the Sass still contains these contracts. **HERO-SCR-003** rema
 
 ### Copy hierarchy
 
-Eyebrow → podcast pill → title → meta → description → **all** subject chips → Watch/Listen + More info.
+Eyebrow → podcast pill → title → meta → (optional description) → (optional subject chips) → Watch/Listen + More info.
+
+When description and subjects are both absent, actions follow meta directly.
 
 ## Known failure modes
 
@@ -102,7 +136,9 @@ Eyebrow → podcast pill → title → meta → description → **all** subject 
 |---------|-----|----------------|
 | Subject chips missing / clipped | HERO-SUB-001 | Spec uncapped chips + Sass forbids subjects overflow/max-height |
 | Actions above / mixed into chips | HERO-SUB-002 | DOM order: subjects before actions |
-| Page jumps on advance | HERO-SCR-* | Sass contract + manual scrolled advance |
+| Page jumps on advance | HERO-SCR-001/003 | Sass `overflow-anchor` + manual scrolled advance |
+| Huge blank gap above Watch (esp. mobile, no description) | HERO-SCR-004 | Specs omit empty desc/copy-body; Sass reserves height only under `.has-desc` |
+| Short description collapses panel / jumpy actions | HERO-SCR-002 | Sass min-height on `.has-desc` / `.billboard__desc` |
 | Chevron dead | HERO-LIF-002 | Spec: next chevron does not cancel content transition |
 | Dwell stuck after pager | focus pause | Spec: releases chevron focus |
 | Blank / text ahead of art | HERO-LIF-001/003 | Image gate + hold-until-ready specs |
@@ -116,12 +152,14 @@ Prefer compiled hero styles under ~16 kB. Soft check — do not sacrifice an inv
 
 ## Regression checklist
 
-**Automated** — `ng test` filter `HomepageHeroComponent` (all HERO-* with “Yes” above).
+**Automated** — `ng test` filter `HomepageHeroComponent` (all HERO-* with “Yes” above), including **HERO-SCR-004**.
 
 **Manual**
 
+- [ ] **HERO-SCR-004:** mobile / narrow — slide with empty description and no subjects: no large blank band between meta and Watch
+- [ ] **HERO-SCR-002:** slide with a 1-line description still keeps actions from jumping up relative to a 3-line description (reserved height when `.has-desc`)
 - [ ] HERO-SCR-003: scroll hero partly off-screen; advance; no jump
-- [ ] Long vs short title/desc visually stable; descenders OK
+- [ ] Long vs short title visually stable; descenders OK
 - [ ] Mobile: swipe vs vertical scroll; CTAs still tappable
 - [ ] Many subjects: all visible; actions still below
 

--- a/cultpodcasts/docs/homepage-hero.md
+++ b/cultpodcasts/docs/homepage-hero.md
@@ -10,27 +10,29 @@ Full-bleed featured-episode carousel: backdrop crossfade, Ken Burns (desktop), d
 
 ## Design tensions (read first)
 
-These two goals fight each other. **Both are required.** Fixes that only optimize one side regress the other.
+These goals fight each other. **All are required.** Fixes that only optimize one side regress the others.
 
 | Goal | Why | Wrong “fix” |
 |------|-----|----------------|
-| **Stable height when copy exists** (HERO-SCR-002) | Short vs long descriptions (1–3 lines) must not collapse the panel or yank scroll mid-autoplay | Always reserve 3 lines of desc height on every slide |
-| **No blank band when copy is absent** (HERO-SCR-004) | Clips / short episodes often have **empty** `episodeDescription` and no subjects — mobile then shows a large black gap between meta and Watch | Leave an empty `<p class="billboard__desc">` with `min-height`, or put `min-height` on `.billboard__copy-body` unconditionally |
+| **Stable height when description exists** (HERO-SCR-002) | Short vs long descriptions (1–3 lines) must not collapse the panel mid-autoplay | Always reserve 3 lines of desc height on every slide |
+| **No blank band when description is absent** (HERO-SCR-004) | Clips / short episodes often have **empty** `episodeDescription` — mobile shows a large black gap between meta and Watch | Empty `<p class="billboard__desc">` with `min-height`, or unconditional `min-height` on `.billboard__copy-body` |
+| **No blank band under short titles** (HERO-SCR-005) | Stacked layout (≤1280) puts the title in normal flow; a 1-line title with a 3-line `min-height` leaves a large gap above the date/meta | `.billboard__title { min-height: calc(1.12em * 3) }` (or similar) on stacked layouts |
 
 **Correct pattern**
 
 1. Render `.billboard__desc` **only** when `hasFeaturedDesc` (trimmed text length > 0).
 2. Render `.billboard__copy-body` **only** when there is a description **or** at least one public subject (`hasCopyBody`).
-3. Apply reserved min-height **only** under `.billboard__copy-body.has-desc` (and `.billboard__desc` itself) — never on a body with no description.
-4. Keep `overflow-anchor: none` on `.billboard` so slides that flip between “has desc” and “no desc” still do not yank `scrollY` (HERO-SCR-001 / 003).
+3. Apply reserved desc min-height **only** under `.billboard__copy-body.has-desc` (and `.billboard__desc` itself).
+4. Title: `line-clamp: 3` as a **ceiling** only — **never** set title `min-height` to N lines. Accept 1–3 line height variance; keep `overflow-anchor: none` (HERO-SCR-001 / 003).
+5. Keep `overflow-anchor: none` on `.billboard` when slides flip between short/long title or has-desc / no-desc.
 
-**How to notice HERO-SCR-004 in review / QA**
+**How to notice in review / QA**
 
-- Pick a hero slide with **no** description and **no** subject chips (common for short YouTube clips).
-- On a narrow viewport: meta (date · duration) should sit close above Watch / More info — **not** a multi-line empty band.
-- Automated: specs tagged `HERO-SCR-004` (omit empty desc/copy-body; `has-desc` only when text exists).
+- **HERO-SCR-004:** slide with no description and no subjects — meta should sit close above Watch (no multi-line empty band).
+- **HERO-SCR-005:** slide with a short title (e.g. “The Rulo Farm”) on mobile/stacked — date/meta should sit close under the title, not after ~2 empty title lines.
+- Automated: specs tagged `HERO-SCR-004` / `HERO-SCR-005` (DOM + Sass forbids title line-reservation `min-height`).
 
-If you “fix scroll jump” by re-adding unconditional `min-height` on `.billboard__copy-body` or always rendering an empty desc paragraph, you will recreate the mobile blank-space bug.
+If you “fix scroll jump” by re-adding unconditional copy-body `min-height` or title `min-height: calc(1.12em * 3)`, you will recreate the mobile blank-space bugs.
 
 ## Key files
 
@@ -55,6 +57,7 @@ Use these IDs in PR notes and test descriptions.
 | **HERO-SCR-002** | When a description exists: title/desc are 3-line clamped; `.billboard__desc` and `.billboard__copy-body.has-desc` reserve min-height so **short** copy does not collapse the panel | Yes (Sass contract) |
 | **HERO-SCR-003** | Changing slide while the page is scrolled must not yank `window.scrollY` | Manual |
 | **HERO-SCR-004** | No description: omit empty desc; omit copy-body when no desc and no subjects; **never** reserve desc `min-height` without `.has-desc` — mobile must not show a blank band above Watch | Yes |
+| **HERO-SCR-005** | Short titles must not reserve empty lines: stacked layout must **not** set `.billboard__title { min-height: N lines }` — meta follows the title tightly | Yes (Sass contract) |
 | **HERO-CTL-001** | Stage / grain / scrim / vignette use `pointer-events: none` so pager stays clickable | Yes (Sass contract) |
 | **HERO-CTL-002** | Touch swipe ignores links, buttons, pager, admin, actions | Yes |
 | **HERO-SWP-001** | Touch horizontal swipe ≥48px → `prevHero` / `nextHero` (existing transition; no drag animation); mouse ignored; `touch-action: pan-y` on billboard | Yes |
@@ -104,7 +107,7 @@ See **Design tensions** above. Summary:
 | Mechanism | Selector / rule |
 |-----------|-----------------|
 | `overflow-anchor: none` | `.billboard`, `.billboard__dots-viewport` |
-| Title clamp 3 | `.billboard__title` |
+| Title clamp 3 (ceiling only) | `.billboard__title` — **no** `min-height` reserving empty lines |
 | Desc clamp 3 + min-height | `.billboard__desc` — **only when rendered** |
 | Reserved copy-body | `.billboard__copy-body.has-desc` only — **not** bare `.billboard__copy-body` |
 | Empty slide | No `.billboard__desc`; no `.billboard__copy-body` if no subjects either |
@@ -113,7 +116,8 @@ See **Design tensions** above. Summary:
 **Forbidden regressions**
 
 - Unconditional `min-height` on `.billboard__copy-body` (breaks HERO-SCR-004).
-- Always rendering `<p class="billboard__desc">{{ featuredDesc() }}</p>` when the string is empty (empty paragraph still consumes reserved height if min-height is on the element or parent).
+- Always rendering `<p class="billboard__desc">{{ featuredDesc() }}</p>` when the string is empty.
+- `.billboard__title { min-height: calc(1.12em * 3) }` (or any N-line title reservation) on stacked layouts (breaks HERO-SCR-005 — short titles leave a blank band above meta).
 - “Fixing” blank space by removing `.has-desc` min-height while a description **is** present (breaks HERO-SCR-002 for short text).
 
 Unit tests assert Sass contracts + HERO-SCR-004 DOM behaviour. **HERO-SCR-003** remains a scrolled visual check.
@@ -138,6 +142,7 @@ When description and subjects are both absent, actions follow meta directly.
 | Actions above / mixed into chips | HERO-SUB-002 | DOM order: subjects before actions |
 | Page jumps on advance | HERO-SCR-001/003 | Sass `overflow-anchor` + manual scrolled advance |
 | Huge blank gap above Watch (esp. mobile, no description) | HERO-SCR-004 | Specs omit empty desc/copy-body; Sass reserves height only under `.has-desc` |
+| Huge blank gap under short title (above date/meta) | HERO-SCR-005 | Sass contract forbids title N-line `min-height` |
 | Short description collapses panel / jumpy actions | HERO-SCR-002 | Sass min-height on `.has-desc` / `.billboard__desc` |
 | Chevron dead | HERO-LIF-002 | Spec: next chevron does not cancel content transition |
 | Dwell stuck after pager | focus pause | Spec: releases chevron focus |
@@ -157,6 +162,7 @@ Prefer compiled hero styles under ~16 kB. Soft check — do not sacrifice an inv
 **Manual**
 
 - [ ] **HERO-SCR-004:** mobile / narrow — slide with empty description and no subjects: no large blank band between meta and Watch
+- [ ] **HERO-SCR-005:** mobile / stacked — short title (1 line): date/meta tight under title, not after empty title lines
 - [ ] **HERO-SCR-002:** slide with a 1-line description still keeps actions from jumping up relative to a 3-line description (reserved height when `.has-desc`)
 - [ ] HERO-SCR-003: scroll hero partly off-screen; advance; no jump
 - [ ] Long vs short title visually stable; descenders OK

--- a/cultpodcasts/docs/homepage-hero.md
+++ b/cultpodcasts/docs/homepage-hero.md
@@ -163,11 +163,15 @@ npm run test:e2e:hero-layout
 
 | Piece | Role |
 |-------|------|
-| `e2e/hero-layout.spec.ts` | Viewports × fixtures; asserts title→meta / meta→actions gaps, `.has-desc` height, DOM omit rules |
-| `e2e/hero-layout/fixtures.ts` | Episode configurations (short title, empty desc, long title, subjects) |
-| `e2e/hero-layout/build-harness.ts` | Compiles **real** `homepage-hero.component.sass` into a light-DOM page (`:host` → `.hero-layout-host`) |
+| `e2e/hero-layout.spec.ts` | Viewport × fixture matrix; geometry + visibility asserts |
+| `e2e/hero-layout/fixtures.ts` | Episode configs (empty desc, many subjects, short/long title) |
+| `e2e/hero-layout/build-harness.ts` | Compiles **real** `homepage-hero.component.sass` (`:host` → `.hero-layout-host`) |
 
-Tagged to **HERO-SCR-002 / 004 / 005** and **HERO-SUB-002**. Keep fixture HTML structure aligned with the billboard copy markup in `homepage-hero.component.html`.
+**Viewports:** mobile (390×844), mobile-landscape (844×390), tablet (768×1024), stacked-desktop (1100×800), wide (1440×900), **full-hd (1920×1080)**.
+
+**Fixtures include:** no description; many subjects (12) with and without description.
+
+Tagged to **HERO-SCR-002 / 004 / 005** and **HERO-SUB-001 / 002**. Keep fixture HTML aligned with `homepage-hero.component.html`.
 
 ## Soft guideline — style budget
 
@@ -178,7 +182,7 @@ Prefer compiled hero styles under ~16 kB. Soft check — do not sacrifice an inv
 **Automated**
 
 - [ ] `ng test` filter `HomepageHeroComponent` (HERO-* unit / Sass contracts)
-- [ ] `npm run test:e2e:hero-layout` (geometry across mobile / tablet / stacked-desktop)
+- [ ] `npm run test:e2e:hero-layout` (geometry: mobile / landscape / tablet / stacked / wide / full-hd × empty-desc & many-subjects)
 
 **Manual**
 

--- a/cultpodcasts/docs/homepage-hero.md
+++ b/cultpodcasts/docs/homepage-hero.md
@@ -151,13 +151,34 @@ When description and subjects are both absent, actions follow meta directly.
 | Scroll fights swipe | HERO-SWP-001 | `touch-action: pan-y` + swipe specs |
 | Ken Burns on phone | HERO-LIF-005 | saveGpu spec |
 
+## Layout geometry e2e (Playwright)
+
+Unit tests cannot apply real CSS media queries / box geometry the way a phone does. Use:
+
+```bash
+npm run test:e2e:hero-layout
+```
+
+(`npx playwright install chromium` once per machine.)
+
+| Piece | Role |
+|-------|------|
+| `e2e/hero-layout.spec.ts` | Viewports × fixtures; asserts title→meta / meta→actions gaps, `.has-desc` height, DOM omit rules |
+| `e2e/hero-layout/fixtures.ts` | Episode configurations (short title, empty desc, long title, subjects) |
+| `e2e/hero-layout/build-harness.ts` | Compiles **real** `homepage-hero.component.sass` into a light-DOM page (`:host` → `.hero-layout-host`) |
+
+Tagged to **HERO-SCR-002 / 004 / 005** and **HERO-SUB-002**. Keep fixture HTML structure aligned with the billboard copy markup in `homepage-hero.component.html`.
+
 ## Soft guideline — style budget
 
 Prefer compiled hero styles under ~16 kB. Soft check — do not sacrifice an invariant for a few hundred bytes.
 
 ## Regression checklist
 
-**Automated** — `ng test` filter `HomepageHeroComponent` (all HERO-* with “Yes” above), including **HERO-SCR-004**.
+**Automated**
+
+- [ ] `ng test` filter `HomepageHeroComponent` (HERO-* unit / Sass contracts)
+- [ ] `npm run test:e2e:hero-layout` (geometry across mobile / tablet / stacked-desktop)
 
 **Manual**
 

--- a/cultpodcasts/docs/homepage-hero.md
+++ b/cultpodcasts/docs/homepage-hero.md
@@ -1,0 +1,131 @@
+# Homepage hero (billboard)
+
+Design contract for `app-homepage-hero`. **Read this before changing** `src/app/homepage-hero/**`, `hero-slides.ts`, or homepage CSS that affects billboard copy height / scroll.
+
+Curation storage / KV API: [flix-prototype.md](./flix-prototype.md) — **out of scope** here.
+
+## Purpose
+
+Full-bleed featured-episode carousel: backdrop crossfade, Ken Burns (desktop), dwell auto-advance, curator controls, pager dashes, touch swipe (mobile).
+
+## Key files
+
+| Path | Role |
+|------|------|
+| `src/app/homepage-hero/homepage-hero.component.{ts,html,sass}` | Billboard UI, transitions, swipe, layout |
+| `src/app/homepage-hero/homepage-hero.component.spec.ts` | Behaviour + CSS-contract regressions |
+| `src/app/hero-slides.ts` | Build / prune curated week slides |
+| `src/app/hero-curation.service.ts` | Client for `/hero-curation` |
+| `src/app/hero-manage-dialog/*` | Curator reorder / remove |
+| `src/app/homepage-api/homepage-api.component.ts` | Supplies `slides`, curation wiring |
+
+## Requirements (stable IDs)
+
+Use these IDs in PR notes and test `DisplayName`-style descriptions.
+
+| ID | Requirement | Automated? |
+|----|-------------|------------|
+| **HERO-SUB-001** | Every public subject (not `_`-prefixed) renders as a chip; no count/row cap in TS, template, or CSS | Yes |
+| **HERO-SUB-002** | Watch/Listen + More info stay **below** the subject chip block | Yes (DOM order) |
+| **HERO-SCR-001** | `.billboard` (and dots viewport) set `overflow-anchor: none` | Yes (Sass contract) |
+| **HERO-SCR-002** | Title and description are 3-line clamped; description and `.billboard__copy-body` reserve min-height so short copy does not collapse the panel | Yes (Sass contract) |
+| **HERO-SCR-003** | Changing slide while the page is scrolled must not yank `window.scrollY` | Manual |
+| **HERO-CTL-001** | Stage / grain / scrim / vignette use `pointer-events: none` so pager stays clickable | Yes (Sass contract) |
+| **HERO-CTL-002** | Touch swipe ignores links, buttons, pager, admin, actions | Yes |
+| **HERO-SWP-001** | Touch horizontal swipe ≥48px → `prevHero` / `nextHero` (existing transition; no drag animation); mouse ignored; `touch-action: pan-y` on billboard | Yes |
+| **HERO-LIF-001** | Image gate blocks dwell until decode or 12s fallback | Yes |
+| **HERO-LIF-002** | `restartHeroCycle` must not clear `heroContentTimer` / in-flight preload | Yes |
+| **HERO-LIF-003** | Hold + crossfade: copy stays until next backdrop ready, then leaves with image | Yes |
+| **HERO-LIF-004** | Reduced motion: immediate index jump, no cycle timer | Yes |
+| **HERO-LIF-005** | Save-GPU: Ken Burns off, auto-advance on | Yes |
+| **HERO-LIF-006** | Quiet slide refresh (same id sequence) does not rebuild layers | Yes |
+| **HERO-CUR-001** | Curator manage / remove controls emit and stay in admin toolbar | Yes |
+
+## Slide lifecycle
+
+```mermaid
+stateDiagram-v2
+  [*] --> ImageGate: slide shown
+  ImageGate --> Dwell: backdrop decoded or fallback
+  Dwell --> Transition: interval elapsed and not paused
+  Transition --> Hold: preload next backdrop
+  Hold --> Crossfade: hold done and image ready
+  Crossfade --> ImageGate: index advanced copy visible
+```
+
+Constants (`HomepageHeroComponent`):
+
+| Constant | Value | Meaning |
+|----------|-------|---------|
+| `heroIntervalMs` | 7500 | Dwell before auto-advance (`--hero-interval` for Ken Burns) |
+| `heroImageFallbackMs` | 12000 | Safety gate if decode never completes |
+| `heroContentHoldMs` | 450 | Hold current copy before leaving |
+| `heroContentOutMs` | 550 | Must match `.billboard__feature.is-hidden` duration |
+| `heroTransitionMs` | 1200 | Stage opacity / outgoing Ken Burns clear |
+| `swipeThresholdPx` | 48 | Touch horizontal swipe → prev/next |
+
+## Hard layout invariants
+
+### Subjects (HERO-SUB-*)
+
+- `featuredSubjects` filters only `_` prefixes — **no** `.slice` / max-count.
+- `.billboard__subjects`: wrapping flex; **no** `overflow: hidden`, fixed `max-height`, or line-clamp.
+- Actions (`.billboard__actions`) follow subjects in the DOM.
+
+### Scroll stability (HERO-SCR-*)
+
+When the user has scrolled (or mid-autoplay while scrolled), slide copy height changes must **not** move `window.scrollY`.
+
+| Mechanism | Selector / rule |
+|-----------|-----------------|
+| `overflow-anchor: none` | `.billboard`, `.billboard__dots-viewport` |
+| Title clamp 3 | `.billboard__title` |
+| Desc clamp 3 + `min-height: calc(1.45em * 3)` | `.billboard__desc` |
+| Reserved copy-body | `.billboard__copy-body` min-height includes desc + chip band |
+| Wide absolute docking / narrow stacked band | media queries in the same Sass file |
+
+Unit tests assert the Sass still contains these contracts. **HERO-SCR-003** remains a scrolled visual check.
+
+### Controls & swipe (HERO-CTL-*, HERO-SWP-*)
+
+- Full-bleed layers: `pointer-events: none`.
+- Billboard: `touch-action: pan-y`.
+- Swipe: touch/pen only; axis lock; ignore interactive targets via `isSwipeIgnoredTarget`.
+
+### Copy hierarchy
+
+Eyebrow → podcast pill → title → meta → description → **all** subject chips → Watch/Listen + More info.
+
+## Known failure modes
+
+| Symptom | REQ | How we catch |
+|---------|-----|----------------|
+| Subject chips missing / clipped | HERO-SUB-001 | Spec uncapped chips + Sass forbids subjects overflow/max-height |
+| Actions above / mixed into chips | HERO-SUB-002 | DOM order: subjects before actions |
+| Page jumps on advance | HERO-SCR-* | Sass contract + manual scrolled advance |
+| Chevron dead | HERO-LIF-002 | Spec: next chevron does not cancel content transition |
+| Dwell stuck after pager | focus pause | Spec: releases chevron focus |
+| Blank / text ahead of art | HERO-LIF-001/003 | Image gate + hold-until-ready specs |
+| Can’t click dashes | HERO-CTL-001 | Sass `pointer-events: none` on stages |
+| Scroll fights swipe | HERO-SWP-001 | `touch-action: pan-y` + swipe specs |
+| Ken Burns on phone | HERO-LIF-005 | saveGpu spec |
+
+## Soft guideline — style budget
+
+Prefer compiled hero styles under ~16 kB. Soft check — do not sacrifice an invariant for a few hundred bytes.
+
+## Regression checklist
+
+**Automated** — `ng test` filter `HomepageHeroComponent` (all HERO-* with “Yes” above).
+
+**Manual**
+
+- [ ] HERO-SCR-003: scroll hero partly off-screen; advance; no jump
+- [ ] Long vs short title/desc visually stable; descenders OK
+- [ ] Mobile: swipe vs vertical scroll; CTAs still tappable
+- [ ] Many subjects: all visible; actions still below
+
+## Out of scope
+
+- Hero KV / Auth0 / M2M — [flix-prototype.md](./flix-prototype.md), Api `docs/hero-curation-m2m-edge.md`
+- Subject / day rails below the fold (except when they affect hero scroll)

--- a/cultpodcasts/e2e/hero-layout.spec.ts
+++ b/cultpodcasts/e2e/hero-layout.spec.ts
@@ -1,0 +1,98 @@
+import { test, expect, type Page } from "@playwright/test";
+import { buildHeroLayoutDocument } from "./hero-layout/build-harness";
+import { heroLayoutCases, type HeroLayoutCaseId } from "./hero-layout/fixtures";
+
+/**
+ * Geometry e2e for homepage-hero layout contracts (HERO-SCR-*).
+ * Compiles real homepage-hero.component.sass into a light-DOM harness so media
+ * queries and min-heights match production CSS without bootstrapping Angular.
+ */
+
+const viewports = [
+  { name: "mobile", width: 390, height: 844 },
+  { name: "tablet", width: 768, height: 1024 },
+  { name: "stacked-desktop", width: 1100, height: 800 },
+] as const;
+
+/** Short title must not leave ~2 empty title lines above meta (was min-height: 3em). */
+const MAX_TITLE_TO_META_GAP_PX = 36;
+/** Empty desc+subjects: meta should sit near Watch (feature gap only). */
+const MAX_META_TO_ACTIONS_GAP_PX_EMPTY = 48;
+/** With .has-desc, copy-body must reserve roughly 3 desc lines + chip band. */
+const MIN_COPY_BODY_HAS_DESC_PX = 70;
+
+async function openCase(page: Page, caseId: HeroLayoutCaseId): Promise<void> {
+  const c = heroLayoutCases.find((x) => x.id === caseId);
+  if (!c) {
+    throw new Error(`Unknown hero layout case: ${caseId}`);
+  }
+  await page.setContent(buildHeroLayoutDocument(c), { waitUntil: "domcontentloaded" });
+}
+
+async function gapBelow(page: Page, upper: string, lower: string): Promise<number> {
+  return page.evaluate(
+    ({ upperSel, lowerSel }) => {
+      const a = document.querySelector(upperSel)?.getBoundingClientRect();
+      const b = document.querySelector(lowerSel)?.getBoundingClientRect();
+      if (!a || !b) {
+        return Number.POSITIVE_INFINITY;
+      }
+      return b.top - a.bottom;
+    },
+    { upperSel: upper, lowerSel: lower }
+  );
+}
+
+for (const vp of viewports) {
+  test.describe(`hero layout @ ${vp.name} (${vp.width}x${vp.height})`, () => {
+    test.use({ viewport: { width: vp.width, height: vp.height } });
+
+    test("HERO-SCR-005: short title keeps meta tight under the title", async ({ page }) => {
+      await openCase(page, "short-title-no-desc");
+      const gap = await gapBelow(page, ".billboard__title", ".hero-meta");
+      expect(gap, `title→meta gap was ${gap}px`).toBeLessThanOrEqual(MAX_TITLE_TO_META_GAP_PX);
+      expect(gap).toBeGreaterThanOrEqual(0);
+    });
+
+    test("HERO-SCR-004: empty description omits desc and blank band above Watch", async ({
+      page,
+    }) => {
+      await openCase(page, "short-title-no-desc");
+      await expect(page.locator(".billboard__desc")).toHaveCount(0);
+      await expect(page.locator(".billboard__copy-body")).toHaveCount(0);
+      const gap = await gapBelow(page, ".hero-meta", ".billboard__actions");
+      expect(gap, `meta→actions gap was ${gap}px`).toBeLessThanOrEqual(
+        MAX_META_TO_ACTIONS_GAP_PX_EMPTY
+      );
+    });
+
+    test("HERO-SCR-002: has-desc reserves copy-body height for short description", async ({
+      page,
+    }) => {
+      await openCase(page, "short-title-with-desc");
+      const body = page.locator(".billboard__copy-body.has-desc");
+      await expect(body).toHaveCount(1);
+      const box = await body.boundingBox();
+      expect(box?.height ?? 0).toBeGreaterThanOrEqual(MIN_COPY_BODY_HAS_DESC_PX);
+    });
+
+    test("HERO-SUB-002: subjects stay above Watch actions when desc is empty", async ({
+      page,
+    }) => {
+      await openCase(page, "empty-desc-with-subjects");
+      await expect(page.locator(".billboard__desc")).toHaveCount(0);
+      await expect(page.locator(".billboard__copy-body.has-desc")).toHaveCount(0);
+      await expect(page.locator(".billboard__subjects")).toHaveCount(1);
+      const gap = await gapBelow(page, ".billboard__subjects", ".billboard__actions");
+      expect(gap).toBeGreaterThanOrEqual(0);
+      expect(gap).toBeLessThanOrEqual(40);
+    });
+
+    test("HERO-SCR-005: long title still places meta below the title box", async ({ page }) => {
+      await openCase(page, "long-title-with-desc");
+      const gap = await gapBelow(page, ".billboard__title", ".hero-meta");
+      expect(gap).toBeGreaterThanOrEqual(0);
+      expect(gap).toBeLessThanOrEqual(MAX_TITLE_TO_META_GAP_PX);
+    });
+  });
+}

--- a/cultpodcasts/e2e/hero-layout.spec.ts
+++ b/cultpodcasts/e2e/hero-layout.spec.ts
@@ -3,23 +3,32 @@ import { buildHeroLayoutDocument } from "./hero-layout/build-harness";
 import { heroLayoutCases, type HeroLayoutCaseId } from "./hero-layout/fixtures";
 
 /**
- * Geometry e2e for homepage-hero layout contracts (HERO-SCR-*).
+ * Geometry e2e for homepage-hero layout contracts (HERO-SCR-* / HERO-SUB-*).
  * Compiles real homepage-hero.component.sass into a light-DOM harness so media
  * queries and min-heights match production CSS without bootstrapping Angular.
+ *
+ * Viewport matrix covers stacked (≤1280) and wide (≥1280) layouts plus a
+ * landscape aspect ratio. Episode fixtures cover empty desc and many subjects.
  */
 
 const viewports = [
-  { name: "mobile", width: 390, height: 844 },
-  { name: "tablet", width: 768, height: 1024 },
-  { name: "stacked-desktop", width: 1100, height: 800 },
+  { name: "mobile", width: 390, height: 844, layout: "stacked" as const },
+  { name: "mobile-landscape", width: 844, height: 390, layout: "stacked" as const },
+  { name: "tablet", width: 768, height: 1024, layout: "stacked" as const },
+  { name: "stacked-desktop", width: 1100, height: 800, layout: "stacked" as const },
+  /** min-width:1280 — docked card; copy-body/desc min-height reset to 0 */
+  { name: "wide", width: 1440, height: 900, layout: "wide" as const },
+  /** Common full-screen desktop (matches primary authoring display). */
+  { name: "full-hd", width: 1920, height: 1080, layout: "wide" as const },
 ] as const;
 
-/** Short title must not leave ~2 empty title lines above meta (was min-height: 3em). */
+/** Short title must not leave ~2 empty title lines above meta. */
 const MAX_TITLE_TO_META_GAP_PX = 36;
 /** Empty desc+subjects: meta should sit near Watch (feature gap only). */
 const MAX_META_TO_ACTIONS_GAP_PX_EMPTY = 48;
-/** With .has-desc, copy-body must reserve roughly 3 desc lines + chip band. */
-const MIN_COPY_BODY_HAS_DESC_PX = 70;
+/** Stacked only: .has-desc reserves roughly 3 desc lines + chip band. */
+const MIN_COPY_BODY_HAS_DESC_STACKED_PX = 70;
+const MANY_SUBJECT_COUNT = 12;
 
 async function openCase(page: Page, caseId: HeroLayoutCaseId): Promise<void> {
   const c = heroLayoutCases.find((x) => x.id === caseId);
@@ -43,8 +52,49 @@ async function gapBelow(page: Page, upper: string, lower: string): Promise<numbe
   );
 }
 
+/** Every chip has a non-zero box and sits above the actions block (HERO-SUB-001/002). */
+async function assertAllSubjectsVisibleAboveActions(
+  page: Page,
+  expectedCount: number
+): Promise<void> {
+  const chips = page.locator(".billboard__subjects .hero-layout-chip");
+  await expect(chips).toHaveCount(expectedCount);
+
+  const report = await page.evaluate(() => {
+    const subjects = document.querySelector(".billboard__subjects");
+    const actions = document.querySelector(".billboard__actions");
+    const chipEls = [...document.querySelectorAll(".billboard__subjects .hero-layout-chip")];
+    if (!subjects || !actions) {
+      return { ok: false, reason: "missing subjects or actions" };
+    }
+    const subjectsBox = subjects.getBoundingClientRect();
+    const actionsBox = actions.getBoundingClientRect();
+    if (actionsBox.top + 0.5 < subjectsBox.bottom) {
+      return {
+        ok: false,
+        reason: `actions overlap/above subjects (actions.top=${actionsBox.top}, subjects.bottom=${subjectsBox.bottom})`,
+      };
+    }
+    for (const el of chipEls) {
+      const r = el.getBoundingClientRect();
+      if (r.width < 1 || r.height < 1) {
+        return { ok: false, reason: `chip not visible: ${el.textContent}` };
+      }
+      if (r.bottom > actionsBox.top + 0.5) {
+        return {
+          ok: false,
+          reason: `chip intersects actions: ${el.textContent}`,
+        };
+      }
+    }
+    return { ok: true, reason: "" };
+  });
+
+  expect(report.ok, report.reason).toBe(true);
+}
+
 for (const vp of viewports) {
-  test.describe(`hero layout @ ${vp.name} (${vp.width}x${vp.height})`, () => {
+  test.describe(`hero layout @ ${vp.name} (${vp.width}x${vp.height}, ${vp.layout})`, () => {
     test.use({ viewport: { width: vp.width, height: vp.height } });
 
     test("HERO-SCR-005: short title keeps meta tight under the title", async ({ page }) => {
@@ -54,7 +104,7 @@ for (const vp of viewports) {
       expect(gap).toBeGreaterThanOrEqual(0);
     });
 
-    test("HERO-SCR-004: empty description omits desc and blank band above Watch", async ({
+    test("HERO-SCR-004: no description and no subjects omits blank band above Watch", async ({
       page,
     }) => {
       await openCase(page, "short-title-no-desc");
@@ -66,26 +116,46 @@ for (const vp of viewports) {
       );
     });
 
-    test("HERO-SCR-002: has-desc reserves copy-body height for short description", async ({
+    test("HERO-SCR-002: has-desc copy-body height (stacked reserve / wide hug)", async ({
       page,
     }) => {
       await openCase(page, "short-title-with-desc");
       const body = page.locator(".billboard__copy-body.has-desc");
       await expect(body).toHaveCount(1);
       const box = await body.boundingBox();
-      expect(box?.height ?? 0).toBeGreaterThanOrEqual(MIN_COPY_BODY_HAS_DESC_PX);
+      const height = box?.height ?? 0;
+      if (vp.layout === "stacked") {
+        expect(height).toBeGreaterThanOrEqual(MIN_COPY_BODY_HAS_DESC_STACKED_PX);
+      } else {
+        // Wide resets min-height to 0 — short desc may hug; still must be non-empty.
+        expect(height).toBeGreaterThan(20);
+      }
     });
 
-    test("HERO-SUB-002: subjects stay above Watch actions when desc is empty", async ({
+    test("HERO-SCR-004 + HERO-SUB-002: empty desc with few subjects keeps actions below chips", async ({
       page,
     }) => {
       await openCase(page, "empty-desc-with-subjects");
       await expect(page.locator(".billboard__desc")).toHaveCount(0);
       await expect(page.locator(".billboard__copy-body.has-desc")).toHaveCount(0);
-      await expect(page.locator(".billboard__subjects")).toHaveCount(1);
-      const gap = await gapBelow(page, ".billboard__subjects", ".billboard__actions");
-      expect(gap).toBeGreaterThanOrEqual(0);
-      expect(gap).toBeLessThanOrEqual(40);
+      await assertAllSubjectsVisibleAboveActions(page, 3);
+    });
+
+    test("HERO-SUB-001/002: many subjects with description all render above Watch", async ({
+      page,
+    }) => {
+      await openCase(page, "many-subjects-with-desc");
+      await expect(page.locator(".billboard__desc")).toHaveCount(1);
+      await assertAllSubjectsVisibleAboveActions(page, MANY_SUBJECT_COUNT);
+    });
+
+    test("HERO-SUB-001/002 + HERO-SCR-004: many subjects without description all render above Watch", async ({
+      page,
+    }) => {
+      await openCase(page, "many-subjects-no-desc");
+      await expect(page.locator(".billboard__desc")).toHaveCount(0);
+      await expect(page.locator(".billboard__copy-body.has-desc")).toHaveCount(0);
+      await assertAllSubjectsVisibleAboveActions(page, MANY_SUBJECT_COUNT);
     });
 
     test("HERO-SCR-005: long title still places meta below the title box", async ({ page }) => {

--- a/cultpodcasts/e2e/hero-layout/build-harness.ts
+++ b/cultpodcasts/e2e/hero-layout/build-harness.ts
@@ -1,0 +1,81 @@
+import * as sass from "sass";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { HeroLayoutCase, renderBillboardHtml } from "./fixtures";
+
+const heroSassPath = join(
+  process.cwd(),
+  "src",
+  "app",
+  "homepage-hero",
+  "homepage-hero.component.sass"
+);
+const stylesPath = join(process.cwd(), "src", "styles.scss");
+
+/** Compile real hero component Sass for light-DOM harness (rewrite :host). */
+export function compileHeroLayoutCss(): string {
+  const heroCss = sass.compile(heroSassPath, { style: "expanded" }).css
+    .replaceAll(":host-context(.cdk-global-scrollblock)", ".cdk-global-scrollblock .hero-layout-host")
+    .replaceAll(":host", ".hero-layout-host");
+
+  const tokenCss = `
+.hero-layout-root {
+  --cp-font-display: Georgia, 'Times New Roman', serif;
+  --cp-font-ui: system-ui, sans-serif;
+  --nflx-accent: #e8a23a;
+  --nflx-on-media: #fff;
+  --nflx-on-media-muted: #e8e8e8;
+  --site-chrome-bar-h: 52px;
+  --nflx-hero-search-clearance: 140px;
+  margin: 0;
+  background: #0b0b0b;
+  color: #fff;
+  font-family: var(--cp-font-ui);
+}
+.hero-layout-chip {
+  display: inline-block;
+  padding: 4px 10px;
+  border: 1px solid #ffffff55;
+  border-radius: 999px;
+  font-size: 0.85rem;
+}
+.hero-pill {
+  display: inline-block;
+  padding: 4px 12px;
+  border: 1px solid #ffffff55;
+  border-radius: 999px;
+  font-size: 0.85rem;
+}
+.hero-meta { margin: 0; }
+.hero-show { margin: 0 0 8px; }
+`;
+
+  let stylesSnippet = "";
+  try {
+    const styles = readFileSync(stylesPath, "utf8");
+    if (styles.includes(".hero-meta")) {
+      stylesSnippet = "/* styles.scss present — tokens inlined above */";
+    }
+  } catch {
+    /* optional */
+  }
+
+  return `${tokenCss}\n${stylesSnippet}\n${heroCss}`;
+}
+
+export function buildHeroLayoutDocument(c: HeroLayoutCase): string {
+  const css = compileHeroLayoutCss();
+  const billboard = renderBillboardHtml(c);
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Hero layout harness — ${c.id}</title>
+  <style>${css}</style>
+</head>
+<body class="hero-layout-root">
+  <div class="hero-layout-host">${billboard}</div>
+</body>
+</html>`;
+}

--- a/cultpodcasts/e2e/hero-layout/fixtures.ts
+++ b/cultpodcasts/e2e/hero-layout/fixtures.ts
@@ -1,5 +1,5 @@
 /**
- * Episode/layout fixtures for homepage-hero geometry e2e (HERO-SCR-*).
+ * Episode/layout fixtures for homepage-hero geometry e2e (HERO-SCR-* / HERO-SUB-*).
  * HTML mirrors the billboard copy structure in homepage-hero.component.html.
  */
 
@@ -7,7 +7,9 @@ export type HeroLayoutCaseId =
   | "short-title-no-desc"
   | "short-title-with-desc"
   | "long-title-with-desc"
-  | "empty-desc-with-subjects";
+  | "empty-desc-with-subjects"
+  | "many-subjects-with-desc"
+  | "many-subjects-no-desc";
 
 export interface HeroLayoutCase {
   id: HeroLayoutCaseId;
@@ -20,6 +22,8 @@ export interface HeroLayoutCase {
   durationLabel: string;
   podcastName: string;
 }
+
+const MANY_SUBJECTS = Array.from({ length: 12 }, (_, i) => `Topic ${i + 1}`);
 
 export const heroLayoutCases: HeroLayoutCase[] = [
   {
@@ -48,7 +52,8 @@ export const heroLayoutCases: HeroLayoutCase[] = [
     reqs: ["HERO-SCR-002"],
     episodeTitle:
       "Anonymous ExMuslim YouTuber Apostate Aladdin Opens up on Sex in Islam and Related Topics That Span Multiple Lines",
-    episodeDescription: "A longer episode description that fills about two lines of the hero copy panel for clamp checks.",
+    episodeDescription:
+      "A longer episode description that fills about two lines of the hero copy panel for clamp checks.",
     subjects: [],
     releaseLabel: "8 Aug 2026",
     durationLabel: "0:00:48",
@@ -64,6 +69,26 @@ export const heroLayoutCases: HeroLayoutCase[] = [
     durationLabel: "0:01:00",
     podcastName: "Clip Show",
   },
+  {
+    id: "many-subjects-with-desc",
+    reqs: ["HERO-SUB-001", "HERO-SUB-002"],
+    episodeTitle: "Crowded Subject Episode",
+    episodeDescription: "Description present with a full subject chip wrap.",
+    subjects: MANY_SUBJECTS,
+    releaseLabel: "8 Aug 2026",
+    durationLabel: "1:05:00",
+    podcastName: "Crowded Show",
+  },
+  {
+    id: "many-subjects-no-desc",
+    reqs: ["HERO-SUB-001", "HERO-SUB-002", "HERO-SCR-004"],
+    episodeTitle: "Crowded Subjects No Desc",
+    episodeDescription: "",
+    subjects: MANY_SUBJECTS,
+    releaseLabel: "8 Aug 2026",
+    durationLabel: "0:45:00",
+    podcastName: "Crowded Show",
+  },
 ];
 
 export function renderBillboardHtml(c: HeroLayoutCase): string {
@@ -73,7 +98,10 @@ export function renderBillboardHtml(c: HeroLayoutCase): string {
 
   const subjectsHtml = hasSubjects
     ? `<div class="billboard__subjects" aria-label="Subjects">${c.subjects
-        .map((s) => `<span class="hero-layout-chip">${escapeHtml(s)}</span>`)
+        .map(
+          (s) =>
+            `<span class="hero-layout-chip" data-subject="${escapeHtml(s)}">${escapeHtml(s)}</span>`
+        )
         .join("")}</div>`
     : "";
 

--- a/cultpodcasts/e2e/hero-layout/fixtures.ts
+++ b/cultpodcasts/e2e/hero-layout/fixtures.ts
@@ -1,0 +1,130 @@
+/**
+ * Episode/layout fixtures for homepage-hero geometry e2e (HERO-SCR-*).
+ * HTML mirrors the billboard copy structure in homepage-hero.component.html.
+ */
+
+export type HeroLayoutCaseId =
+  | "short-title-no-desc"
+  | "short-title-with-desc"
+  | "long-title-with-desc"
+  | "empty-desc-with-subjects";
+
+export interface HeroLayoutCase {
+  id: HeroLayoutCaseId;
+  /** HERO-* ids this case primarily guards. */
+  reqs: string[];
+  episodeTitle: string;
+  episodeDescription: string;
+  subjects: string[];
+  releaseLabel: string;
+  durationLabel: string;
+  podcastName: string;
+}
+
+export const heroLayoutCases: HeroLayoutCase[] = [
+  {
+    id: "short-title-no-desc",
+    reqs: ["HERO-SCR-004", "HERO-SCR-005"],
+    episodeTitle: "The Rulo Farm",
+    episodeDescription: "",
+    subjects: [],
+    releaseLabel: "8 Aug 2026",
+    durationLabel: "0:18:47",
+    podcastName: "Heinous Beliefs",
+  },
+  {
+    id: "short-title-with-desc",
+    reqs: ["HERO-SCR-002", "HERO-SCR-005"],
+    episodeTitle: "The Rulo Farm",
+    episodeDescription:
+      "HEINOUS BELIEFS — SEASON 2, EPISODE 2. Short description for reserved-height checks.",
+    subjects: ["Michael W. Ryan"],
+    releaseLabel: "8 Aug 2026",
+    durationLabel: "0:18:47",
+    podcastName: "Heinous Beliefs",
+  },
+  {
+    id: "long-title-with-desc",
+    reqs: ["HERO-SCR-002"],
+    episodeTitle:
+      "Anonymous ExMuslim YouTuber Apostate Aladdin Opens up on Sex in Islam and Related Topics That Span Multiple Lines",
+    episodeDescription: "A longer episode description that fills about two lines of the hero copy panel for clamp checks.",
+    subjects: [],
+    releaseLabel: "8 Aug 2026",
+    durationLabel: "0:00:48",
+    podcastName: "Cults To Consciousness Clips",
+  },
+  {
+    id: "empty-desc-with-subjects",
+    reqs: ["HERO-SCR-004", "HERO-SUB-002"],
+    episodeTitle: "Clip Title",
+    episodeDescription: "",
+    subjects: ["Subject One", "Subject Two", "Subject Three"],
+    releaseLabel: "8 Aug 2026",
+    durationLabel: "0:01:00",
+    podcastName: "Clip Show",
+  },
+];
+
+export function renderBillboardHtml(c: HeroLayoutCase): string {
+  const hasDesc = c.episodeDescription.trim().length > 0;
+  const hasSubjects = c.subjects.length > 0;
+  const hasCopyBody = hasDesc || hasSubjects;
+
+  const subjectsHtml = hasSubjects
+    ? `<div class="billboard__subjects" aria-label="Subjects">${c.subjects
+        .map((s) => `<span class="hero-layout-chip">${escapeHtml(s)}</span>`)
+        .join("")}</div>`
+    : "";
+
+  const descHtml = hasDesc
+    ? `<p class="billboard__desc">${escapeHtml(c.episodeDescription)}</p>`
+    : "";
+
+  const copyBodyHtml = hasCopyBody
+    ? `<div class="billboard__copy-body${hasDesc ? " has-desc" : ""}">${descHtml}${subjectsHtml}</div>`
+    : "";
+
+  return `
+<section class="billboard has-art-aspect" aria-label="Featured episodes" data-case="${c.id}">
+  <div class="billboard__stages" aria-hidden="true">
+    <div class="billboard__stage is-active" style="--hero-art-aspect: 1.777">
+      <div class="billboard__stage-motion">
+        <div class="billboard__stage-focus-slot">
+          <div class="billboard__stage-focus" style="background:#333"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="billboard__grain" aria-hidden="true"></div>
+  <div class="billboard__scrim" aria-hidden="true"></div>
+  <div class="billboard__vignette" aria-hidden="true"></div>
+  <div class="billboard__content">
+    <div class="billboard__feature">
+      <div class="billboard__copy">
+        <p class="billboard__eyebrow"><span class="billboard__live" aria-hidden="true"></span> Now featuring</p>
+        <p class="hero-show"><span class="hero-pill">${escapeHtml(c.podcastName)}</span></p>
+        <h1 class="billboard__title">${escapeHtml(c.episodeTitle)}</h1>
+        <p class="hero-meta">
+          <span>${escapeHtml(c.releaseLabel)}</span>
+          <span class="hero-meta__dot" aria-hidden="true">·</span>
+          <span>${escapeHtml(c.durationLabel)}</span>
+        </p>
+        ${copyBodyHtml}
+      </div>
+      <div class="billboard__actions">
+        <button type="button" class="billboard__play">Watch</button>
+        <a class="billboard__more" href="#">More info</a>
+      </div>
+    </div>
+  </div>
+</section>`;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}

--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.90",
+  "version": "1.10.91",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.10.90",
+      "version": "1.10.91",
       "dependencies": {
         "@angular/cdk": "22.1.0",
         "@angular/common": "22.1.0",
@@ -35,6 +35,7 @@
         "@types/node": "24.13.3",
         "baseline-browser-mapping": "2.11.12",
         "happy-dom": "20.11.1",
+        "sass": "^1.101.0",
         "typescript": "6.0.3",
         "vitest": "^4.0.8",
         "wrangler": "4.118.0"

--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.84",
+  "version": "1.10.83",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.10.84",
+      "version": "1.10.83",
       "dependencies": {
         "@angular/cdk": "22.1.0",
         "@angular/common": "22.1.0",

--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.91",
+  "version": "1.10.93",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.10.91",
+      "version": "1.10.93",
       "dependencies": {
         "@angular/cdk": "22.1.0",
         "@angular/common": "22.1.0",

--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.89",
+  "version": "1.10.90",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.10.89",
+      "version": "1.10.90",
       "dependencies": {
         "@angular/cdk": "22.1.0",
         "@angular/common": "22.1.0",

--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.82",
+  "version": "1.10.84",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.10.82",
+      "version": "1.10.84",
       "dependencies": {
         "@angular/cdk": "22.1.0",
         "@angular/common": "22.1.0",

--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.83",
+  "version": "1.10.84",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.10.83",
+      "version": "1.10.84",
       "dependencies": {
         "@angular/cdk": "22.1.0",
         "@angular/common": "22.1.0",

--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.82",
+  "version": "1.10.83",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.10.82",
+      "version": "1.10.83",
       "dependencies": {
         "@angular/cdk": "22.1.0",
         "@angular/common": "22.1.0",

--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.85",
+  "version": "1.10.88",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.10.85",
+      "version": "1.10.88",
       "dependencies": {
         "@angular/cdk": "22.1.0",
         "@angular/common": "22.1.0",

--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.84",
+  "version": "1.10.85",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.10.84",
+      "version": "1.10.85",
       "dependencies": {
         "@angular/cdk": "22.1.0",
         "@angular/common": "22.1.0",

--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.88",
+  "version": "1.10.89",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.10.88",
+      "version": "1.10.89",
       "dependencies": {
         "@angular/cdk": "22.1.0",
         "@angular/common": "22.1.0",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.84",
+  "version": "1.10.85",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.85",
+  "version": "1.10.88",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.83",
+  "version": "1.10.84",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.82",
+  "version": "1.10.83",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.91",
+  "version": "1.10.93",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",
@@ -12,6 +12,8 @@
     "test:watch": "ng test --watch",
     "test:e2e": "playwright test",
     "test:e2e:hero-layout": "playwright test e2e/hero-layout.spec.ts",
+    "test:all": "npm run test && npm run test:e2e",
+    "prepare": "node ./tools/install-git-hooks.cjs",
     "serve:ssr:cultpodcasts": "node dist/server/server.mjs",
     "process": "node ./tools/copy-files.mjs && node ./tools/alter-polyfills.mjs",
     "deploy": "npm run build -- production && npm run process && wrangler pages deploy dist/cloudflare",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.89",
+  "version": "1.10.90",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.82",
+  "version": "1.10.84",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,10 @@
 {
   "name": "cultpodcasts",
+<<<<<<< HEAD
   "version": "1.10.84",
+=======
+  "version": "1.10.85",
+>>>>>>> 9ef691c (fix(homepage): show all day rails on first paint)
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,10 +1,6 @@
 {
   "name": "cultpodcasts",
-<<<<<<< HEAD
-  "version": "1.10.84",
-=======
-  "version": "1.10.85",
->>>>>>> 9ef691c (fix(homepage): show all day rails on first paint)
+  "version": "1.10.83",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",
@@ -26,7 +22,7 @@
   "engines": {
     "node": ">=22.22.3"
   },
-  "//overrides": "Temporary transitive CVE pins — why / when to remove: docs/dependency-updates.md#npm-audit",
+  "//overrides": "Temporary transitive CVE pins ΓÇö why / when to remove: docs/dependency-updates.md#npm-audit",
   "overrides": {
     "@hono/node-server": "2.0.11",
     "undici": "7.29.0"
@@ -64,3 +60,4 @@
     "wrangler": "4.118.0"
   }
 }
+

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.88",
+  "version": "1.10.89",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.90",
+  "version": "1.10.91",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",
@@ -11,6 +11,7 @@
     "test": "ng test --watch=false",
     "test:watch": "ng test --watch",
     "test:e2e": "playwright test",
+    "test:e2e:hero-layout": "playwright test e2e/hero-layout.spec.ts",
     "serve:ssr:cultpodcasts": "node dist/server/server.mjs",
     "process": "node ./tools/copy-files.mjs && node ./tools/alter-polyfills.mjs",
     "deploy": "npm run build -- production && npm run process && wrangler pages deploy dist/cloudflare",
@@ -55,9 +56,9 @@
     "@types/node": "24.13.3",
     "baseline-browser-mapping": "2.11.12",
     "happy-dom": "20.11.1",
+    "sass": "^1.101.0",
     "typescript": "6.0.3",
     "vitest": "^4.0.8",
     "wrangler": "4.118.0"
   }
 }
-

--- a/cultpodcasts/playwright.config.ts
+++ b/cultpodcasts/playwright.config.ts
@@ -4,6 +4,9 @@ import { defineConfig, devices } from "@playwright/test";
  * Behavior-first e2e harness. Prefer route mocks over live Auth0.
  * Set PLAYWRIGHT_BASE_URL to exercise a running app (8788 or 4200).
  * Default fixtures run without a live Angular server.
+ *
+ * Hero layout geometry (`e2e/hero-layout.spec.ts`) compiles real billboard Sass
+ * into setContent documents — no Angular server required.
  */
 export default defineConfig({
 	testDir: "./e2e",

--- a/cultpodcasts/src/app/add-episode-dialog/add-episode-dialog.component.html
+++ b/cultpodcasts/src/app/add-episode-dialog/add-episode-dialog.component.html
@@ -29,7 +29,7 @@
                     <mat-checkbox [formControl]="form()!.controls.posted">Posted</mat-checkbox>
                     }
                     <mat-checkbox [formControl]="form()!.controls.tweeted">Tweeted</mat-checkbox>
-                    <mat-checkbox [formControl]="form()!.controls.blueskyPosted">Bluesky Post</mat-checkbox>
+                    <div class="bluesky-flag bluesky-flag--idle">Not posted to Bluesky</div>
                     <mat-checkbox [formControl]="form()!.controls.ignored">Ignored</mat-checkbox>
                     <mat-checkbox [formControl]="form()!.controls.removed">Removed</mat-checkbox>
                     <mat-checkbox [formControl]="form()!.controls.explicit">Explicit</mat-checkbox>

--- a/cultpodcasts/src/app/add-episode-dialog/add-episode-dialog.component.html
+++ b/cultpodcasts/src/app/add-episode-dialog/add-episode-dialog.component.html
@@ -120,7 +120,7 @@
                     <input type="text" [formControl]="form()!.controls.spotifyImage" matInput>
                     <button type="button" matIconButton matSuffix aria-label="Preview Spotify image"
                         [disabled]="!hasNonEmptyUrlValue(form()!.controls.spotifyImage.value)"
-                        (click)="previewImage(form()!.controls.spotifyImage.value)">
+                        (click)="previewImage('spotify')">
                         <mat-icon>visibility</mat-icon>
                     </button>
                     <button type="button" matIconButton matSuffix aria-label="Remove Spotify image"
@@ -134,7 +134,7 @@
                     <input type="text" [formControl]="form()!.controls.appleImage" matInput>
                     <button type="button" matIconButton matSuffix aria-label="Preview Apple image"
                         [disabled]="!hasNonEmptyUrlValue(form()!.controls.appleImage.value)"
-                        (click)="previewImage(form()!.controls.appleImage.value)">
+                        (click)="previewImage('apple')">
                         <mat-icon>visibility</mat-icon>
                     </button>
                     <button type="button" matIconButton matSuffix aria-label="Remove Apple image"
@@ -148,7 +148,7 @@
                     <input type="text" [formControl]="form()!.controls.youtubeImage" matInput>
                     <button type="button" matIconButton matSuffix aria-label="Preview YouTube image"
                         [disabled]="!hasNonEmptyUrlValue(form()!.controls.youtubeImage.value)"
-                        (click)="previewImage(form()!.controls.youtubeImage.value)">
+                        (click)="previewImage('youtube')">
                         <mat-icon>visibility</mat-icon>
                     </button>
                     <button type="button" matIconButton matSuffix aria-label="Remove YouTube image"
@@ -162,7 +162,7 @@
                     <input type="text" [formControl]="form()!.controls.otherImage" matInput>
                     <button type="button" matIconButton matSuffix aria-label="Preview other image"
                         [disabled]="!hasNonEmptyUrlValue(form()!.controls.otherImage.value)"
-                        (click)="previewImage(form()!.controls.otherImage.value)">
+                        (click)="previewImage('other')">
                         <mat-icon>visibility</mat-icon>
                     </button>
                     <button type="button" matIconButton matSuffix aria-label="Remove other image"

--- a/cultpodcasts/src/app/add-episode-dialog/add-episode-dialog.component.html
+++ b/cultpodcasts/src/app/add-episode-dialog/add-episode-dialog.component.html
@@ -39,14 +39,44 @@
                 <mat-form-field class="full-width">
                     <mat-label>Spotify</mat-label>
                     <input type="text" [formControl]="form()!.controls.spotify" matInput>
+                    <button type="button" matIconButton matSuffix aria-label="Open Spotify URL"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.spotify.value)"
+                        (click)="openExternalUrl(form()!.controls.spotify.value)">
+                        <mat-icon>open_in_new</mat-icon>
+                    </button>
+                    <button type="button" matIconButton matSuffix aria-label="Remove Spotify URL"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.spotify.value)"
+                        (click)="clearField(form()!.controls.spotify)">
+                        <mat-icon>clear</mat-icon>
+                    </button>
                 </mat-form-field>
                 <mat-form-field class="full-width">
                     <mat-label>Apple</mat-label>
                     <input type="text" [formControl]="form()!.controls.apple" matInput>
+                    <button type="button" matIconButton matSuffix aria-label="Open Apple URL"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.apple.value)"
+                        (click)="openExternalUrl(form()!.controls.apple.value)">
+                        <mat-icon>open_in_new</mat-icon>
+                    </button>
+                    <button type="button" matIconButton matSuffix aria-label="Remove Apple URL"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.apple.value)"
+                        (click)="clearField(form()!.controls.apple)">
+                        <mat-icon>clear</mat-icon>
+                    </button>
                 </mat-form-field>
                 <mat-form-field class="full-width">
                     <mat-label>YouTube</mat-label>
                     <input type="text" [formControl]="form()!.controls.youtube" matInput>
+                    <button type="button" matIconButton matSuffix aria-label="Open YouTube URL"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.youtube.value)"
+                        (click)="openExternalUrl(form()!.controls.youtube.value)">
+                        <mat-icon>open_in_new</mat-icon>
+                    </button>
+                    <button type="button" matIconButton matSuffix aria-label="Remove YouTube URL"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.youtube.value)"
+                        (click)="clearField(form()!.controls.youtube)">
+                        <mat-icon>clear</mat-icon>
+                    </button>
                 </mat-form-field>
                 <mat-accordion>
                     <mat-expansion-panel>
@@ -56,10 +86,30 @@
                         <mat-form-field class="full-width">
                     <mat-label>BBC</mat-label>
                     <input type="text" [formControl]="form()!.controls.bbc" matInput>
+                    <button type="button" matIconButton matSuffix aria-label="Open BBC URL"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.bbc.value)"
+                        (click)="openExternalUrl(form()!.controls.bbc.value)">
+                        <mat-icon>open_in_new</mat-icon>
+                    </button>
+                    <button type="button" matIconButton matSuffix aria-label="Remove BBC URL"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.bbc.value)"
+                        (click)="clearField(form()!.controls.bbc)">
+                        <mat-icon>clear</mat-icon>
+                    </button>
                 </mat-form-field>
                         <mat-form-field class="full-width">
                     <mat-label>Internet Archive</mat-label>
                     <input type="text" [formControl]="form()!.controls.internetArchive" matInput>
+                    <button type="button" matIconButton matSuffix aria-label="Open Internet Archive URL"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.internetArchive.value)"
+                        (click)="openExternalUrl(form()!.controls.internetArchive.value)">
+                        <mat-icon>open_in_new</mat-icon>
+                    </button>
+                    <button type="button" matIconButton matSuffix aria-label="Remove Internet Archive URL"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.internetArchive.value)"
+                        (click)="clearField(form()!.controls.internetArchive)">
+                        <mat-icon>clear</mat-icon>
+                    </button>
                 </mat-form-field>
                     </mat-expansion-panel>
                 </mat-accordion>
@@ -68,18 +118,58 @@
                 <mat-form-field class="full-width">
                     <mat-label>Spotify</mat-label>
                     <input type="text" [formControl]="form()!.controls.spotifyImage" matInput>
+                    <button type="button" matIconButton matSuffix aria-label="Preview Spotify image"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.spotifyImage.value)"
+                        (click)="previewImage(form()!.controls.spotifyImage.value)">
+                        <mat-icon>visibility</mat-icon>
+                    </button>
+                    <button type="button" matIconButton matSuffix aria-label="Remove Spotify image"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.spotifyImage.value)"
+                        (click)="clearField(form()!.controls.spotifyImage)">
+                        <mat-icon>clear</mat-icon>
+                    </button>
                 </mat-form-field>
                 <mat-form-field class="full-width">
                     <mat-label>Apple</mat-label>
                     <input type="text" [formControl]="form()!.controls.appleImage" matInput>
+                    <button type="button" matIconButton matSuffix aria-label="Preview Apple image"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.appleImage.value)"
+                        (click)="previewImage(form()!.controls.appleImage.value)">
+                        <mat-icon>visibility</mat-icon>
+                    </button>
+                    <button type="button" matIconButton matSuffix aria-label="Remove Apple image"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.appleImage.value)"
+                        (click)="clearField(form()!.controls.appleImage)">
+                        <mat-icon>clear</mat-icon>
+                    </button>
                 </mat-form-field>
                 <mat-form-field class="full-width">
                     <mat-label>YouTube</mat-label>
                     <input type="text" [formControl]="form()!.controls.youtubeImage" matInput>
+                    <button type="button" matIconButton matSuffix aria-label="Preview YouTube image"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.youtubeImage.value)"
+                        (click)="previewImage(form()!.controls.youtubeImage.value)">
+                        <mat-icon>visibility</mat-icon>
+                    </button>
+                    <button type="button" matIconButton matSuffix aria-label="Remove YouTube image"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.youtubeImage.value)"
+                        (click)="clearField(form()!.controls.youtubeImage)">
+                        <mat-icon>clear</mat-icon>
+                    </button>
                 </mat-form-field>
                 <mat-form-field class="full-width">
                     <mat-label>Other</mat-label>
                     <input type="text" [formControl]="form()!.controls.otherImage" matInput>
+                    <button type="button" matIconButton matSuffix aria-label="Preview other image"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.otherImage.value)"
+                        (click)="previewImage(form()!.controls.otherImage.value)">
+                        <mat-icon>visibility</mat-icon>
+                    </button>
+                    <button type="button" matIconButton matSuffix aria-label="Remove other image"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.otherImage.value)"
+                        (click)="clearField(form()!.controls.otherImage)">
+                        <mat-icon>clear</mat-icon>
+                    </button>
                 </mat-form-field>
             </mat-tab>
             <mat-tab label="Meta">

--- a/cultpodcasts/src/app/add-episode-dialog/add-episode-dialog.component.sass
+++ b/cultpodcasts/src/app/add-episode-dialog/add-episode-dialog.component.sass
@@ -11,6 +11,13 @@
         flex-direction: column
         gap: 8px
         margin-top: 8px
+    .bluesky-flag
+        display: flex
+        align-items: center
+        gap: 8px
+        min-height: 40px
+        &--idle
+            opacity: 0.7
     .guest-actions
         margin: 8px 0
     .guest-suggestions

--- a/cultpodcasts/src/app/add-episode-dialog/add-episode-dialog.component.ts
+++ b/cultpodcasts/src/app/add-episode-dialog/add-episode-dialog.component.ts
@@ -200,7 +200,8 @@ export class AddEpisodeDialogComponent {
     }
     this.dialog.open(ImagePreviewDialogComponent, {
       data: { images, initialService: service },
-      maxWidth: '90vw'
+      maxWidth: 'min(920px, 95vw)',
+      width: 'min(920px, 95vw)'
     });
   }
 

--- a/cultpodcasts/src/app/add-episode-dialog/add-episode-dialog.component.ts
+++ b/cultpodcasts/src/app/add-episode-dialog/add-episode-dialog.component.ts
@@ -10,7 +10,7 @@ import { Person } from '../person.interface';
 import { PersonMatch } from '../person-match.interface';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatButtonModule } from '@angular/material/button';
-import { FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { EpisodeForm } from '../episode-form.interface';
 import { MatTabsModule } from '@angular/material/tabs';
 import { MatSelectModule } from '@angular/material/select';
@@ -30,11 +30,16 @@ import { EditPersonDialogComponent } from '../edit-person-dialog/edit-person-dia
 import { comparePeopleBySortKey } from '../person-sort';
 import { FeatureSwitch } from '../feature-switch.enum';
 import { FeatureSwitchService } from '../feature-switch-service';
+import { MatIconModule } from '@angular/material/icon';
+import { ImagePreviewDialogComponent } from '../image-preview-dialog/image-preview-dialog.component';
 import {
   buildEpisodeForm,
+  clearFormControl,
   getEpisodeChanges,
+  hasNonEmptyUrlValue,
   mergeEpisodeSubjects,
   noCompareFunction,
+  openExternalUrl,
   personLabel,
   regroupGuests as regroupGuestsPure,
   regroupSubjects as regroupSubjectsPure
@@ -56,7 +61,8 @@ import {
     MatInputModule,
     MatCheckboxModule,
     KeyValuePipe,
-    MatDividerModule
+    MatDividerModule,
+    MatIconModule
   ],
   templateUrl: './add-episode-dialog.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -69,6 +75,8 @@ export class AddEpisodeDialogComponent {
     && window.matchMedia('(hover: hover) and (pointer: fine)').matches;
   protected readonly personLabel = personLabel;
   protected readonly noCompareFunction = noCompareFunction;
+  protected readonly hasNonEmptyUrlValue = hasNonEmptyUrlValue;
+  protected readonly openExternalUrl = openExternalUrl;
 
   episodeId: string;
   podcastName: string | undefined;
@@ -170,6 +178,21 @@ export class AddEpisodeDialogComponent {
           episodeLangUnset: this.isEpisodeLanguageUnset(),
           ...this.getNewPodcastDialogDefaults()
         });
+  }
+
+  clearField(control: FormControl<string | URL | null>) {
+    clearFormControl(control);
+  }
+
+  previewImage(value: string | URL | null | undefined) {
+    const url = value instanceof URL ? value.toString() : value?.trim();
+    if (!url) {
+      return;
+    }
+    this.dialog.open(ImagePreviewDialogComponent, {
+      data: { url },
+      maxWidth: '90vw'
+    });
   }
 
   onSubmit() {

--- a/cultpodcasts/src/app/add-episode-dialog/add-episode-dialog.component.ts
+++ b/cultpodcasts/src/app/add-episode-dialog/add-episode-dialog.component.ts
@@ -145,6 +145,9 @@ export class AddEpisodeDialogComponent {
       this.podcastName = podcast?.name;
 
       this.form.set(buildEpisodeForm(resp.episode));
+      // Bluesky state is set by a real network post (or cleared via un-post elsewhere),
+      // not by flipping this form flag.
+      this.form()!.controls.blueskyPosted.disable({ emitEvent: false });
       this.allPeople = resp.people.sort(comparePeopleBySortKey);
       this.guestSuggestions.set(resp.episode.guestSuggestions ?? []);
       this.regroupGuests(resp.episode.guests ?? []);
@@ -182,7 +185,6 @@ export class AddEpisodeDialogComponent {
         description: form.controls.description.value,
         posted: form.controls.posted.value,
         tweeted: form.controls.tweeted.value,
-        bluesky: form.controls.blueskyPosted.value,
         ignored: form.controls.ignored.value,
         removed: form.controls.removed.value,
         explicit: form.controls.explicit.value,

--- a/cultpodcasts/src/app/add-episode-dialog/add-episode-dialog.component.ts
+++ b/cultpodcasts/src/app/add-episode-dialog/add-episode-dialog.component.ts
@@ -35,6 +35,7 @@ import { ImagePreviewDialogComponent } from '../image-preview-dialog/image-previ
 import {
   buildEpisodeForm,
   clearFormControl,
+  collectEpisodeImagePreviews,
   getEpisodeChanges,
   hasNonEmptyUrlValue,
   mergeEpisodeSubjects,
@@ -42,7 +43,8 @@ import {
   openExternalUrl,
   personLabel,
   regroupGuests as regroupGuestsPure,
-  regroupSubjects as regroupSubjectsPure
+  regroupSubjects as regroupSubjectsPure,
+  type EpisodeImageService
 } from '../episode-form.util';
 
 @Component({
@@ -187,13 +189,17 @@ export class AddEpisodeDialogComponent {
     clearFormControl(control);
   }
 
-  previewImage(value: string | URL | null | undefined) {
-    const url = value instanceof URL ? value.toString() : value?.trim();
-    if (!url) {
+  previewImage(service: EpisodeImageService) {
+    const form = this.form();
+    if (!form) {
+      return;
+    }
+    const images = collectEpisodeImagePreviews(form);
+    if (images.length === 0) {
       return;
     }
     this.dialog.open(ImagePreviewDialogComponent, {
-      data: { url },
+      data: { images, initialService: service },
       maxWidth: '90vw'
     });
   }

--- a/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.html
+++ b/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.html
@@ -29,7 +29,19 @@
                     <mat-checkbox [formControl]="form()!.controls.posted">Posted</mat-checkbox>
                     }
                     <mat-checkbox [formControl]="form()!.controls.tweeted">Tweeted</mat-checkbox>
-                    <mat-checkbox [formControl]="form()!.controls.blueskyPosted">Bluesky Post</mat-checkbox>
+                    @if (blueskyOriginallyPosted()) {
+                    <div class="bluesky-flag">
+                        <span>Bluesky post</span>
+                        @if (!pendingUnBluesky()) {
+                        <button type="button" matButton="text" (click)="markRemoveBlueskyPost()">Remove</button>
+                        } @else {
+                        <span class="bluesky-flag__pending">Will remove on save</span>
+                        <button type="button" matButton="text" (click)="cancelRemoveBlueskyPost()">Undo</button>
+                        }
+                    </div>
+                    } @else {
+                    <div class="bluesky-flag bluesky-flag--idle">Not posted to Bluesky</div>
+                    }
                     <mat-checkbox [formControl]="form()!.controls.ignored">Ignored</mat-checkbox>
                     <mat-checkbox [formControl]="form()!.controls.removed">Removed</mat-checkbox>
                     <mat-checkbox [formControl]="form()!.controls.explicit">Explicit</mat-checkbox>

--- a/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.html
+++ b/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.html
@@ -39,14 +39,44 @@
                 <mat-form-field class="full-width">
                     <mat-label>Spotify</mat-label>
                     <input type="text" [formControl]="form()!.controls.spotify" matInput>
+                    <button type="button" matIconButton matSuffix aria-label="Open Spotify URL"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.spotify.value)"
+                        (click)="openExternalUrl(form()!.controls.spotify.value)">
+                        <mat-icon>open_in_new</mat-icon>
+                    </button>
+                    <button type="button" matIconButton matSuffix aria-label="Remove Spotify URL"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.spotify.value)"
+                        (click)="clearField(form()!.controls.spotify)">
+                        <mat-icon>clear</mat-icon>
+                    </button>
                 </mat-form-field>
                 <mat-form-field class="full-width">
                     <mat-label>Apple</mat-label>
                     <input type="text" [formControl]="form()!.controls.apple" matInput>
+                    <button type="button" matIconButton matSuffix aria-label="Open Apple URL"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.apple.value)"
+                        (click)="openExternalUrl(form()!.controls.apple.value)">
+                        <mat-icon>open_in_new</mat-icon>
+                    </button>
+                    <button type="button" matIconButton matSuffix aria-label="Remove Apple URL"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.apple.value)"
+                        (click)="clearField(form()!.controls.apple)">
+                        <mat-icon>clear</mat-icon>
+                    </button>
                 </mat-form-field>
                 <mat-form-field class="full-width">
                     <mat-label>YouTube</mat-label>
                     <input type="text" [formControl]="form()!.controls.youtube" matInput>
+                    <button type="button" matIconButton matSuffix aria-label="Open YouTube URL"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.youtube.value)"
+                        (click)="openExternalUrl(form()!.controls.youtube.value)">
+                        <mat-icon>open_in_new</mat-icon>
+                    </button>
+                    <button type="button" matIconButton matSuffix aria-label="Remove YouTube URL"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.youtube.value)"
+                        (click)="clearField(form()!.controls.youtube)">
+                        <mat-icon>clear</mat-icon>
+                    </button>
                 </mat-form-field>
                 <mat-accordion>
                     <mat-expansion-panel>
@@ -56,10 +86,30 @@
                         <mat-form-field class="full-width">
                     <mat-label>BBC</mat-label>
                     <input type="text" [formControl]="form()!.controls.bbc" matInput>
+                    <button type="button" matIconButton matSuffix aria-label="Open BBC URL"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.bbc.value)"
+                        (click)="openExternalUrl(form()!.controls.bbc.value)">
+                        <mat-icon>open_in_new</mat-icon>
+                    </button>
+                    <button type="button" matIconButton matSuffix aria-label="Remove BBC URL"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.bbc.value)"
+                        (click)="clearField(form()!.controls.bbc)">
+                        <mat-icon>clear</mat-icon>
+                    </button>
                 </mat-form-field>
                         <mat-form-field class="full-width">
                     <mat-label>Internet Archive</mat-label>
                     <input type="text" [formControl]="form()!.controls.internetArchive" matInput>
+                    <button type="button" matIconButton matSuffix aria-label="Open Internet Archive URL"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.internetArchive.value)"
+                        (click)="openExternalUrl(form()!.controls.internetArchive.value)">
+                        <mat-icon>open_in_new</mat-icon>
+                    </button>
+                    <button type="button" matIconButton matSuffix aria-label="Remove Internet Archive URL"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.internetArchive.value)"
+                        (click)="clearField(form()!.controls.internetArchive)">
+                        <mat-icon>clear</mat-icon>
+                    </button>
                 </mat-form-field>
                     </mat-expansion-panel>
                 </mat-accordion>
@@ -123,18 +173,58 @@
                 <mat-form-field class="full-width">
                     <mat-label>Spotify</mat-label>
                     <input type="text" [formControl]="form()!.controls.spotifyImage" matInput>
+                    <button type="button" matIconButton matSuffix aria-label="Preview Spotify image"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.spotifyImage.value)"
+                        (click)="previewImage(form()!.controls.spotifyImage.value)">
+                        <mat-icon>visibility</mat-icon>
+                    </button>
+                    <button type="button" matIconButton matSuffix aria-label="Remove Spotify image"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.spotifyImage.value)"
+                        (click)="clearField(form()!.controls.spotifyImage)">
+                        <mat-icon>clear</mat-icon>
+                    </button>
                 </mat-form-field>
                 <mat-form-field class="full-width">
                     <mat-label>Apple</mat-label>
                     <input type="text" [formControl]="form()!.controls.appleImage" matInput>
+                    <button type="button" matIconButton matSuffix aria-label="Preview Apple image"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.appleImage.value)"
+                        (click)="previewImage(form()!.controls.appleImage.value)">
+                        <mat-icon>visibility</mat-icon>
+                    </button>
+                    <button type="button" matIconButton matSuffix aria-label="Remove Apple image"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.appleImage.value)"
+                        (click)="clearField(form()!.controls.appleImage)">
+                        <mat-icon>clear</mat-icon>
+                    </button>
                 </mat-form-field>
                 <mat-form-field class="full-width">
                     <mat-label>YouTube</mat-label>
                     <input type="text" [formControl]="form()!.controls.youtubeImage" matInput>
+                    <button type="button" matIconButton matSuffix aria-label="Preview YouTube image"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.youtubeImage.value)"
+                        (click)="previewImage(form()!.controls.youtubeImage.value)">
+                        <mat-icon>visibility</mat-icon>
+                    </button>
+                    <button type="button" matIconButton matSuffix aria-label="Remove YouTube image"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.youtubeImage.value)"
+                        (click)="clearField(form()!.controls.youtubeImage)">
+                        <mat-icon>clear</mat-icon>
+                    </button>
                 </mat-form-field>
                 <mat-form-field class="full-width">
                     <mat-label>Other</mat-label>
                     <input type="text" [formControl]="form()!.controls.otherImage" matInput>
+                    <button type="button" matIconButton matSuffix aria-label="Preview other image"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.otherImage.value)"
+                        (click)="previewImage(form()!.controls.otherImage.value)">
+                        <mat-icon>visibility</mat-icon>
+                    </button>
+                    <button type="button" matIconButton matSuffix aria-label="Remove other image"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.otherImage.value)"
+                        (click)="clearField(form()!.controls.otherImage)">
+                        <mat-icon>clear</mat-icon>
+                    </button>
                 </mat-form-field>
             </mat-tab>
             <mat-tab label="Guests">

--- a/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.html
+++ b/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.html
@@ -187,7 +187,7 @@
                     <input type="text" [formControl]="form()!.controls.spotifyImage" matInput>
                     <button type="button" matIconButton matSuffix aria-label="Preview Spotify image"
                         [disabled]="!hasNonEmptyUrlValue(form()!.controls.spotifyImage.value)"
-                        (click)="previewImage(form()!.controls.spotifyImage.value)">
+                        (click)="previewImage('spotify')">
                         <mat-icon>visibility</mat-icon>
                     </button>
                     <button type="button" matIconButton matSuffix aria-label="Remove Spotify image"
@@ -201,7 +201,7 @@
                     <input type="text" [formControl]="form()!.controls.appleImage" matInput>
                     <button type="button" matIconButton matSuffix aria-label="Preview Apple image"
                         [disabled]="!hasNonEmptyUrlValue(form()!.controls.appleImage.value)"
-                        (click)="previewImage(form()!.controls.appleImage.value)">
+                        (click)="previewImage('apple')">
                         <mat-icon>visibility</mat-icon>
                     </button>
                     <button type="button" matIconButton matSuffix aria-label="Remove Apple image"
@@ -215,7 +215,7 @@
                     <input type="text" [formControl]="form()!.controls.youtubeImage" matInput>
                     <button type="button" matIconButton matSuffix aria-label="Preview YouTube image"
                         [disabled]="!hasNonEmptyUrlValue(form()!.controls.youtubeImage.value)"
-                        (click)="previewImage(form()!.controls.youtubeImage.value)">
+                        (click)="previewImage('youtube')">
                         <mat-icon>visibility</mat-icon>
                     </button>
                     <button type="button" matIconButton matSuffix aria-label="Remove YouTube image"
@@ -229,7 +229,7 @@
                     <input type="text" [formControl]="form()!.controls.otherImage" matInput>
                     <button type="button" matIconButton matSuffix aria-label="Preview other image"
                         [disabled]="!hasNonEmptyUrlValue(form()!.controls.otherImage.value)"
-                        (click)="previewImage(form()!.controls.otherImage.value)">
+                        (click)="previewImage('other')">
                         <mat-icon>visibility</mat-icon>
                     </button>
                     <button type="button" matIconButton matSuffix aria-label="Remove other image"

--- a/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.sass
+++ b/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.sass
@@ -11,6 +11,15 @@
         flex-direction: column
         gap: 8px
         margin-top: 8px
+    .bluesky-flag
+        display: flex
+        align-items: center
+        gap: 8px
+        min-height: 40px
+        &__pending
+            opacity: 0.8
+        &--idle
+            opacity: 0.7
     .guest-actions
         margin: 8px 0
     .guest-suggestions

--- a/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.ts
+++ b/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.ts
@@ -178,7 +178,6 @@ export class EditEpisodeDialogComponent {
         description: form.controls.description.value,
         posted: form.controls.posted.value,
         tweeted: form.controls.tweeted.value,
-        bluesky: form.controls.blueskyPosted.value,
         ignored: form.controls.ignored.value,
         removed: form.controls.removed.value,
         explicit: form.controls.explicit.value,

--- a/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.ts
+++ b/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.ts
@@ -145,6 +145,9 @@ export class EditEpisodeDialogComponent {
       this.podcastId = podcast.id!;
 
       this.form.set(buildEpisodeForm(resp.episode));
+      // Bluesky state is set by a real network post (or cleared via un-post elsewhere),
+      // not by flipping this edit-form flag.
+      this.form()!.controls.blueskyPosted.disable({ emitEvent: false });
       this.allPeople = resp.people.sort(comparePeopleBySortKey);
       this.guestSuggestions.set(resp.episode.guestSuggestions ?? []);
       this.regroupGuests(resp.episode.guests ?? []);

--- a/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.ts
+++ b/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.ts
@@ -205,7 +205,8 @@ export class EditEpisodeDialogComponent {
     }
     this.dialog.open(ImagePreviewDialogComponent, {
       data: { images, initialService: service },
-      maxWidth: '90vw'
+      maxWidth: 'min(920px, 95vw)',
+      width: 'min(920px, 95vw)'
     });
   }
 

--- a/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.ts
+++ b/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.ts
@@ -12,7 +12,7 @@ import { Person } from '../person.interface';
 import { PersonMatch } from '../person-match.interface';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatButtonModule } from '@angular/material/button';
-import { FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { EpisodeForm } from '../episode-form.interface';
 import { MatTabsModule } from '@angular/material/tabs';
 import { MatSelectModule } from '@angular/material/select';
@@ -31,11 +31,16 @@ import { EditPersonDialogComponent } from '../edit-person-dialog/edit-person-dia
 import { comparePeopleBySortKey } from '../person-sort';
 import { FeatureSwitch } from '../feature-switch.enum';
 import { FeatureSwitchService } from '../feature-switch-service';
+import { MatIconModule } from '@angular/material/icon';
+import { ImagePreviewDialogComponent } from '../image-preview-dialog/image-preview-dialog.component';
 import {
   buildEpisodeForm,
+  clearFormControl,
   getEpisodeChanges,
+  hasNonEmptyUrlValue,
   mergeEpisodeSubjects,
   noCompareFunction,
+  openExternalUrl,
   personLabel,
   regroupGuests as regroupGuestsPure,
   regroupSubjects as regroupSubjectsPure
@@ -57,7 +62,8 @@ import {
     MatInputModule,
     MatCheckboxModule,
     KeyValuePipe,
-    MatDividerModule
+    MatDividerModule,
+    MatIconModule
   ],
   templateUrl: './edit-episode-dialog.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -70,6 +76,8 @@ export class EditEpisodeDialogComponent {
     && window.matchMedia('(hover: hover) and (pointer: fine)').matches;
   protected readonly personLabel = personLabel;
   protected readonly noCompareFunction = noCompareFunction;
+  protected readonly hasNonEmptyUrlValue = hasNonEmptyUrlValue;
+  protected readonly openExternalUrl = openExternalUrl;
 
   episodeId: string;
   podcastIdentifier: string;
@@ -163,6 +171,21 @@ export class EditEpisodeDialogComponent {
 
   close() {
     this.dialogRef.close({ closed: true });
+  }
+
+  clearField(control: FormControl<string | URL | null>) {
+    clearFormControl(control);
+  }
+
+  previewImage(value: string | URL | null | undefined) {
+    const url = value instanceof URL ? value.toString() : value?.trim();
+    if (!url) {
+      return;
+    }
+    this.dialog.open(ImagePreviewDialogComponent, {
+      data: { url },
+      maxWidth: '90vw'
+    });
   }
 
   onSubmit() {

--- a/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.ts
+++ b/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.ts
@@ -88,6 +88,8 @@ export class EditEpisodeDialogComponent {
   readonly guestsFilterTerm = signal<string>('');
   readonly guestSuggestions = signal<PersonMatch[]>([]);
   readonly languages = signal<{ [key: string]: string }>({});
+  readonly blueskyOriginallyPosted = signal(false);
+  readonly pendingUnBluesky = signal(false);
 
   readonly form = signal<FormGroup<EpisodeForm> | undefined>(undefined);
   originalEpisode: ApiEpisode | undefined;
@@ -145,9 +147,8 @@ export class EditEpisodeDialogComponent {
       this.podcastId = podcast.id!;
 
       this.form.set(buildEpisodeForm(resp.episode));
-      // Bluesky state is set by a real network post (or cleared via un-post elsewhere),
-      // not by flipping this edit-form flag.
-      this.form()!.controls.blueskyPosted.disable({ emitEvent: false });
+      this.blueskyOriginallyPosted.set(!!resp.episode.bluesky);
+      this.pendingUnBluesky.set(false);
       this.allPeople = resp.people.sort(comparePeopleBySortKey);
       this.guestSuggestions.set(resp.episode.guestSuggestions ?? []);
       this.regroupGuests(resp.episode.guests ?? []);
@@ -166,6 +167,17 @@ export class EditEpisodeDialogComponent {
 
   close() {
     this.dialogRef.close({ closed: true });
+  }
+
+  markRemoveBlueskyPost() {
+    if (!this.blueskyOriginallyPosted()) {
+      return;
+    }
+    this.pendingUnBluesky.set(true);
+  }
+
+  cancelRemoveBlueskyPost() {
+    this.pendingUnBluesky.set(false);
   }
 
   onSubmit() {
@@ -212,6 +224,9 @@ export class EditEpisodeDialogComponent {
         update.urls.internetArchive = new URL(form.controls.internetArchive.value);
       }
       var changes = getEpisodeChanges(this.originalEpisode!, update);
+      if (this.pendingUnBluesky()) {
+        changes.unBluesky = true;
+      }
       if (Object.keys(changes).length == 0) {
         this.dialogRef.close({ noChange: true, podcastId: this.podcastId });
       } else {

--- a/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.ts
+++ b/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.ts
@@ -36,6 +36,7 @@ import { ImagePreviewDialogComponent } from '../image-preview-dialog/image-previ
 import {
   buildEpisodeForm,
   clearFormControl,
+  collectEpisodeImagePreviews,
   getEpisodeChanges,
   hasNonEmptyUrlValue,
   mergeEpisodeSubjects,
@@ -43,7 +44,8 @@ import {
   openExternalUrl,
   personLabel,
   regroupGuests as regroupGuestsPure,
-  regroupSubjects as regroupSubjectsPure
+  regroupSubjects as regroupSubjectsPure,
+  type EpisodeImageService
 } from '../episode-form.util';
 
 @Component({
@@ -192,13 +194,17 @@ export class EditEpisodeDialogComponent {
     clearFormControl(control);
   }
 
-  previewImage(value: string | URL | null | undefined) {
-    const url = value instanceof URL ? value.toString() : value?.trim();
-    if (!url) {
+  previewImage(service: EpisodeImageService) {
+    const form = this.form();
+    if (!form) {
+      return;
+    }
+    const images = collectEpisodeImagePreviews(form);
+    if (images.length === 0) {
       return;
     }
     this.dialog.open(ImagePreviewDialogComponent, {
-      data: { url },
+      data: { images, initialService: service },
       maxWidth: '90vw'
     });
   }

--- a/cultpodcasts/src/app/episode-form.util.ts
+++ b/cultpodcasts/src/app/episode-form.util.ts
@@ -26,6 +26,36 @@ export function noCompareFunction(): number {
   return 0;
 }
 
+export function hasNonEmptyUrlValue(value: string | URL | null | undefined): boolean {
+  if (value instanceof URL) {
+    return true;
+  }
+  return !!value?.trim();
+}
+
+/** Opens a trimmed absolute URL in a new tab; no-ops on blank or invalid values. */
+export function openExternalUrl(value: string | URL | null | undefined): void {
+  if (value instanceof URL) {
+    window.open(value.toString(), '_blank', 'noopener,noreferrer');
+    return;
+  }
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return;
+  }
+  try {
+    const url = new URL(trimmed);
+    window.open(url.toString(), '_blank', 'noopener,noreferrer');
+  } catch {
+    // Invalid URL — leave the field as-is for the curator to fix.
+  }
+}
+
+export function clearFormControl(control: FormControl<string | URL | null>): void {
+  control.setValue(null);
+  control.markAsDirty();
+}
+
 export function personLabel(person: Person): string {
   const handles = [person.twitterHandle, person.blueskyHandle].filter(x => !!x).join(' ');
   return handles ? `${person.name} (${handles})` : person.name;

--- a/cultpodcasts/src/app/episode-form.util.ts
+++ b/cultpodcasts/src/app/episode-form.util.ts
@@ -198,7 +198,6 @@ export function getEpisodeChanges(prev: ApiEpisode, now: ApiEpisode): EpisodePos
   if (prev.ignored != now.ignored) changes.ignored = now.ignored;
   if (prev.posted != now.posted) changes.posted = now.posted;
   if (prev.tweeted != now.tweeted) changes.tweeted = now.tweeted;
-  if ((prev.bluesky ?? false) != (now.bluesky ?? false)) changes.bluesky = now.bluesky ?? false;
   if (prev.release.toISOString() != nowReleaseDate) changes.release = nowReleaseDate;
   if (prev.removed != now.removed) changes.removed = now.removed;
   if (prev.searchTerms != now.searchTerms) changes.searchTerms = now.searchTerms;

--- a/cultpodcasts/src/app/episode-form.util.ts
+++ b/cultpodcasts/src/app/episode-form.util.ts
@@ -56,6 +56,30 @@ export function clearFormControl(control: FormControl<string | URL | null>): voi
   control.markAsDirty();
 }
 
+export type EpisodeImageService = 'spotify' | 'apple' | 'youtube' | 'other';
+
+export interface EpisodeImagePreviewItem {
+  service: EpisodeImageService;
+  label: string;
+  url: string;
+}
+
+/** Non-empty episode image fields in display order for the preview gallery. */
+export function collectEpisodeImagePreviews(form: FormGroup<EpisodeForm>): EpisodeImagePreviewItem[] {
+  const items: EpisodeImagePreviewItem[] = [];
+  const add = (service: EpisodeImageService, label: string, value: string | URL | null | undefined) => {
+    const url = value instanceof URL ? value.toString() : value?.trim();
+    if (url) {
+      items.push({ service, label, url });
+    }
+  };
+  add('spotify', 'Spotify', form.controls.spotifyImage.value);
+  add('apple', 'Apple', form.controls.appleImage.value);
+  add('youtube', 'YouTube', form.controls.youtubeImage.value);
+  add('other', 'Other', form.controls.otherImage.value);
+  return items;
+}
+
 export function personLabel(person: Person): string {
   const handles = [person.twitterHandle, person.blueskyHandle].filter(x => !!x).join(' ');
   return handles ? `${person.name} (${handles})` : person.name;

--- a/cultpodcasts/src/app/episode-post.interface.ts
+++ b/cultpodcasts/src/app/episode-post.interface.ts
@@ -5,7 +5,8 @@ export interface EpisodePost {
     description?: string;
     posted?: boolean;
     tweeted?: boolean;
-    bluesky?: boolean;
+    /** When true, clear Bluesky post state and delete the remote post. */
+    unBluesky?: boolean;
     ignored?: boolean;
     removed?: boolean;
     explicit?: boolean;

--- a/cultpodcasts/src/app/episode-update.service.ts
+++ b/cultpodcasts/src/app/episode-update.service.ts
@@ -122,7 +122,7 @@ export class EpisodeUpdateService {
   }
 
   async unpostBluesky(episode: ApiEpisode): Promise<ApiEpisode> {
-    return this.applyAndRefresh(episode, { bluesky: false });
+    return this.applyAndRefresh(episode, { unBluesky: true });
   }
 
   async toggleBluesky(episode: ApiEpisode): Promise<ApiEpisode> {

--- a/cultpodcasts/src/app/homepage-api/homepage-api.component.spec.ts
+++ b/cultpodcasts/src/app/homepage-api/homepage-api.component.spec.ts
@@ -169,7 +169,7 @@ describe('HomepageApiComponent', () => {
   }): void {
     component['curatedEpisodeIds'].set(curation?.episodeIds ?? []);
     component['curatedRailSubjects'].set(curation?.railSubjects ?? []);
-    component['applyHomepage'](homepageWith(episodes), { resetScrollProgress: true });
+    component['applyHomepage'](homepageWith(episodes));
   }
 
   it('prunes stale curated episode ids for local display only', () => {
@@ -203,24 +203,22 @@ describe('HomepageApiComponent', () => {
     expect(component['curatedEpisodeIds']()).toEqual([]);
   });
 
-  it('loads the initial progressive block then grows on loadMoreEpisodes', () => {
-    const episodes = Array.from({ length: 120 }, (_, i) => ep(`e${i}`, { daysAgo: i % 6 }));
-    apply(episodes);
-    const initial = Object.values(component['grouped']()).flat().length;
-    expect(initial).toBe(component.renderConfig.initialBlockSize);
+  it('shows every week day rail on first paint without scrolling', () => {
+    // Enough episodes that a progressive 40-episode window would omit older days.
+    const newest = Array.from({ length: 35 }, (_, i) => ep(`n${i}`, { daysAgo: 0 }));
+    const mid = Array.from({ length: 35 }, (_, i) => ep(`m${i}`, { daysAgo: 1 }));
+    const older = Array.from({ length: 35 }, (_, i) => ep(`o${i}`, { daysAgo: 3 }));
+    apply([...newest, ...mid, ...older]);
 
-    component['loadMoreEpisodes'](component.renderConfig.firstScrollBlockSize);
-    const after = Object.values(component['grouped']()).flat().length;
-    expect(after).toBe(
-      component.renderConfig.initialBlockSize + component.renderConfig.firstScrollBlockSize
-    );
+    const dayRails = component['rails']().filter((r) => r.id.startsWith('day:'));
+    expect(dayRails).toHaveLength(3);
+    expect(dayRails.map((r) => r.episodes.length)).toEqual([35, 35, 35]);
   });
 
-  it('background refresh keeps the current visible count', async () => {
+  it('background refresh replaces the week without progressive scroll state', async () => {
     const episodes = Array.from({ length: 100 }, (_, i) => ep(`e${i}`, { daysAgo: i % 5 }));
     apply(episodes);
-    component['loadMoreEpisodes'](component.renderConfig.firstScrollBlockSize);
-    const visibleBefore = component['visibleCount'];
+    const dayCountBefore = component['rails']().filter((r) => r.id.startsWith('day:')).length;
 
     const homepageService = TestBed.inject(HomepageService) as unknown as {
       getHomepageFromApi: ReturnType<typeof vi.fn>;
@@ -232,7 +230,9 @@ describe('HomepageApiComponent', () => {
       updatedAt: null,
     });
     await component['refreshHomepageInBackground']();
-    expect(component['visibleCount']).toBe(visibleBefore);
+    const dayCountAfter = component['rails']().filter((r) => r.id.startsWith('day:')).length;
+    expect(dayCountAfter).toBe(dayCountBefore);
+    expect(dayCountAfter).toBe(5);
   });
 
   it('interleaves newest day, then pinned subject rails, then remaining days by default', () => {

--- a/cultpodcasts/src/app/homepage-api/homepage-api.component.ts
+++ b/cultpodcasts/src/app/homepage-api/homepage-api.component.ts
@@ -87,10 +87,19 @@ export class HomepageApiComponent {
   /** Floor between any two fetches (interval or visibility-triggered) so a tab-switch flurry can't spam the API. */
   private static readonly minBackgroundRefreshGapMs = 5 * 60 * 1000;
 
-  protected grouped = signal<{ [key: string]: HomepageEpisode[] }>({});
   private allEpisodes = signal<HomepageEpisode[]>([]);
-  private visibleCount: number = 0;
-  private hasStartedScrolling: boolean = false;
+  /** Full week grouped by date key — day rails read this so every day appears on first paint. */
+  protected readonly grouped = computed(() => {
+    const group: { [key: string]: HomepageEpisode[] } = {};
+    for (const item of this.allEpisodes()) {
+      const releaseDateKey = dateKey(item.release as Date);
+      if (!group[releaseDateKey]) {
+        group[releaseDateKey] = [];
+      }
+      group[releaseDateKey].push(item);
+    }
+    return group;
+  });
   protected weekEpisodeCount = signal<number | undefined>(undefined);
   protected isLoading = signal<boolean>(true);
   protected isInError = signal<boolean>(false);
@@ -119,12 +128,6 @@ export class HomepageApiComponent {
   protected isSignedIn = toSignal(this.auth.isSignedIn, { initialValue: false });
   protected authRoles = toSignal(this.auth.roles, { initialValue: [] as string[] });
   protected readonly isCurator = computed(() => this.authRoles().includes('Curator'));
-  readonly renderConfig = {
-    initialBlockSize: 40,
-    firstScrollBlockSize: 80,
-    nearEndBlockSize: 80,
-    nearEndThresholdPixels: 1200,
-  };
 
   /** Ordered episode IDs from the hero-curation API (may include stale ids). */
   protected readonly curatedEpisodeIds = signal<string[]>([]);
@@ -195,6 +198,8 @@ export class HomepageApiComponent {
   );
 
   protected readonly rails = computed((): EpisodeRail[] => {
+    // Day rails use the full week so every date slot appears on first paint.
+    // Poster DOM cost is deferred per-rail via episode-rail [deferPosters].
     const g = this.grouped();
     const weekKeys = this.weekDayKeysNewestFirst();
     const dayRails = weekKeys.map((key) => {
@@ -206,7 +211,7 @@ export class HomepageApiComponent {
       return {
         id: `day:${key}`,
         title: `${this.Weekday[d.getDay()]} ${d.getDate()} ${this.Month[d.getMonth()]}`,
-        // Day rails have no "Browse all" destination — show the full progressive window.
+        // Day rails have no "Browse all" destination — show the full day.
         episodes,
       } satisfies EpisodeRail;
     });
@@ -268,22 +273,6 @@ export class HomepageApiComponent {
       this.maybeBackgroundRefresh();
     }
   };
-  private scrollFrame = 0;
-  /**
-   * Bound outside Angular's event manager on purpose: in a zoneless app every listener
-   * invocation schedules a change-detection pass, so a `@HostListener` here would run one
-   * per scroll event. Only `loadMoreEpisodes` writes signals, so CD now runs when the
-   * visible set actually grows.
-   */
-  private readonly onScrollEvent = (): void => {
-    if (this.scrollFrame) {
-      return;
-    }
-    this.scrollFrame = requestAnimationFrame(() => {
-      this.scrollFrame = 0;
-      this.onWindowScroll();
-    });
-  };
 
   ngOnInit() {
     this.siteService.homepageRefresh$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
@@ -293,31 +282,9 @@ export class HomepageApiComponent {
 
     if (isPlatformBrowser(this.platformId)) {
       this.startBackgroundRefresh();
-      this.startScrollWatch();
       this.destroyRef.onDestroy(() => {
         this.stopBackgroundRefresh();
-        this.stopScrollWatch();
       });
-    }
-  }
-
-  onWindowScroll(): void {
-    if (!this.homepage() || this.isLoading() || this.isInError() || this.allEpisodes().length === 0) {
-      return;
-    }
-
-    if (!this.hasStartedScrolling && window.scrollY > 0) {
-      this.hasStartedScrolling = true;
-      this.loadMoreEpisodes(this.renderConfig.firstScrollBlockSize);
-      return;
-    }
-
-    const currentBottom = window.innerHeight + window.scrollY;
-    const documentHeight = document.documentElement.scrollHeight;
-    const isNearEnd = currentBottom >= documentHeight - this.renderConfig.nearEndThresholdPixels;
-
-    if (isNearEnd) {
-      this.loadMoreEpisodes(this.renderConfig.nearEndBlockSize);
     }
   }
 
@@ -615,7 +582,7 @@ export class HomepageApiComponent {
     }
 
     if (homepageContent) {
-      this.applyHomepage(homepageContent, { resetScrollProgress: true });
+      this.applyHomepage(homepageContent);
       this.isLoading.set(false);
       this.isInError.set(false);
     } else {
@@ -644,21 +611,14 @@ export class HomepageApiComponent {
     if (!homepageContent) {
       return;
     }
-    this.applyHomepage(homepageContent, { resetScrollProgress: false });
+    this.applyHomepage(homepageContent);
   }
 
-  private applyHomepage(
-    homepageContent: Homepage,
-    options: { resetScrollProgress: boolean }
-  ): void {
+  private applyHomepage(homepageContent: Homepage): void {
     this.homepage.set(homepageContent);
     this.episodeCount.set(homepageContent.episodeCount);
     this.totalDurationDays.set(homepageContent.totalDuration.split('.')[0]);
     this.weekEpisodeCount.set(homepageContent.recentEpisodes.length);
-    if (options.resetScrollProgress) {
-      this.hasStartedScrolling = false;
-      this.visibleCount = 0;
-    }
     this.allEpisodes.set(
       homepageContent.recentEpisodes.map((item) => ({
         ...item,
@@ -668,27 +628,6 @@ export class HomepageApiComponent {
     // Week-window drop: curated picks that left recentEpisodes fall out locally
     // (and persist when a Curator is signed in).
     this.pruneCurationToCurrentWeek();
-    if (options.resetScrollProgress) {
-      this.loadMoreEpisodes(this.renderConfig.initialBlockSize);
-    } else if (this.visibleCount > 0) {
-      const keep = this.visibleCount;
-      this.visibleCount = 0;
-      this.loadMoreEpisodes(keep);
-    } else {
-      this.loadMoreEpisodes(this.renderConfig.initialBlockSize);
-    }
-  }
-
-  private startScrollWatch(): void {
-    window.addEventListener('scroll', this.onScrollEvent, { passive: true });
-  }
-
-  private stopScrollWatch(): void {
-    window.removeEventListener('scroll', this.onScrollEvent);
-    if (this.scrollFrame) {
-      cancelAnimationFrame(this.scrollFrame);
-      this.scrollFrame = 0;
-    }
   }
 
   private startBackgroundRefresh(): void {
@@ -721,28 +660,6 @@ export class HomepageApiComponent {
 
   private static heroTimeBucket(now: Date = new Date()): number {
     return Math.floor(now.getTime() / HomepageApiComponent.heroBucketMs);
-  }
-
-  private loadMoreEpisodes(count: number): void {
-    const episodes = this.allEpisodes();
-    const nextVisibleCount = Math.min(this.visibleCount + count, episodes.length);
-    if (nextVisibleCount === this.visibleCount) {
-      return;
-    }
-
-    this.visibleCount = nextVisibleCount;
-    const visibleEpisodes = episodes.slice(0, this.visibleCount);
-    this.grouped.set(
-      visibleEpisodes.reduce((group: { [key: string]: HomepageEpisode[] }, item) => {
-        const releaseDate = item.release as Date;
-        const releaseDateKey = dateKey(releaseDate);
-        if (!group[releaseDateKey]) {
-          group[releaseDateKey] = [];
-        }
-        group[releaseDateKey].push(item);
-        return group;
-      }, {})
-    );
   }
 
   ToDate = (key: string) => dateFromKey(key);

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.html
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.html
@@ -89,8 +89,11 @@
           </span>
           }
         </p>
-        <div class="billboard__copy-body">
+        @if (hasCopyBody()) {
+        <div class="billboard__copy-body" [class.has-desc]="hasFeaturedDesc()">
+          @if (hasFeaturedDesc()) {
           <p class="billboard__desc">{{ featuredDesc() }}</p>
+          }
           @if (featuredSubjects().length > 0) {
           <div class="billboard__subjects" aria-label="Subjects">
             @for (subject of featuredSubjects(); track subject) {
@@ -99,6 +102,7 @@
           </div>
           }
         </div>
+        }
       </div>
       <div class="billboard__actions">
         @if (canPlay(feature)) {

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.html
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.html
@@ -4,7 +4,11 @@
   [class.has-art-aspect]="heroArtAspect() != null"
   [style.--hero-art-aspect]="heroArtAspect() ?? null"
   (mouseenter)="onHeroPointerEnter()" (mouseleave)="onHeroPointerLeave()"
-  (focusin)="onHeroFocusIn()" (focusout)="onHeroFocusOut($event)">
+  (focusin)="onHeroFocusIn()" (focusout)="onHeroFocusOut($event)"
+  (pointerdown)="onHeroSwipeDown($event)"
+  (pointermove)="onHeroSwipeMove($event)"
+  (pointerup)="onHeroSwipeUp($event)"
+  (pointercancel)="onHeroSwipeCancel($event)">
 
   <div class="billboard__stages" aria-hidden="true">
     <div class="billboard__stage" [class.is-active]="heroFrontLayer() === 'a'"

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
@@ -15,6 +15,7 @@
     background-color: #0b0b0b
     // Slide copy height can still change mid-autoplay; block scroll anchoring
     // from yanking window scrollY when the billboard reflows.
+    // Contract: docs/homepage-hero.md § Scroll stability
     overflow-anchor: none
     // Allow vertical page scroll; horizontal swipe advances heroes on touch.
     touch-action: pan-y
@@ -329,6 +330,8 @@
     min-height: calc(1.45em * 3)
 
 .billboard__subjects
+    // Do not overflow-clip or max-height — all public chips must show.
+    // Contract: docs/homepage-hero.md § Subjects
     display: flex
     flex-wrap: wrap
     gap: 8px

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
@@ -16,6 +16,8 @@
     // Slide copy height can still change mid-autoplay; block scroll anchoring
     // from yanking window scrollY when the billboard reflows.
     overflow-anchor: none
+    // Allow vertical page scroll; horizontal swipe advances heroes on touch.
+    touch-action: pan-y
 
 .billboard__stages,
 .billboard__grain,

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
@@ -686,10 +686,11 @@
             backdrop-filter: none
             -webkit-mask-image: none
             mask-image: none
-    // Stacked: details panel is in document flow under a fixed art frame. Title
-    // line-count used to resize the panel (~125px between 1- and 3-line titles).
-    .billboard__title
-        min-height: calc(1.12em * 3)
+    // Stacked: details panel is in document flow under a fixed art frame.
+    // Do NOT reserve 3 title lines with min-height — short titles left a large
+    // blank band above meta (HERO-SCR-005). Cap with line-clamp only; rely on
+    // overflow-anchor when 1-line vs 3-line titles change in-flow height.
+    // (Was: min-height: calc(1.12em * 3) — removed Aug 2026.)
     // Copy no longer sits on the art, so the only job left is keeping the frosted
     // chrome legible over the top of the frame.
     .billboard__scrim

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.sass
@@ -240,11 +240,13 @@
     min-width: 0
 
 .billboard__copy-body
-    // Reserve stable space for desc + chips so Watch/More info keep a steady Y.
     display: flex
     flex-direction: column
-    min-height: calc(1.45em * 3 + 44px)
     margin-bottom: 4px
+    // Only reserve desc height when a description is present — empty slides must
+    // not leave a blank band (especially on mobile). Contract: docs/homepage-hero.md
+    &.has-desc
+        min-height: calc(1.45em * 3 + 44px)
 
 .billboard__eyebrow
     // Sits directly above the podcast pill — the pill carries the gap to the title.
@@ -326,7 +328,7 @@
     -webkit-line-clamp: 3
     line-clamp: 3
     overflow: hidden
-    // Keep the reserved copy-body height honest even when text is short.
+    // Keep short descriptions from collapsing the reserved copy-body height.
     min-height: calc(1.45em * 3)
 
 .billboard__subjects
@@ -738,7 +740,7 @@
     .billboard__title
         font-size: clamp(1.85rem, 7vw, 2.6rem)
         margin-bottom: 10px
-    .billboard__copy-body
+    .billboard__copy-body.has-desc
         min-height: calc(1.45em * 3 + 40px)
     .billboard__desc
         font-size: 0.98rem

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.spec.ts
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.spec.ts
@@ -210,7 +210,7 @@ describe('HomepageHeroComponent', () => {
     expect(fixture.nativeElement.querySelector('.billboard__subjects')).toBeTruthy();
   });
 
-  it('HERO-SCR-001/002 + HERO-CTL-001 + HERO-SWP-001: Sass keeps scroll-stability and hit-target contracts', () => {
+  it('HERO-SCR-001/002/005 + HERO-CTL-001 + HERO-SWP-001: Sass keeps scroll-stability and hit-target contracts', () => {
     // Layout bugs often land in CSS; assert the source contracts stay present.
     expect(heroSass).toMatch(/\.billboard[\s\S]*?overflow-anchor:\s*none/);
     expect(heroSass).toMatch(/\.billboard__dots-viewport[\s\S]*?overflow-anchor:\s*none/);
@@ -220,6 +220,10 @@ describe('HomepageHeroComponent', () => {
     expect(heroSass).toMatch(/\.billboard__copy-body[\s\S]*?&\.has-desc[\s\S]*?min-height:\s*calc\(1\.45em \* 3/);
     expect(heroSass).toMatch(/\.billboard__stages,[\s\S]*?pointer-events:\s*none/);
     expect(heroSass).toMatch(/\.billboard[\s\S]*?touch-action:\s*pan-y/);
+
+    // HERO-SCR-005: short titles must not reserve empty lines on stacked layouts.
+    expect(heroSass).not.toMatch(/\.billboard__title\s*\n[ \t]+min-height:\s*calc\(1\.12em \* 3\)/);
+    expect(heroSass).not.toMatch(/\.billboard__title[^\n]*\{[^}]*min-height:\s*calc\(1\.12em \* 3\)/);
 
     const subjectsStart = heroSass.indexOf('.billboard__subjects');
     expect(subjectsStart).toBeGreaterThanOrEqual(0);

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.spec.ts
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.spec.ts
@@ -1,9 +1,15 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
 import { PLATFORM_ID, provideZonelessChangeDetection } from '@angular/core';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { HomepageHeroComponent } from './homepage-hero.component';
 import { HomepageEpisode } from '../homepage-episode.interface';
 import { PlayerService } from '../player.service';
+
+const heroDir = dirname(fileURLToPath(import.meta.url));
+const heroSass = readFileSync(join(heroDir, 'homepage-hero.component.sass'), 'utf8');
 
 function ep(id: string, overrides: Partial<HomepageEpisode> = {}): HomepageEpisode {
   return {
@@ -35,6 +41,28 @@ class ImmediateImage {
   set src(_value: string) {
     this.complete = true;
   }
+}
+
+function pointerEvent(
+  type: string,
+  init: PointerEventInit & {
+    target?: EventTarget | null;
+    currentTarget?: EventTarget | null;
+  }
+): PointerEvent {
+  const { target, currentTarget, ...rest } = init;
+  const event = new PointerEvent(type, {
+    bubbles: true,
+    cancelable: true,
+    ...rest,
+  });
+  if (target) {
+    Object.defineProperty(event, 'target', { configurable: true, value: target });
+  }
+  if (currentTarget) {
+    Object.defineProperty(event, 'currentTarget', { configurable: true, value: currentTarget });
+  }
+  return event;
 }
 
 describe('HomepageHeroComponent', () => {
@@ -111,7 +139,7 @@ describe('HomepageHeroComponent', () => {
     expect(meta.textContent?.replace(/\s+/g, ' ').trim()).toBe('1:00:00');
   });
 
-  it('shows every public subject chip without capping count', () => {
+  it('HERO-SUB-001: shows every public subject chip without capping count', () => {
     const many = Array.from({ length: 12 }, (_, i) => `Topic ${i + 1}`);
     fixture.componentRef.setInput('slides', [
       ep('a', { subjects: ['_internal', ...many] }),
@@ -125,6 +153,53 @@ describe('HomepageHeroComponent', () => {
       '.billboard__subjects app-subject-chip'
     );
     expect(chips.length).toBe(12);
+  });
+
+  it('HERO-SUB-002: keeps Watch/More info actions below the subject chips', () => {
+    const many = Array.from({ length: 8 }, (_, i) => `Topic ${i + 1}`);
+    fixture.componentRef.setInput('slides', [
+      ep('a', { subjects: many }),
+      ep('b'),
+      ep('c'),
+    ]);
+    fixture.detectChanges();
+
+    const subjects = fixture.nativeElement.querySelector('.billboard__subjects') as HTMLElement;
+    const actions = fixture.nativeElement.querySelector('.billboard__actions') as HTMLElement;
+    expect(subjects).toBeTruthy();
+    expect(actions).toBeTruthy();
+    expect(subjects.compareDocumentPosition(actions) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('HERO-SCR-001/002 + HERO-CTL-001 + HERO-SWP-001: Sass keeps scroll-stability and hit-target contracts', () => {
+    // Layout bugs often land in CSS; assert the source contracts stay present.
+    expect(heroSass).toMatch(/\.billboard[\s\S]*?overflow-anchor:\s*none/);
+    expect(heroSass).toMatch(/\.billboard__dots-viewport[\s\S]*?overflow-anchor:\s*none/);
+    expect(heroSass).toMatch(/\.billboard__title[\s\S]*?line-clamp:\s*3/);
+    expect(heroSass).toMatch(/\.billboard__desc[\s\S]*?line-clamp:\s*3/);
+    expect(heroSass).toMatch(/\.billboard__desc[\s\S]*?min-height:\s*calc\(1\.45em \* 3\)/);
+    expect(heroSass).toMatch(/\.billboard__copy-body[\s\S]*?min-height:\s*calc\(1\.45em \* 3/);
+    expect(heroSass).toMatch(/\.billboard__stages,[\s\S]*?pointer-events:\s*none/);
+    expect(heroSass).toMatch(/\.billboard[\s\S]*?touch-action:\s*pan-y/);
+
+    const subjectsStart = heroSass.indexOf('.billboard__subjects');
+    expect(subjectsStart).toBeGreaterThanOrEqual(0);
+    const subjectsSlice = heroSass.slice(subjectsStart, subjectsStart + 400);
+    expect(subjectsSlice).toMatch(/flex-wrap:\s*wrap/);
+    expect(subjectsSlice).not.toMatch(/overflow:\s*hidden/);
+    expect(subjectsSlice).not.toMatch(/max-height:/);
+    expect(subjectsSlice).not.toMatch(/line-clamp:/);
+  });
+
+  it('truncates featured description for the hero copy panel', () => {
+    const long = 'x'.repeat(300);
+    fixture.componentRef.setInput('slides', [ep('a', { episodeDescription: long }), ep('b'), ep('c')]);
+    fixture.detectChanges();
+
+    const desc = component['featuredDesc']();
+    expect(desc.length).toBeLessThan(long.length);
+    expect(desc.endsWith('…')).toBe(true);
+    expect(desc.startsWith('x'.repeat(220).trim())).toBe(true);
   });
 
   it('jumps to a slide when its hero dash is clicked', () => {
@@ -142,7 +217,7 @@ describe('HomepageHeroComponent', () => {
     expect(component['featured']()?.id).toBe('c');
   });
 
-  it('advances when the next chevron is clicked without cancelling the content transition', () => {
+  it('HERO-LIF-002: advances when the next chevron is clicked without cancelling the content transition', () => {
     vi.useFakeTimers();
     component['reduceMotion'] = false;
     component['heroIndex'].set(0);
@@ -176,6 +251,139 @@ describe('HomepageHeroComponent', () => {
 
     expect(component['heroIndex']()).toBe(0);
     expect(component['featured']()?.id).toBe('a');
+  });
+
+  it('HERO-SWP-001: touch swipe left advances and swipe right goes previous', () => {
+    component['reduceMotion'] = true;
+    component['heroIndex'].set(1);
+    component['lastFeaturedId'] = 'b';
+    fixture.detectChanges();
+
+    const billboard = fixture.nativeElement.querySelector('.billboard') as HTMLElement;
+
+    component.onHeroSwipeDown(
+      pointerEvent('pointerdown', {
+        pointerId: 1,
+        pointerType: 'touch',
+        clientX: 200,
+        clientY: 100,
+        target: billboard,
+        currentTarget: billboard,
+      })
+    );
+    component.onHeroSwipeMove(
+      pointerEvent('pointermove', {
+        pointerId: 1,
+        pointerType: 'touch',
+        clientX: 140,
+        clientY: 100,
+        currentTarget: billboard,
+      })
+    );
+    component.onHeroSwipeUp(
+      pointerEvent('pointerup', {
+        pointerId: 1,
+        pointerType: 'touch',
+        clientX: 140,
+        clientY: 100,
+        currentTarget: billboard,
+      })
+    );
+    expect(component['heroIndex']()).toBe(2);
+
+    component.onHeroSwipeDown(
+      pointerEvent('pointerdown', {
+        pointerId: 2,
+        pointerType: 'touch',
+        clientX: 100,
+        clientY: 100,
+        target: billboard,
+        currentTarget: billboard,
+      })
+    );
+    component.onHeroSwipeMove(
+      pointerEvent('pointermove', {
+        pointerId: 2,
+        pointerType: 'touch',
+        clientX: 160,
+        clientY: 100,
+        currentTarget: billboard,
+      })
+    );
+    component.onHeroSwipeUp(
+      pointerEvent('pointerup', {
+        pointerId: 2,
+        pointerType: 'touch',
+        clientX: 160,
+        clientY: 100,
+        currentTarget: billboard,
+      })
+    );
+    expect(component['heroIndex']()).toBe(1);
+  });
+
+  it('HERO-CTL-002: touch swipe that starts on a control does not change the slide', () => {
+    component['reduceMotion'] = true;
+    component['heroIndex'].set(0);
+    fixture.detectChanges();
+
+    const next = fixture.nativeElement.querySelector(
+      'button.billboard__nav--next'
+    ) as HTMLButtonElement;
+    const billboard = fixture.nativeElement.querySelector('.billboard') as HTMLElement;
+
+    component.onHeroSwipeDown(
+      pointerEvent('pointerdown', {
+        pointerId: 3,
+        pointerType: 'touch',
+        clientX: 200,
+        clientY: 100,
+        target: next,
+        currentTarget: billboard,
+      })
+    );
+    component.onHeroSwipeMove(
+      pointerEvent('pointermove', {
+        pointerId: 3,
+        pointerType: 'touch',
+        clientX: 100,
+        clientY: 100,
+        currentTarget: billboard,
+      })
+    );
+    component.onHeroSwipeUp(
+      pointerEvent('pointerup', {
+        pointerId: 3,
+        pointerType: 'touch',
+        clientX: 100,
+        clientY: 100,
+        currentTarget: billboard,
+      })
+    );
+
+    expect(component['heroIndex']()).toBe(0);
+    expect(component['swipePointerId']).toBeNull();
+  });
+
+  it('HERO-SWP-001: mouse pointer swipes do not change the slide', () => {
+    component['reduceMotion'] = true;
+    component['heroIndex'].set(0);
+    fixture.detectChanges();
+
+    const billboard = fixture.nativeElement.querySelector('.billboard') as HTMLElement;
+    component.onHeroSwipeDown(
+      pointerEvent('pointerdown', {
+        pointerId: 4,
+        pointerType: 'mouse',
+        button: 0,
+        clientX: 200,
+        clientY: 100,
+        target: billboard,
+        currentTarget: billboard,
+      })
+    );
+    expect(component['swipePointerId']).toBeNull();
+    expect(component['heroIndex']()).toBe(0);
   });
 
   it('releases chevron focus so the dash timer can run again after navigation', () => {
@@ -240,7 +448,7 @@ describe('HomepageHeroComponent', () => {
     expect(component['featured']()?.id).toBe('c');
   });
 
-  it('does not rebuild image layers when slides refresh with an unchanged sequence', () => {
+  it('HERO-LIF-006: does not rebuild image layers when slides refresh with an unchanged sequence', () => {
     component['heroImageReady'].set(true);
 
     fixture.componentRef.setInput('slides', [ep('a'), ep('b'), ep('c')]);
@@ -250,7 +458,7 @@ describe('HomepageHeroComponent', () => {
     expect(component['heroImageReady']()).toBe(true);
   });
 
-  it('emits removeFeatured with the active slide id', () => {
+  it('HERO-CUR-001: emits removeFeatured with the active slide id', () => {
     const removed: string[] = [];
     component.removeFeatured.subscribe((id) => removed.push(id));
     fixture.componentRef.setInput('isCurator', true);
@@ -265,7 +473,7 @@ describe('HomepageHeroComponent', () => {
     expect(removed).toEqual(['a']);
   });
 
-  it('emits manageHero / manageRails from curator controls', () => {
+  it('HERO-CUR-001: emits manageHero / manageRails from curator controls', () => {
     const managed: string[] = [];
     component.manageHero.subscribe(() => managed.push('hero'));
     component.manageRails.subscribe(() => managed.push('rails'));
@@ -300,7 +508,7 @@ describe('HomepageHeroComponent', () => {
     expect(actionsRemove).toBeNull();
   });
 
-  it('image gate stays blocked until the fallback timeout when decode never completes', () => {
+  it('HERO-LIF-001: image gate stays blocked until the fallback timeout when decode never completes', () => {
     vi.useFakeTimers();
     class StuckImage {
       onload: (() => void) | null = null;
@@ -343,7 +551,7 @@ describe('HomepageHeroComponent', () => {
     expect(component['heroIndex']()).toBe(1);
   });
 
-  it('holds copy until the next backdrop is ready, then fades with the image', () => {
+  it('HERO-LIF-003: holds copy until the next backdrop is ready, then fades with the image', () => {
     vi.useFakeTimers();
     const deferred: { fire: (() => void) | null } = { fire: null };
     class DeferredImage {
@@ -387,7 +595,7 @@ describe('HomepageHeroComponent', () => {
     expect(component['heroImageReady']()).toBe(true);
   });
 
-  it('reduce-motion jumps index immediately without starting the cycle timer', () => {
+  it('HERO-LIF-004: reduce-motion jumps index immediately without starting the cycle timer', () => {
     component['reduceMotion'] = true;
     component['stopHeroCycle']();
     component['heroIndex'].set(0);
@@ -396,7 +604,7 @@ describe('HomepageHeroComponent', () => {
     expect(component['heroTimer']).toBeUndefined();
   });
 
-  it('still auto-advances on saveGpu mobile mode (Ken Burns off, timer on)', () => {
+  it('HERO-LIF-005: still auto-advances on saveGpu mobile mode (Ken Burns off, timer on)', () => {
     // Arrange — mobile GPU saver must not reuse reduceMotion's "no cycle" path.
     vi.useFakeTimers();
     component['reduceMotion'] = false;

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.spec.ts
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.spec.ts
@@ -171,6 +171,45 @@ describe('HomepageHeroComponent', () => {
     expect(subjects.compareDocumentPosition(actions) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
+  it('HERO-SCR-004: omits description and reserved copy-body height when there is no description', () => {
+    fixture.componentRef.setInput('slides', [
+      ep('a', { episodeDescription: '', subjects: [] }),
+      ep('b'),
+      ep('c'),
+    ]);
+    fixture.detectChanges();
+
+    expect(component['hasFeaturedDesc']()).toBe(false);
+    expect(component['hasCopyBody']()).toBe(false);
+    expect(fixture.nativeElement.querySelector('.billboard__desc')).toBeNull();
+    expect(fixture.nativeElement.querySelector('.billboard__copy-body')).toBeNull();
+    expect(fixture.nativeElement.querySelector('.billboard__actions')).toBeTruthy();
+  });
+
+  it('HERO-SCR-004: marks copy-body has-desc only when description text is present', () => {
+    fixture.componentRef.setInput('slides', [
+      ep('a', { episodeDescription: 'Hello world', subjects: [] }),
+      ep('b', { episodeDescription: '', subjects: ['Topic'] }),
+      ep('c'),
+    ]);
+    fixture.detectChanges();
+
+    const withDesc = fixture.nativeElement.querySelector(
+      '.billboard__copy-body.has-desc .billboard__desc'
+    ) as HTMLElement | null;
+    expect(withDesc?.textContent?.trim()).toBe('Hello world');
+
+    component['reduceMotion'] = true;
+    component['transitionTo'](1);
+    fixture.detectChanges();
+
+    const body = fixture.nativeElement.querySelector('.billboard__copy-body') as HTMLElement;
+    expect(body).toBeTruthy();
+    expect(body.classList.contains('has-desc')).toBe(false);
+    expect(fixture.nativeElement.querySelector('.billboard__desc')).toBeNull();
+    expect(fixture.nativeElement.querySelector('.billboard__subjects')).toBeTruthy();
+  });
+
   it('HERO-SCR-001/002 + HERO-CTL-001 + HERO-SWP-001: Sass keeps scroll-stability and hit-target contracts', () => {
     // Layout bugs often land in CSS; assert the source contracts stay present.
     expect(heroSass).toMatch(/\.billboard[\s\S]*?overflow-anchor:\s*none/);
@@ -178,7 +217,7 @@ describe('HomepageHeroComponent', () => {
     expect(heroSass).toMatch(/\.billboard__title[\s\S]*?line-clamp:\s*3/);
     expect(heroSass).toMatch(/\.billboard__desc[\s\S]*?line-clamp:\s*3/);
     expect(heroSass).toMatch(/\.billboard__desc[\s\S]*?min-height:\s*calc\(1\.45em \* 3\)/);
-    expect(heroSass).toMatch(/\.billboard__copy-body[\s\S]*?min-height:\s*calc\(1\.45em \* 3/);
+    expect(heroSass).toMatch(/\.billboard__copy-body[\s\S]*?&\.has-desc[\s\S]*?min-height:\s*calc\(1\.45em \* 3/);
     expect(heroSass).toMatch(/\.billboard__stages,[\s\S]*?pointer-events:\s*none/);
     expect(heroSass).toMatch(/\.billboard[\s\S]*?touch-action:\s*pan-y/);
 

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.ts
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.ts
@@ -142,6 +142,12 @@ export class HomepageHeroComponent {
    */
   private heroTransitionToken = 0;
 
+  private static readonly swipeThresholdPx = 48;
+  private swipePointerId: number | null = null;
+  private swipeStartX = 0;
+  private swipeStartY = 0;
+  private swipeAxis: 'x' | 'y' | null = null;
+
   /**
    * Window resize and dots-strip scroll are bound outside Angular's event manager: in a
    * zoneless app each listener invocation schedules a change-detection pass, and both fire
@@ -378,6 +384,79 @@ export class HomepageHeroComponent {
     this.transitionTo((this.heroIndex() - 1 + n) % n);
     this.restartHeroCycle();
     this.releasePagerFocus(event);
+  }
+
+  onHeroSwipeDown(event: PointerEvent): void {
+    if (this.slides().length < 2 || event.pointerType === 'mouse') {
+      return;
+    }
+    if (this.isSwipeIgnoredTarget(event.target)) {
+      return;
+    }
+    this.swipePointerId = event.pointerId;
+    this.swipeStartX = event.clientX;
+    this.swipeStartY = event.clientY;
+    this.swipeAxis = null;
+    (event.currentTarget as HTMLElement).setPointerCapture?.(event.pointerId);
+  }
+
+  onHeroSwipeMove(event: PointerEvent): void {
+    if (event.pointerId !== this.swipePointerId) {
+      return;
+    }
+    const dx = event.clientX - this.swipeStartX;
+    const dy = event.clientY - this.swipeStartY;
+    if (!this.swipeAxis) {
+      if (Math.abs(dx) < 8 && Math.abs(dy) < 8) {
+        return;
+      }
+      this.swipeAxis = Math.abs(dx) >= Math.abs(dy) ? 'x' : 'y';
+      if (this.swipeAxis === 'y') {
+        this.endHeroSwipe();
+        return;
+      }
+    }
+    if (this.swipeAxis === 'x') {
+      event.preventDefault();
+    }
+  }
+
+  onHeroSwipeUp(event: PointerEvent): void {
+    if (event.pointerId !== this.swipePointerId) {
+      return;
+    }
+    const dx = event.clientX - this.swipeStartX;
+    const swiped = this.swipeAxis === 'x' && Math.abs(dx) >= HomepageHeroComponent.swipeThresholdPx;
+    this.endHeroSwipe();
+    if (!swiped) {
+      return;
+    }
+    if (dx < 0) {
+      this.nextHero();
+    } else {
+      this.prevHero();
+    }
+  }
+
+  onHeroSwipeCancel(event: PointerEvent): void {
+    if (event.pointerId !== this.swipePointerId) {
+      return;
+    }
+    this.endHeroSwipe();
+  }
+
+  private endHeroSwipe(): void {
+    this.swipePointerId = null;
+    this.swipeAxis = null;
+  }
+
+  private isSwipeIgnoredTarget(target: EventTarget | null): boolean {
+    if (!(target instanceof Element)) {
+      return false;
+    }
+    return !!target.closest(
+      'a, button, input, textarea, select, [role="tab"], .billboard__pager, .billboard__admin, .billboard__actions'
+    );
   }
 
   /**

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.ts
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.ts
@@ -109,12 +109,18 @@ export class HomepageHeroComponent {
     return text.length > 220 ? `${text.slice(0, 220).trim()}…` : text;
   });
 
+  protected readonly hasFeaturedDesc = computed(() => this.featuredDesc().trim().length > 0);
+
   protected readonly featuredSubjects = computed(() => {
     const subjects = this.featured()?.subjects ?? [];
     // Show every public subject — do not cap rows/count in the hero.
     // Contract: docs/homepage-hero.md § Subjects
     return subjects.filter((s) => !s.startsWith('_'));
   });
+
+  protected readonly hasCopyBody = computed(
+    () => this.hasFeaturedDesc() || this.featuredSubjects().length > 0
+  );
 
   private heroTimer: ReturnType<typeof setInterval> | undefined;
   private heroContentTimer: ReturnType<typeof setTimeout> | undefined;

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.ts
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.ts
@@ -112,6 +112,7 @@ export class HomepageHeroComponent {
   protected readonly featuredSubjects = computed(() => {
     const subjects = this.featured()?.subjects ?? [];
     // Show every public subject — do not cap rows/count in the hero.
+    // Contract: docs/homepage-hero.md § Subjects
     return subjects.filter((s) => !s.startsWith('_'));
   });
 

--- a/cultpodcasts/src/app/image-preview-dialog/image-preview-dialog.component.html
+++ b/cultpodcasts/src/app/image-preview-dialog/image-preview-dialog.component.html
@@ -1,25 +1,59 @@
+@let image = current();
+
 <h2 mat-dialog-title>Episode images</h2>
 
-<mat-dialog-content #scrollHost class="gallery">
-  @for (image of data.images; track image.service) {
-  <section class="gallery__item" [id]="'preview-' + image.service">
-    <header class="gallery__header">
-      @if (image.service === 'apple') {
-      <mat-icon class="gallery__logo" aria-hidden="true">
-        <app-apple-podcasts-svg></app-apple-podcasts-svg>
-      </mat-icon>
-      } @else if (image.service === 'spotify') {
-      <mat-icon class="gallery__logo" svgIcon="spotify" aria-hidden="true"></mat-icon>
-      } @else if (image.service === 'youtube') {
-      <mat-icon class="gallery__logo" svgIcon="youtube" aria-hidden="true"></mat-icon>
-      } @else {
-      <mat-icon class="gallery__logo" svgIcon="cultpodcasts" aria-hidden="true"></mat-icon>
-      }
-      <span class="gallery__label">{{ image.label }}</span>
-      <a matButton class="gallery__open" [href]="image.url" target="_blank" rel="noopener noreferrer">Open</a>
-    </header>
-    <img class="gallery__image" [src]="image.url" [alt]="image.label + ' episode image'" />
-  </section>
+<mat-dialog-content class="carousel" aria-roledescription="carousel" [attr.aria-label]="image.label + ' episode image'">
+  <header class="carousel__header">
+    @if (image.service === 'apple') {
+    <mat-icon class="carousel__logo" aria-hidden="true">
+      <app-apple-podcasts-svg></app-apple-podcasts-svg>
+    </mat-icon>
+    } @else if (image.service === 'spotify') {
+    <mat-icon class="carousel__logo" svgIcon="spotify" aria-hidden="true"></mat-icon>
+    } @else if (image.service === 'youtube') {
+    <mat-icon class="carousel__logo" svgIcon="youtube" aria-hidden="true"></mat-icon>
+    } @else {
+    <mat-icon class="carousel__logo" svgIcon="cultpodcasts" aria-hidden="true"></mat-icon>
+    }
+    <span class="carousel__label">{{ image.label }}</span>
+    <a matButton class="carousel__open" [href]="image.url" target="_blank" rel="noopener noreferrer">Open</a>
+  </header>
+
+  <div class="carousel__stage">
+    @if (hasMultiple()) {
+    <button matIconButton type="button" class="carousel__nav carousel__nav--prev" aria-label="Previous image"
+      (click)="previous()">
+      <mat-icon>chevron_left</mat-icon>
+    </button>
+    }
+    <div class="carousel__frame"
+      [class.carousel__frame--swipeable]="hasMultiple()"
+      [class.is-dragging]="dragging()"
+      (pointerdown)="onPointerDown($event)"
+      (pointermove)="onPointerMove($event)"
+      (pointerup)="onPointerUp($event)"
+      (pointercancel)="onPointerCancel($event)">
+      <img class="carousel__image" draggable="false" [src]="image.url" [alt]="image.label + ' episode image'"
+        [style.transform]="dragPx() ? 'translateX(' + dragPx() + 'px)' : null" />
+    </div>
+    @if (hasMultiple()) {
+    <button matIconButton type="button" class="carousel__nav carousel__nav--next" aria-label="Next image"
+      (click)="next()">
+      <mat-icon>chevron_right</mat-icon>
+    </button>
+    }
+  </div>
+
+  @if (hasMultiple()) {
+  <div class="carousel__dots" role="tablist" aria-label="Episode images">
+    @for (item of data.images; track item.service; let i = $index) {
+    <button type="button" class="carousel__dot" role="tab"
+      [class.is-active]="index() === i"
+      [attr.aria-selected]="index() === i"
+      [attr.aria-label]="'Show ' + item.label + ' image'"
+      (click)="select(i)"></button>
+    }
+  </div>
   }
 </mat-dialog-content>
 

--- a/cultpodcasts/src/app/image-preview-dialog/image-preview-dialog.component.html
+++ b/cultpodcasts/src/app/image-preview-dialog/image-preview-dialog.component.html
@@ -1,10 +1,28 @@
-<h2 mat-dialog-title>Image preview</h2>
+<h2 mat-dialog-title>Episode images</h2>
 
-<mat-dialog-content>
-  <img class="preview" [src]="data.url" [alt]="'Preview of ' + data.url" />
+<mat-dialog-content #scrollHost class="gallery">
+  @for (image of data.images; track image.service) {
+  <section class="gallery__item" [id]="'preview-' + image.service">
+    <header class="gallery__header">
+      @if (image.service === 'apple') {
+      <mat-icon class="gallery__logo" aria-hidden="true">
+        <app-apple-podcasts-svg></app-apple-podcasts-svg>
+      </mat-icon>
+      } @else if (image.service === 'spotify') {
+      <mat-icon class="gallery__logo" svgIcon="spotify" aria-hidden="true"></mat-icon>
+      } @else if (image.service === 'youtube') {
+      <mat-icon class="gallery__logo" svgIcon="youtube" aria-hidden="true"></mat-icon>
+      } @else {
+      <mat-icon class="gallery__logo" svgIcon="cultpodcasts" aria-hidden="true"></mat-icon>
+      }
+      <span class="gallery__label">{{ image.label }}</span>
+      <a matButton class="gallery__open" [href]="image.url" target="_blank" rel="noopener noreferrer">Open</a>
+    </header>
+    <img class="gallery__image" [src]="image.url" [alt]="image.label + ' episode image'" />
+  </section>
+  }
 </mat-dialog-content>
 
 <mat-dialog-actions>
-  <a matButton [href]="data.url" target="_blank" rel="noopener noreferrer">Open</a>
   <button matButton mat-dialog-close type="button">Close</button>
 </mat-dialog-actions>

--- a/cultpodcasts/src/app/image-preview-dialog/image-preview-dialog.component.html
+++ b/cultpodcasts/src/app/image-preview-dialog/image-preview-dialog.component.html
@@ -1,0 +1,10 @@
+<h2 mat-dialog-title>Image preview</h2>
+
+<mat-dialog-content>
+  <img class="preview" [src]="data.url" [alt]="'Preview of ' + data.url" />
+</mat-dialog-content>
+
+<mat-dialog-actions>
+  <a matButton [href]="data.url" target="_blank" rel="noopener noreferrer">Open</a>
+  <button matButton mat-dialog-close type="button">Close</button>
+</mat-dialog-actions>

--- a/cultpodcasts/src/app/image-preview-dialog/image-preview-dialog.component.sass
+++ b/cultpodcasts/src/app/image-preview-dialog/image-preview-dialog.component.sass
@@ -1,5 +1,34 @@
-.preview
-  display: block
-  max-width: 100%
-  max-height: 70vh
-  margin: 0 auto
+.gallery
+  max-height: min(75vh, 720px)
+  overflow: auto
+  padding-top: 4px
+
+  &__item
+    margin-bottom: 20px
+    &:last-child
+      margin-bottom: 0
+
+  &__header
+    display: flex
+    align-items: center
+    gap: 8px
+    margin-bottom: 8px
+
+  &__logo
+    width: 28px
+    height: 28px
+    flex-shrink: 0
+
+  &__label
+    flex: 1
+    font-weight: 500
+
+  &__open
+    flex-shrink: 0
+
+  &__image
+    display: block
+    max-width: 100%
+    max-height: 55vh
+    margin: 0 auto
+    border-radius: 4px

--- a/cultpodcasts/src/app/image-preview-dialog/image-preview-dialog.component.sass
+++ b/cultpodcasts/src/app/image-preview-dialog/image-preview-dialog.component.sass
@@ -1,18 +1,16 @@
-.gallery
-  max-height: min(75vh, 720px)
-  overflow: auto
+.carousel
+  display: flex
+  flex-direction: column
+  gap: 12px
+  max-height: min(80vh, 800px)
+  overflow: hidden
   padding-top: 4px
-
-  &__item
-    margin-bottom: 20px
-    &:last-child
-      margin-bottom: 0
 
   &__header
     display: flex
     align-items: center
     gap: 8px
-    margin-bottom: 8px
+    flex-shrink: 0
 
   &__logo
     width: 28px
@@ -26,9 +24,69 @@
   &__open
     flex-shrink: 0
 
+  &__stage
+    display: flex
+    align-items: center
+    gap: 4px
+    min-height: 0
+    flex: 1
+
+  &__frame
+    flex: 1
+    min-width: 0
+    min-height: 0
+    height: min(60vh, 560px)
+    display: flex
+    align-items: center
+    justify-content: center
+    overflow: hidden
+    user-select: none
+    -webkit-user-select: none
+
+    &--swipeable
+      touch-action: pan-y
+      cursor: grab
+
+    &.is-dragging
+      cursor: grabbing
+      touch-action: none
+
   &__image
     display: block
     max-width: 100%
-    max-height: 55vh
-    margin: 0 auto
+    max-height: 100%
+    width: auto
+    height: auto
+    object-fit: contain
     border-radius: 4px
+    pointer-events: none
+    transition: transform 0.12s ease-out
+
+  &__frame.is-dragging &__image
+    transition: none
+
+  &__nav
+    flex-shrink: 0
+
+  &__dots
+    display: flex
+    justify-content: center
+    gap: 8px
+    flex-shrink: 0
+    padding-bottom: 4px
+
+  &__dot
+    width: 10px
+    height: 10px
+    padding: 0
+    border: none
+    border-radius: 50%
+    background: color-mix(in srgb, currentColor 35%, transparent)
+    cursor: pointer
+
+    &.is-active
+      background: currentColor
+
+    &:focus-visible
+      outline: 2px solid currentColor
+      outline-offset: 2px

--- a/cultpodcasts/src/app/image-preview-dialog/image-preview-dialog.component.sass
+++ b/cultpodcasts/src/app/image-preview-dialog/image-preview-dialog.component.sass
@@ -1,0 +1,5 @@
+.preview
+  display: block
+  max-width: 100%
+  max-height: 70vh
+  margin: 0 auto

--- a/cultpodcasts/src/app/image-preview-dialog/image-preview-dialog.component.ts
+++ b/cultpodcasts/src/app/image-preview-dialog/image-preview-dialog.component.ts
@@ -1,18 +1,34 @@
-import { ChangeDetectionStrategy, Component, Inject } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, ElementRef, Inject, ViewChild } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
+import { MatIconModule } from '@angular/material/icon';
+import { ApplePodcastsSvgComponent } from '../apple-podcasts-svg/apple-podcasts-svg.component';
+import { EpisodeImagePreviewItem, EpisodeImageService } from '../episode-form.util';
 
 export interface ImagePreviewDialogData {
-  url: string;
+  images: EpisodeImagePreviewItem[];
+  /** Service of the field whose preview button was clicked — scrolled into view on open. */
+  initialService?: EpisodeImageService;
 }
 
 @Component({
   selector: 'app-image-preview-dialog',
-  imports: [MatDialogModule, MatButtonModule],
+  imports: [MatDialogModule, MatButtonModule, MatIconModule, ApplePodcastsSvgComponent],
   templateUrl: './image-preview-dialog.component.html',
   styleUrl: './image-preview-dialog.component.sass',
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class ImagePreviewDialogComponent {
+export class ImagePreviewDialogComponent implements AfterViewInit {
+  @ViewChild('scrollHost') private scrollHost?: ElementRef<HTMLElement>;
+
   constructor(@Inject(MAT_DIALOG_DATA) public data: ImagePreviewDialogData) {}
+
+  ngAfterViewInit(): void {
+    const service = this.data.initialService;
+    if (!service || !this.scrollHost) {
+      return;
+    }
+    const target = this.scrollHost.nativeElement.querySelector<HTMLElement>(`#preview-${service}`);
+    target?.scrollIntoView({ block: 'start', behavior: 'auto' });
+  }
 }

--- a/cultpodcasts/src/app/image-preview-dialog/image-preview-dialog.component.ts
+++ b/cultpodcasts/src/app/image-preview-dialog/image-preview-dialog.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, ChangeDetectionStrategy, Component, ElementRef, Inject, ViewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Inject, computed, signal } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
 import { MatIconModule } from '@angular/material/icon';
@@ -7,7 +7,7 @@ import { EpisodeImagePreviewItem, EpisodeImageService } from '../episode-form.ut
 
 export interface ImagePreviewDialogData {
   images: EpisodeImagePreviewItem[];
-  /** Service of the field whose preview button was clicked — scrolled into view on open. */
+  /** Service of the field whose preview button was clicked — shown first. */
   initialService?: EpisodeImageService;
 }
 
@@ -16,19 +16,136 @@ export interface ImagePreviewDialogData {
   imports: [MatDialogModule, MatButtonModule, MatIconModule, ApplePodcastsSvgComponent],
   templateUrl: './image-preview-dialog.component.html',
   styleUrl: './image-preview-dialog.component.sass',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    '(document:keydown)': 'onKeydown($event)'
+  }
 })
-export class ImagePreviewDialogComponent implements AfterViewInit {
-  @ViewChild('scrollHost') private scrollHost?: ElementRef<HTMLElement>;
+export class ImagePreviewDialogComponent {
+  private static readonly SWIPE_THRESHOLD_PX = 48;
 
-  constructor(@Inject(MAT_DIALOG_DATA) public data: ImagePreviewDialogData) {}
+  protected readonly index = signal(0);
+  protected readonly dragging = signal(false);
+  protected readonly dragPx = signal(0);
 
-  ngAfterViewInit(): void {
-    const service = this.data.initialService;
-    if (!service || !this.scrollHost) {
+  protected readonly current = computed(() => this.data.images[this.index()] ?? this.data.images[0]);
+
+  protected readonly hasMultiple = computed(() => this.data.images.length > 1);
+
+  private pointerId: number | null = null;
+  private startX = 0;
+  private startY = 0;
+  private axisLocked: 'x' | 'y' | null = null;
+
+  constructor(@Inject(MAT_DIALOG_DATA) public data: ImagePreviewDialogData) {
+    const service = data.initialService;
+    if (service) {
+      const i = data.images.findIndex((img) => img.service === service);
+      if (i >= 0) {
+        this.index.set(i);
+      }
+    }
+  }
+
+  previous(): void {
+    const n = this.data.images.length;
+    if (n < 2) {
       return;
     }
-    const target = this.scrollHost.nativeElement.querySelector<HTMLElement>(`#preview-${service}`);
-    target?.scrollIntoView({ block: 'start', behavior: 'auto' });
+    this.index.update((i) => (i - 1 + n) % n);
+  }
+
+  next(): void {
+    const n = this.data.images.length;
+    if (n < 2) {
+      return;
+    }
+    this.index.update((i) => (i + 1) % n);
+  }
+
+  select(i: number): void {
+    if (i >= 0 && i < this.data.images.length) {
+      this.index.set(i);
+    }
+  }
+
+  onKeydown(event: KeyboardEvent): void {
+    if (event.key === 'ArrowLeft') {
+      event.preventDefault();
+      this.previous();
+    } else if (event.key === 'ArrowRight') {
+      event.preventDefault();
+      this.next();
+    }
+  }
+
+  onPointerDown(event: PointerEvent): void {
+    if (!this.hasMultiple()) {
+      return;
+    }
+    if (event.pointerType === 'mouse' && event.button !== 0) {
+      return;
+    }
+    this.pointerId = event.pointerId;
+    this.startX = event.clientX;
+    this.startY = event.clientY;
+    this.axisLocked = null;
+    this.dragging.set(true);
+    this.dragPx.set(0);
+    (event.currentTarget as HTMLElement).setPointerCapture?.(event.pointerId);
+  }
+
+  onPointerMove(event: PointerEvent): void {
+    if (!this.dragging() || event.pointerId !== this.pointerId) {
+      return;
+    }
+    const dx = event.clientX - this.startX;
+    const dy = event.clientY - this.startY;
+    if (!this.axisLocked) {
+      if (Math.abs(dx) < 8 && Math.abs(dy) < 8) {
+        return;
+      }
+      this.axisLocked = Math.abs(dx) >= Math.abs(dy) ? 'x' : 'y';
+      if (this.axisLocked === 'y') {
+        this.endDrag();
+        return;
+      }
+    }
+    if (this.axisLocked !== 'x') {
+      return;
+    }
+    event.preventDefault();
+    this.dragPx.set(dx);
+  }
+
+  onPointerUp(event: PointerEvent): void {
+    if (event.pointerId !== this.pointerId) {
+      return;
+    }
+    const dx = this.dragPx();
+    const swiped = this.axisLocked === 'x' && Math.abs(dx) >= ImagePreviewDialogComponent.SWIPE_THRESHOLD_PX;
+    this.endDrag();
+    if (!swiped) {
+      return;
+    }
+    if (dx < 0) {
+      this.next();
+    } else {
+      this.previous();
+    }
+  }
+
+  onPointerCancel(event: PointerEvent): void {
+    if (event.pointerId !== this.pointerId) {
+      return;
+    }
+    this.endDrag();
+  }
+
+  private endDrag(): void {
+    this.pointerId = null;
+    this.axisLocked = null;
+    this.dragging.set(false);
+    this.dragPx.set(0);
   }
 }

--- a/cultpodcasts/src/app/image-preview-dialog/image-preview-dialog.component.ts
+++ b/cultpodcasts/src/app/image-preview-dialog/image-preview-dialog.component.ts
@@ -1,0 +1,18 @@
+import { ChangeDetectionStrategy, Component, Inject } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
+
+export interface ImagePreviewDialogData {
+  url: string;
+}
+
+@Component({
+  selector: 'app-image-preview-dialog',
+  imports: [MatDialogModule, MatButtonModule],
+  templateUrl: './image-preview-dialog.component.html',
+  styleUrl: './image-preview-dialog.component.sass',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class ImagePreviewDialogComponent {
+  constructor(@Inject(MAT_DIALOG_DATA) public data: ImagePreviewDialogData) {}
+}

--- a/cultpodcasts/tools/install-git-hooks.cjs
+++ b/cultpodcasts/tools/install-git-hooks.cjs
@@ -1,0 +1,25 @@
+/**
+ * Point this clone's git hooksPath at repo .githooks/ (pre-push runs test:all).
+ * Safe no-op when not inside a git checkout.
+ */
+const { execSync } = require("node:child_process");
+const { existsSync } = require("node:fs");
+const { join } = require("node:path");
+
+try {
+  const root = execSync("git rev-parse --show-toplevel", {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  }).trim();
+  const hooksDir = join(root, ".githooks");
+  if (!existsSync(hooksDir)) {
+    return;
+  }
+  execSync("git config core.hooksPath .githooks", {
+    cwd: root,
+    stdio: "inherit",
+  });
+  console.log("git hooksPath -> .githooks (pre-push runs cultpodcasts test:all)");
+} catch {
+  // npm ci in a tarball / non-git context
+}

--- a/cultpodcasts/tsconfig.spec.json
+++ b/cultpodcasts/tsconfig.spec.json
@@ -4,7 +4,8 @@
   "compilerOptions": {
     "outDir": "./out-tsc/spec",
     "types": [
-      "vitest/globals"
+      "vitest/globals",
+      "node"
     ]
   },
   "include": [


### PR DESCRIPTION
## Summary
- Edit-episode Bluesky: status + Remove/Undo (`unBluesky` on save); cannot mark posted from edit/add
- Episode URL/image fields: open/preview + clear
- Homepage day rails from full week on first paint
- Version **1.10.84**. Pairs with Azure #954 / Api #135

## Test plan
- [x] Not posted: Not posted to Bluesky; cannot mark posted
- [x] Posted: Remove then Submit un-posts Bluesky
- [ ] URL Open / image Preview / Clear work on edit and add
- [x] Homepage day rails without scrolling

Supersedes #469 #470 #472.
