### PR TITLE
fix(ui): open/preview/clear actions on episode URL and image fields

### DIFF
--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.82",
+  "version": "1.10.84",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.10.82",
+      "version": "1.10.84",
       "dependencies": {
         "@angular/cdk": "22.1.0",
         "@angular/common": "22.1.0",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.82",
+  "version": "1.10.84",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/src/app/add-episode-dialog/add-episode-dialog.component.html
+++ b/cultpodcasts/src/app/add-episode-dialog/add-episode-dialog.component.html
@@ -39,14 +39,44 @@
                 <mat-form-field class="full-width">
                     <mat-label>Spotify</mat-label>
                     <input type="text" [formControl]="form()!.controls.spotify" matInput>
+                    <button type="button" matIconButton matSuffix aria-label="Open Spotify URL"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.spotify.value)"
+                        (click)="openExternalUrl(form()!.controls.spotify.value)">
+                        <mat-icon>open_in_new</mat-icon>
+                    </button>
+                    <button type="button" matIconButton matSuffix aria-label="Remove Spotify URL"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.spotify.value)"
+                        (click)="clearField(form()!.controls.spotify)">
+                        <mat-icon>clear</mat-icon>
+                    </button>
                 </mat-form-field>
                 <mat-form-field class="full-width">
                     <mat-label>Apple</mat-label>
                     <input type="text" [formControl]="form()!.controls.apple" matInput>
+                    <button type="button" matIconButton matSuffix aria-label="Open Apple URL"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.apple.value)"
+                        (click)="openExternalUrl(form()!.controls.apple.value)">
+                        <mat-icon>open_in_new</mat-icon>
+                    </button>
+                    <button type="button" matIconButton matSuffix aria-label="Remove Apple URL"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.apple.value)"
+                        (click)="clearField(form()!.controls.apple)">
+                        <mat-icon>clear</mat-icon>
+                    </button>
                 </mat-form-field>
                 <mat-form-field class="full-width">
                     <mat-label>YouTube</mat-label>
                     <input type="text" [formControl]="form()!.controls.youtube" matInput>
+                    <button type="button" matIconButton matSuffix aria-label="Open YouTube URL"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.youtube.value)"
+                        (click)="openExternalUrl(form()!.controls.youtube.value)">
+                        <mat-icon>open_in_new</mat-icon>
+                    </button>
+                    <button type="button" matIconButton matSuffix aria-label="Remove YouTube URL"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.youtube.value)"
+                        (click)="clearField(form()!.controls.youtube)">
+                        <mat-icon>clear</mat-icon>
+                    </button>
                 </mat-form-field>
                 <mat-accordion>
                     <mat-expansion-panel>
@@ -56,10 +86,30 @@
                         <mat-form-field class="full-width">
                     <mat-label>BBC</mat-label>
                     <input type="text" [formControl]="form()!.controls.bbc" matInput>
+                    <button type="button" matIconButton matSuffix aria-label="Open BBC URL"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.bbc.value)"
+                        (click)="openExternalUrl(form()!.controls.bbc.value)">
+                        <mat-icon>open_in_new</mat-icon>
+                    </button>
+                    <button type="button" matIconButton matSuffix aria-label="Remove BBC URL"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.bbc.value)"
+                        (click)="clearField(form()!.controls.bbc)">
+                        <mat-icon>clear</mat-icon>
+                    </button>
                 </mat-form-field>
                         <mat-form-field class="full-width">
                     <mat-label>Internet Archive</mat-label>
                     <input type="text" [formControl]="form()!.controls.internetArchive" matInput>
+                    <button type="button" matIconButton matSuffix aria-label="Open Internet Archive URL"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.internetArchive.value)"
+                        (click)="openExternalUrl(form()!.controls.internetArchive.value)">
+                        <mat-icon>open_in_new</mat-icon>
+                    </button>
+                    <button type="button" matIconButton matSuffix aria-label="Remove Internet Archive URL"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.internetArchive.value)"
+                        (click)="clearField(form()!.controls.internetArchive)">
+                        <mat-icon>clear</mat-icon>
+                    </button>
                 </mat-form-field>
                     </mat-expansion-panel>
                 </mat-accordion>
@@ -68,18 +118,58 @@
                 <mat-form-field class="full-width">
                     <mat-label>Spotify</mat-label>
                     <input type="text" [formControl]="form()!.controls.spotifyImage" matInput>
+                    <button type="button" matIconButton matSuffix aria-label="Preview Spotify image"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.spotifyImage.value)"
+                        (click)="previewImage(form()!.controls.spotifyImage.value)">
+                        <mat-icon>visibility</mat-icon>
+                    </button>
+                    <button type="button" matIconButton matSuffix aria-label="Remove Spotify image"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.spotifyImage.value)"
+                        (click)="clearField(form()!.controls.spotifyImage)">
+                        <mat-icon>clear</mat-icon>
+                    </button>
                 </mat-form-field>
                 <mat-form-field class="full-width">
                     <mat-label>Apple</mat-label>
                     <input type="text" [formControl]="form()!.controls.appleImage" matInput>
+                    <button type="button" matIconButton matSuffix aria-label="Preview Apple image"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.appleImage.value)"
+                        (click)="previewImage(form()!.controls.appleImage.value)">
+                        <mat-icon>visibility</mat-icon>
+                    </button>
+                    <button type="button" matIconButton matSuffix aria-label="Remove Apple image"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.appleImage.value)"
+                        (click)="clearField(form()!.controls.appleImage)">
+                        <mat-icon>clear</mat-icon>
+                    </button>
                 </mat-form-field>
                 <mat-form-field class="full-width">
                     <mat-label>YouTube</mat-label>
                     <input type="text" [formControl]="form()!.controls.youtubeImage" matInput>
+                    <button type="button" matIconButton matSuffix aria-label="Preview YouTube image"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.youtubeImage.value)"
+                        (click)="previewImage(form()!.controls.youtubeImage.value)">
+                        <mat-icon>visibility</mat-icon>
+                    </button>
+                    <button type="button" matIconButton matSuffix aria-label="Remove YouTube image"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.youtubeImage.value)"
+                        (click)="clearField(form()!.controls.youtubeImage)">
+                        <mat-icon>clear</mat-icon>
+                    </button>
                 </mat-form-field>
                 <mat-form-field class="full-width">
                     <mat-label>Other</mat-label>
                     <input type="text" [formControl]="form()!.controls.otherImage" matInput>
+                    <button type="button" matIconButton matSuffix aria-label="Preview other image"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.otherImage.value)"
+                        (click)="previewImage(form()!.controls.otherImage.value)">
+                        <mat-icon>visibility</mat-icon>
+                    </button>
+                    <button type="button" matIconButton matSuffix aria-label="Remove other image"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.otherImage.value)"
+                        (click)="clearField(form()!.controls.otherImage)">
+                        <mat-icon>clear</mat-icon>
+                    </button>
                 </mat-form-field>
             </mat-tab>
             <mat-tab label="Meta">

--- a/cultpodcasts/src/app/add-episode-dialog/add-episode-dialog.component.ts
+++ b/cultpodcasts/src/app/add-episode-dialog/add-episode-dialog.component.ts
@@ -10,7 +10,7 @@ import { Person } from '../person.interface';
 import { PersonMatch } from '../person-match.interface';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatButtonModule } from '@angular/material/button';
-import { FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { EpisodeForm } from '../episode-form.interface';
 import { MatTabsModule } from '@angular/material/tabs';
 import { MatSelectModule } from '@angular/material/select';
@@ -30,11 +30,16 @@ import { EditPersonDialogComponent } from '../edit-person-dialog/edit-person-dia
 import { comparePeopleBySortKey } from '../person-sort';
 import { FeatureSwitch } from '../feature-switch.enum';
 import { FeatureSwitchService } from '../feature-switch-service';
+import { MatIconModule } from '@angular/material/icon';
+import { ImagePreviewDialogComponent } from '../image-preview-dialog/image-preview-dialog.component';
 import {
   buildEpisodeForm,
+  clearFormControl,
   getEpisodeChanges,
+  hasNonEmptyUrlValue,
   mergeEpisodeSubjects,
   noCompareFunction,
+  openExternalUrl,
   personLabel,
   regroupGuests as regroupGuestsPure,
   regroupSubjects as regroupSubjectsPure
@@ -56,7 +61,8 @@ import {
     MatInputModule,
     MatCheckboxModule,
     KeyValuePipe,
-    MatDividerModule
+    MatDividerModule,
+    MatIconModule
   ],
   templateUrl: './add-episode-dialog.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -69,6 +75,8 @@ export class AddEpisodeDialogComponent {
     && window.matchMedia('(hover: hover) and (pointer: fine)').matches;
   protected readonly personLabel = personLabel;
   protected readonly noCompareFunction = noCompareFunction;
+  protected readonly hasNonEmptyUrlValue = hasNonEmptyUrlValue;
+  protected readonly openExternalUrl = openExternalUrl;
 
   episodeId: string;
   podcastName: string | undefined;
@@ -170,6 +178,21 @@ export class AddEpisodeDialogComponent {
           episodeLangUnset: this.isEpisodeLanguageUnset(),
           ...this.getNewPodcastDialogDefaults()
         });
+  }
+
+  clearField(control: FormControl<string | URL | null>) {
+    clearFormControl(control);
+  }
+
+  previewImage(value: string | URL | null | undefined) {
+    const url = value instanceof URL ? value.toString() : value?.trim();
+    if (!url) {
+      return;
+    }
+    this.dialog.open(ImagePreviewDialogComponent, {
+      data: { url },
+      maxWidth: '90vw'
+    });
   }
 
   onSubmit() {

--- a/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.html
+++ b/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.html
@@ -39,14 +39,44 @@
                 <mat-form-field class="full-width">
                     <mat-label>Spotify</mat-label>
                     <input type="text" [formControl]="form()!.controls.spotify" matInput>
+                    <button type="button" matIconButton matSuffix aria-label="Open Spotify URL"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.spotify.value)"
+                        (click)="openExternalUrl(form()!.controls.spotify.value)">
+                        <mat-icon>open_in_new</mat-icon>
+                    </button>
+                    <button type="button" matIconButton matSuffix aria-label="Remove Spotify URL"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.spotify.value)"
+                        (click)="clearField(form()!.controls.spotify)">
+                        <mat-icon>clear</mat-icon>
+                    </button>
                 </mat-form-field>
                 <mat-form-field class="full-width">
                     <mat-label>Apple</mat-label>
                     <input type="text" [formControl]="form()!.controls.apple" matInput>
+                    <button type="button" matIconButton matSuffix aria-label="Open Apple URL"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.apple.value)"
+                        (click)="openExternalUrl(form()!.controls.apple.value)">
+                        <mat-icon>open_in_new</mat-icon>
+                    </button>
+                    <button type="button" matIconButton matSuffix aria-label="Remove Apple URL"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.apple.value)"
+                        (click)="clearField(form()!.controls.apple)">
+                        <mat-icon>clear</mat-icon>
+                    </button>
                 </mat-form-field>
                 <mat-form-field class="full-width">
                     <mat-label>YouTube</mat-label>
                     <input type="text" [formControl]="form()!.controls.youtube" matInput>
+                    <button type="button" matIconButton matSuffix aria-label="Open YouTube URL"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.youtube.value)"
+                        (click)="openExternalUrl(form()!.controls.youtube.value)">
+                        <mat-icon>open_in_new</mat-icon>
+                    </button>
+                    <button type="button" matIconButton matSuffix aria-label="Remove YouTube URL"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.youtube.value)"
+                        (click)="clearField(form()!.controls.youtube)">
+                        <mat-icon>clear</mat-icon>
+                    </button>
                 </mat-form-field>
                 <mat-accordion>
                     <mat-expansion-panel>
@@ -56,10 +86,30 @@
                         <mat-form-field class="full-width">
                     <mat-label>BBC</mat-label>
                     <input type="text" [formControl]="form()!.controls.bbc" matInput>
+                    <button type="button" matIconButton matSuffix aria-label="Open BBC URL"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.bbc.value)"
+                        (click)="openExternalUrl(form()!.controls.bbc.value)">
+                        <mat-icon>open_in_new</mat-icon>
+                    </button>
+                    <button type="button" matIconButton matSuffix aria-label="Remove BBC URL"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.bbc.value)"
+                        (click)="clearField(form()!.controls.bbc)">
+                        <mat-icon>clear</mat-icon>
+                    </button>
                 </mat-form-field>
                         <mat-form-field class="full-width">
                     <mat-label>Internet Archive</mat-label>
                     <input type="text" [formControl]="form()!.controls.internetArchive" matInput>
+                    <button type="button" matIconButton matSuffix aria-label="Open Internet Archive URL"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.internetArchive.value)"
+                        (click)="openExternalUrl(form()!.controls.internetArchive.value)">
+                        <mat-icon>open_in_new</mat-icon>
+                    </button>
+                    <button type="button" matIconButton matSuffix aria-label="Remove Internet Archive URL"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.internetArchive.value)"
+                        (click)="clearField(form()!.controls.internetArchive)">
+                        <mat-icon>clear</mat-icon>
+                    </button>
                 </mat-form-field>
                     </mat-expansion-panel>
                 </mat-accordion>
@@ -123,18 +173,58 @@
                 <mat-form-field class="full-width">
                     <mat-label>Spotify</mat-label>
                     <input type="text" [formControl]="form()!.controls.spotifyImage" matInput>
+                    <button type="button" matIconButton matSuffix aria-label="Preview Spotify image"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.spotifyImage.value)"
+                        (click)="previewImage(form()!.controls.spotifyImage.value)">
+                        <mat-icon>visibility</mat-icon>
+                    </button>
+                    <button type="button" matIconButton matSuffix aria-label="Remove Spotify image"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.spotifyImage.value)"
+                        (click)="clearField(form()!.controls.spotifyImage)">
+                        <mat-icon>clear</mat-icon>
+                    </button>
                 </mat-form-field>
                 <mat-form-field class="full-width">
                     <mat-label>Apple</mat-label>
                     <input type="text" [formControl]="form()!.controls.appleImage" matInput>
+                    <button type="button" matIconButton matSuffix aria-label="Preview Apple image"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.appleImage.value)"
+                        (click)="previewImage(form()!.controls.appleImage.value)">
+                        <mat-icon>visibility</mat-icon>
+                    </button>
+                    <button type="button" matIconButton matSuffix aria-label="Remove Apple image"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.appleImage.value)"
+                        (click)="clearField(form()!.controls.appleImage)">
+                        <mat-icon>clear</mat-icon>
+                    </button>
                 </mat-form-field>
                 <mat-form-field class="full-width">
                     <mat-label>YouTube</mat-label>
                     <input type="text" [formControl]="form()!.controls.youtubeImage" matInput>
+                    <button type="button" matIconButton matSuffix aria-label="Preview YouTube image"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.youtubeImage.value)"
+                        (click)="previewImage(form()!.controls.youtubeImage.value)">
+                        <mat-icon>visibility</mat-icon>
+                    </button>
+                    <button type="button" matIconButton matSuffix aria-label="Remove YouTube image"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.youtubeImage.value)"
+                        (click)="clearField(form()!.controls.youtubeImage)">
+                        <mat-icon>clear</mat-icon>
+                    </button>
                 </mat-form-field>
                 <mat-form-field class="full-width">
                     <mat-label>Other</mat-label>
                     <input type="text" [formControl]="form()!.controls.otherImage" matInput>
+                    <button type="button" matIconButton matSuffix aria-label="Preview other image"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.otherImage.value)"
+                        (click)="previewImage(form()!.controls.otherImage.value)">
+                        <mat-icon>visibility</mat-icon>
+                    </button>
+                    <button type="button" matIconButton matSuffix aria-label="Remove other image"
+                        [disabled]="!hasNonEmptyUrlValue(form()!.controls.otherImage.value)"
+                        (click)="clearField(form()!.controls.otherImage)">
+                        <mat-icon>clear</mat-icon>
+                    </button>
                 </mat-form-field>
             </mat-tab>
             <mat-tab label="Guests">

--- a/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.ts
+++ b/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.ts
@@ -12,7 +12,7 @@ import { Person } from '../person.interface';
 import { PersonMatch } from '../person-match.interface';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatButtonModule } from '@angular/material/button';
-import { FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { EpisodeForm } from '../episode-form.interface';
 import { MatTabsModule } from '@angular/material/tabs';
 import { MatSelectModule } from '@angular/material/select';
@@ -31,11 +31,16 @@ import { EditPersonDialogComponent } from '../edit-person-dialog/edit-person-dia
 import { comparePeopleBySortKey } from '../person-sort';
 import { FeatureSwitch } from '../feature-switch.enum';
 import { FeatureSwitchService } from '../feature-switch-service';
+import { MatIconModule } from '@angular/material/icon';
+import { ImagePreviewDialogComponent } from '../image-preview-dialog/image-preview-dialog.component';
 import {
   buildEpisodeForm,
+  clearFormControl,
   getEpisodeChanges,
+  hasNonEmptyUrlValue,
   mergeEpisodeSubjects,
   noCompareFunction,
+  openExternalUrl,
   personLabel,
   regroupGuests as regroupGuestsPure,
   regroupSubjects as regroupSubjectsPure
@@ -57,7 +62,8 @@ import {
     MatInputModule,
     MatCheckboxModule,
     KeyValuePipe,
-    MatDividerModule
+    MatDividerModule,
+    MatIconModule
   ],
   templateUrl: './edit-episode-dialog.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -70,6 +76,8 @@ export class EditEpisodeDialogComponent {
     && window.matchMedia('(hover: hover) and (pointer: fine)').matches;
   protected readonly personLabel = personLabel;
   protected readonly noCompareFunction = noCompareFunction;
+  protected readonly hasNonEmptyUrlValue = hasNonEmptyUrlValue;
+  protected readonly openExternalUrl = openExternalUrl;
 
   episodeId: string;
   podcastIdentifier: string;
@@ -163,6 +171,21 @@ export class EditEpisodeDialogComponent {
 
   close() {
     this.dialogRef.close({ closed: true });
+  }
+
+  clearField(control: FormControl<string | URL | null>) {
+    clearFormControl(control);
+  }
+
+  previewImage(value: string | URL | null | undefined) {
+    const url = value instanceof URL ? value.toString() : value?.trim();
+    if (!url) {
+      return;
+    }
+    this.dialog.open(ImagePreviewDialogComponent, {
+      data: { url },
+      maxWidth: '90vw'
+    });
   }
 
   onSubmit() {

--- a/cultpodcasts/src/app/episode-form.util.ts
+++ b/cultpodcasts/src/app/episode-form.util.ts
@@ -26,6 +26,36 @@ export function noCompareFunction(): number {
   return 0;
 }
 
+export function hasNonEmptyUrlValue(value: string | URL | null | undefined): boolean {
+  if (value instanceof URL) {
+    return true;
+  }
+  return !!value?.trim();
+}
+
+/** Opens a trimmed absolute URL in a new tab; no-ops on blank or invalid values. */
+export function openExternalUrl(value: string | URL | null | undefined): void {
+  if (value instanceof URL) {
+    window.open(value.toString(), '_blank', 'noopener,noreferrer');
+    return;
+  }
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return;
+  }
+  try {
+    const url = new URL(trimmed);
+    window.open(url.toString(), '_blank', 'noopener,noreferrer');
+  } catch {
+    // Invalid URL — leave the field as-is for the curator to fix.
+  }
+}
+
+export function clearFormControl(control: FormControl<string | URL | null>): void {
+  control.setValue(null);
+  control.markAsDirty();
+}
+
 export function personLabel(person: Person): string {
   const handles = [person.twitterHandle, person.blueskyHandle].filter(x => !!x).join(' ');
   return handles ? `${person.name} (${handles})` : person.name;

--- a/cultpodcasts/src/app/image-preview-dialog/image-preview-dialog.component.html
+++ b/cultpodcasts/src/app/image-preview-dialog/image-preview-dialog.component.html
@@ -1,0 +1,10 @@
+<h2 mat-dialog-title>Image preview</h2>
+
+<mat-dialog-content>
+  <img class="preview" [src]="data.url" [alt]="'Preview of ' + data.url" />
+</mat-dialog-content>
+
+<mat-dialog-actions>
+  <a matButton [href]="data.url" target="_blank" rel="noopener noreferrer">Open</a>
+  <button matButton mat-dialog-close type="button">Close</button>
+</mat-dialog-actions>

--- a/cultpodcasts/src/app/image-preview-dialog/image-preview-dialog.component.sass
+++ b/cultpodcasts/src/app/image-preview-dialog/image-preview-dialog.component.sass
@@ -1,0 +1,5 @@
+.preview
+  display: block
+  max-width: 100%
+  max-height: 70vh
+  margin: 0 auto

--- a/cultpodcasts/src/app/image-preview-dialog/image-preview-dialog.component.ts
+++ b/cultpodcasts/src/app/image-preview-dialog/image-preview-dialog.component.ts
@@ -1,0 +1,18 @@
+import { ChangeDetectionStrategy, Component, Inject } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
+
+export interface ImagePreviewDialogData {
+  url: string;
+}
+
+@Component({
+  selector: 'app-image-preview-dialog',
+  imports: [MatDialogModule, MatButtonModule],
+  templateUrl: './image-preview-dialog.component.html',
+  styleUrl: './image-preview-dialog.component.sass',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class ImagePreviewDialogComponent {
+  constructor(@Inject(MAT_DIALOG_DATA) public data: ImagePreviewDialogData) {}
+}


### PR DESCRIPTION
## Summary
- Episode URL fields: open in new tab + clear
- Episode image fields: preview dialog + clear
- Same chrome on edit and add episode dialogs
- Bump to **1.10.84** (after #471 at 1.10.83)

## Test plan
- [ ] Non-empty URL: Open works; Clear empties field
- [ ] Empty URL/image: suffix buttons disabled
- [ ] Image Preview shows dialog; Open/Close work
- [ ] Clearing a previously set URL/image and submit sends empty-string clear


Made with [Cursor](https://cursor.com)