### PR TITLE
Admin UI: language ignored subjects dialog

### DIFF
--- a/cultpodcasts/src/app/language-ignored-subjects/language-ignored-subjects.component.html
+++ b/cultpodcasts/src/app/language-ignored-subjects/language-ignored-subjects.component.html
@@ -1,0 +1,112 @@
+<h2 mat-dialog-title>Language ignored subjects</h2>
+
+<mat-dialog-content>
+  @if (isInError()) {
+  <p id="error">{{ errorMessage() || "An error occurred" }}</p>
+  }
+
+  @if (isDefault() && !isLoading()) {
+  <p class="default-note">Showing code defaults — no Cosmos document yet. The first add will persist them.</p>
+  }
+
+  @if (languageOptions().length > 0) {
+  <div class="language-row">
+    <mat-form-field class="language-select" subscriptSizing="dynamic">
+      <mat-label>Language</mat-label>
+      <mat-select
+        [value]="selectedLanguage()"
+        (valueChange)="onLanguageChange($event)"
+        [disabled]="isLoading() || isMutating()">
+        @for (lang of languageOptions(); track lang.code) {
+        <mat-option [value]="lang.code">{{ lang.name }} ({{ lang.code }})</mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
+  </div>
+  } @else if (!isLoading()) {
+  <p class="empty">No non-English supported languages.</p>
+  }
+
+  <div class="rules-body" [class.is-busy]="isLoading() || isMutating()">
+    @if (isLoading() || isMutating()) {
+    <div class="busy-overlay" aria-busy="true">
+      <mat-spinner class="dialog-spinner" mode="indeterminate"></mat-spinner>
+    </div>
+    }
+
+    @if (selectedLanguage()) {
+    <section class="add-panel">
+      <p class="add-hint">Subjects to skip during enrichment for this language</p>
+      @if (addError()) {
+      <p class="add-error">{{ addError() }}</p>
+      }
+      <div class="add-row">
+        <mat-form-field class="grow" subscriptSizing="dynamic">
+          <mat-label>Subject</mat-label>
+          <input
+            matInput
+            type="text"
+            [ngModel]="newSubject()"
+            (ngModelChange)="newSubject.set($event)"
+            [matAutocomplete]="subjectAuto"
+            (keydown.enter)="addIgnoredSubject()"
+            autocomplete="off">
+          <mat-autocomplete #subjectAuto="matAutocomplete" (optionSelected)="newSubject.set($event.option.value)">
+            @for (name of pickerSubjects(); track name) {
+            <mat-option [value]="name">{{ name }}</mat-option>
+            }
+          </mat-autocomplete>
+        </mat-form-field>
+        <button
+          mat-flat-button
+          color="primary"
+          type="button"
+          [disabled]="!newSubject().trim() || isMutating()"
+          (click)="addIgnoredSubject()">
+          Add
+        </button>
+      </div>
+    </section>
+
+    <section class="existing-panel">
+      <div class="existing-header">
+        <h3>Ignored <span class="tab-count">{{ ignoredSubjects().length }}</span></h3>
+        @if (ignoredSubjects().length > 0) {
+        <mat-form-field class="filter-field" subscriptSizing="dynamic">
+          <mat-label>Find</mat-label>
+          <input matInput type="search" [ngModel]="subjectFilter()" (ngModelChange)="subjectFilter.set($event)" autocomplete="off">
+        </mat-form-field>
+        }
+      </div>
+
+      @if (ignoredSubjects().length === 0) {
+      <p class="empty">None yet — first add creates the language rules document for {{ selectedLanguage() }}.</p>
+      } @else if (filteredIgnoredSubjects().length === 0) {
+      <p class="empty">No matches for “{{ subjectFilter() }}”.</p>
+      } @else {
+      <ul class="term-list">
+        @for (item of filteredIgnoredSubjects(); track item.term) {
+        <li>
+          <span class="term-text">{{ item.term }}</span>
+          <span class="term-actions">
+            <button
+              mat-icon-button
+              type="button"
+              aria-label="Remove ignored subject"
+              [disabled]="isMutating()"
+              (click)="deleteIgnoredSubject(item.index)">
+              <mat-icon class="material-symbols-outlined">delete</mat-icon>
+            </button>
+          </span>
+        </li>
+        }
+      </ul>
+      }
+    </section>
+    }
+  </div>
+</mat-dialog-content>
+
+<mat-dialog-actions>
+  <button mat-raised-button (click)="close()" [disabled]="isMutating()">Close</button>
+</mat-dialog-actions>

--- a/cultpodcasts/src/app/language-ignored-subjects/language-ignored-subjects.component.sass
+++ b/cultpodcasts/src/app/language-ignored-subjects/language-ignored-subjects.component.sass
@@ -1,0 +1,145 @@
+#error
+  font-size: 1em
+  color: #b00020
+
+.default-note
+  font-size: 0.9em
+  margin: 0 0 0.75em
+  color: #6a4c00
+
+.add-error
+  font-size: 0.9em
+  margin: 0 0 0.5em
+  color: #b00020
+
+:host
+  ::ng-deep .mat-mdc-dialog-content
+    overflow-x: hidden
+    overflow-y: auto
+    padding-top: 1em
+
+.language-row
+  display: flex
+  align-items: center
+  gap: 0.75em
+  flex-wrap: wrap
+  padding-top: 0.35em
+  margin-bottom: 0.25em
+
+.language-select
+  width: 100%
+  max-width: 24em
+  flex: 1 1 14em
+  margin-top: 0.25em
+
+.rules-body
+  position: relative
+  min-height: 14em
+
+  &.is-busy > :not(.busy-overlay)
+    opacity: 0.45
+    pointer-events: none
+
+.busy-overlay
+  position: absolute
+  inset: 0
+  z-index: 2
+  display: flex
+  align-items: center
+  justify-content: center
+  background: rgba(0, 0, 0, 0.12)
+
+.dialog-spinner
+  display: block
+  margin: 0
+
+.tab-count
+  margin-left: 0.4em
+  opacity: 0.65
+  font-size: 0.85em
+
+.add-panel
+  margin: 1em 0 1.25em
+  padding: 0.85em 1em
+  border: 1px solid rgba(128, 128, 128, 0.35)
+  border-radius: 6px
+  background: rgba(128, 128, 128, 0.08)
+
+  .add-hint
+    margin: 0 0 0.75em
+    font-size: 0.9em
+    opacity: 0.85
+
+.add-row
+  display: flex
+  gap: 0.75em
+  align-items: flex-start
+
+.grow
+  flex: 1
+  min-width: 0
+
+.existing-panel
+  margin-top: 0.25em
+
+.existing-header
+  display: flex
+  align-items: center
+  justify-content: space-between
+  gap: 0.75em
+  margin-bottom: 0.5em
+
+  h3
+    margin: 0
+    font-size: 0.95em
+    font-weight: 600
+    opacity: 0.8
+
+.filter-field
+  width: 12em
+  max-width: 45%
+
+.empty
+  font-size: 0.9em
+  margin: 0.5em 0 0
+  opacity: 0.7
+
+.term-list
+  margin: 0
+  padding: 0.85em 0.35em 0.75em 0
+  list-style: none
+  max-height: 22em
+  overflow-x: hidden
+  overflow-y: auto
+  scrollbar-gutter: stable
+
+  li
+    display: flex
+    align-items: center
+    gap: 0.25em
+    min-height: 2.5em
+    min-width: 0
+    max-width: 100%
+    box-sizing: border-box
+    padding: 0 0.25em
+    border-bottom: 1px solid rgba(128, 128, 128, 0.2)
+
+    &:hover .term-actions,
+    &:focus-within .term-actions
+      opacity: 1
+
+  .term-text
+    flex: 1
+    min-width: 0
+    overflow: hidden
+    text-overflow: ellipsis
+
+  .term-actions
+    display: flex
+    flex: 0 0 auto
+    opacity: 0.35
+    transition: opacity 0.12s ease
+
+mat-dialog-actions
+  padding-top: 1em
+  padding-bottom: 1em

--- a/cultpodcasts/src/app/language-ignored-subjects/language-ignored-subjects.component.spec.ts
+++ b/cultpodcasts/src/app/language-ignored-subjects/language-ignored-subjects.component.spec.ts
@@ -1,0 +1,322 @@
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { of, throwError } from 'rxjs';
+import { environment } from '../../environments/environment';
+import { AuthServiceWrapper } from '../auth-service-wrapper.class';
+import { LanguageIgnoredSubjectsComponent } from './language-ignored-subjects.component';
+import { LanguageTitleCasingRulesResponse } from '../title-casing-rules/title-casing-rules.interface';
+
+describe('LanguageIgnoredSubjectsComponent', () => {
+  let fixture: ComponentFixture<LanguageIgnoredSubjectsComponent>;
+  let component: LanguageIgnoredSubjectsComponent;
+  let httpMock: HttpTestingController;
+  let dialogRef: { close: ReturnType<typeof vi.fn> };
+  let confirmResult: { result: boolean };
+  let dialogOpen: ReturnType<typeof vi.fn>;
+  let getAccessTokenSilently: ReturnType<typeof vi.fn>;
+
+  const languagesUrl = new URL('/languages', environment.api).toString();
+  const subjectsUrl = new URL('/subjects', environment.api).toString();
+  const frRulesUrl = new URL('/title-casing-rules/fr', environment.api).toString();
+  const deRulesUrl = new URL('/title-casing-rules/de', environment.api).toString();
+  const frIgnoredSubjectsUrl = new URL(
+    '/title-casing-rules/fr/ignored-subjects',
+    environment.api
+  ).toString();
+
+  const frRules: LanguageTitleCasingRulesResponse = {
+    language: 'fr',
+    lowerCaseTerms: [],
+    knownTerms: [],
+    ignoredSubjects: ['Comedy'],
+    isDefault: false,
+  };
+
+  const allSubjects = [
+    { name: 'Comedy' },
+    { name: 'News' },
+    { name: 'Sport' },
+  ];
+
+  async function expectOneSoon(url: string) {
+    for (let i = 0; i < 20; i++) {
+      const matches = httpMock.match(url);
+      if (matches.length === 1) {
+        return matches[0];
+      }
+      await Promise.resolve();
+    }
+    return httpMock.expectOne(url);
+  }
+
+  async function flushInitialLoad(
+    rules: LanguageTitleCasingRulesResponse = frRules,
+    languages: Record<string, string> = { en: 'English', fr: 'French', de: 'German' }
+  ) {
+    let languagesReq;
+    let subjectsReq;
+    for (let i = 0; i < 20; i++) {
+      languagesReq = httpMock.match(languagesUrl)[0] ?? languagesReq;
+      subjectsReq = httpMock.match(subjectsUrl)[0] ?? subjectsReq;
+      if (languagesReq && subjectsReq) {
+        break;
+      }
+      await Promise.resolve();
+    }
+    if (!languagesReq || !subjectsReq) {
+      languagesReq = languagesReq ?? httpMock.expectOne(languagesUrl);
+      subjectsReq = subjectsReq ?? httpMock.expectOne(subjectsUrl);
+    }
+
+    expect(languagesReq.request.method).toBe('GET');
+    expect(subjectsReq.request.method).toBe('GET');
+    expect(languagesReq.request.headers.get('Authorization')).toBe('Bearer test-token');
+    expect(subjectsReq.request.headers.get('Authorization')).toBe('Bearer test-token');
+    languagesReq.flush(languages);
+    subjectsReq.flush(allSubjects);
+
+    const rulesReq = await expectOneSoon(frRulesUrl);
+    expect(rulesReq.request.method).toBe('GET');
+    expect(rulesReq.request.headers.get('Authorization')).toBe('Bearer test-token');
+    rulesReq.flush(rules);
+  }
+
+  beforeEach(async () => {
+    dialogRef = { close: vi.fn() };
+    confirmResult = { result: true };
+    dialogOpen = vi.fn().mockImplementation(() => ({
+      afterClosed: () => of(confirmResult),
+    }));
+    getAccessTokenSilently = vi.fn().mockReturnValue(of('test-token'));
+
+    await TestBed.configureTestingModule({
+      imports: [LanguageIgnoredSubjectsComponent],
+      providers: [
+        provideZonelessChangeDetection(),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: MatDialogRef, useValue: dialogRef },
+        {
+          provide: AuthServiceWrapper,
+          useValue: {
+            authService: { getAccessTokenSilently },
+          },
+        },
+      ],
+    }).compileComponents();
+
+    TestBed.overrideProvider(MatDialog, { useValue: { open: dialogOpen } });
+
+    fixture = TestBed.createComponent(LanguageIgnoredSubjectsComponent);
+    component = fixture.componentInstance;
+    httpMock = TestBed.inject(HttpTestingController);
+
+    const initPromise = component.ngOnInit();
+    await flushInitialLoad();
+    await initPromise;
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('loads non-English languages, ignored subjects, and subject picker on init', () => {
+    expect(getAccessTokenSilently).toHaveBeenCalledWith({
+      authorizationParams: {
+        audience: 'https://api.cultpodcasts.com/',
+        scope: 'admin',
+      },
+    });
+    expect(component.languageOptions().map(o => o.code)).toEqual(['fr', 'de']);
+    expect(component.languageOptions().some(o => o.code === 'en')).toBe(false);
+    expect(component.selectedLanguage()).toBe('fr');
+    expect(component.ignoredSubjects()).toEqual(['Comedy']);
+    expect(component.allSubjects()).toEqual(['Comedy', 'News', 'Sport']);
+  });
+
+  it('reloads ignored subjects when language changes', async () => {
+    const pending = component.onLanguageChange('de');
+
+    const rulesReq = await expectOneSoon(deRulesUrl);
+    expect(rulesReq.request.method).toBe('GET');
+    rulesReq.flush({
+      ...frRules,
+      language: 'de',
+      ignoredSubjects: ['News'],
+    });
+
+    await pending;
+    expect(component.selectedLanguage()).toBe('de');
+    expect(component.ignoredSubjects()).toEqual(['News']);
+  });
+
+  it('adds an ignored subject via POST', async () => {
+    component.newSubject.set('News');
+    const pending = component.addIgnoredSubject();
+
+    const post = await expectOneSoon(frIgnoredSubjectsUrl);
+    expect(post.request.method).toBe('POST');
+    expect(post.request.body).toEqual({ term: 'News' });
+    expect(post.request.headers.get('Authorization')).toBe('Bearer test-token');
+    post.flush({
+      ...frRules,
+      ignoredSubjects: ['Comedy', 'News'],
+    });
+
+    await pending;
+    expect(component.ignoredSubjects()).toEqual(['Comedy', 'News']);
+    expect(component.newSubject()).toBe('');
+
+    component.close();
+    expect(dialogRef.close).toHaveBeenCalledWith({ saved: true });
+  });
+
+  it('removes an ignored subject via DELETE after confirm', async () => {
+    const pending = component.deleteIgnoredSubject(0);
+    const delUrl = new URL(
+      '/title-casing-rules/fr/ignored-subjects/Comedy',
+      environment.api
+    ).toString();
+
+    const del = await expectOneSoon(delUrl);
+    expect(del.request.method).toBe('DELETE');
+    expect(del.request.headers.get('Authorization')).toBe('Bearer test-token');
+    del.flush({
+      ...frRules,
+      ignoredSubjects: [],
+    });
+
+    await pending;
+    expect(component.ignoredSubjects()).toEqual([]);
+    expect(dialogOpen).toHaveBeenCalled();
+  });
+
+  it('shows empty state when ignored subjects list is empty', async () => {
+    const pending = component.onLanguageChange('de');
+
+    const reload = await expectOneSoon(deRulesUrl);
+    reload.flush({ ...frRules, language: 'de', ignoredSubjects: [] });
+
+    await pending;
+    expect(component.ignoredSubjects()).toEqual([]);
+  });
+
+  it('blocks add/delete while mutating', async () => {
+    component.newSubject.set('News');
+    const pending = component.addIgnoredSubject();
+    expect(component.isMutating()).toBe(true);
+
+    await component.addIgnoredSubject();
+    await component.deleteIgnoredSubject(0);
+
+    const post = await expectOneSoon(frIgnoredSubjectsUrl);
+    post.flush({ ...frRules, ignoredSubjects: ['Comedy', 'News'] });
+    await pending;
+    expect(component.isMutating()).toBe(false);
+  });
+
+  it('rejects unknown subject names without POST', async () => {
+    component.newSubject.set('NotARealSubject');
+    await component.addIgnoredSubject();
+
+    expect(component.addError()).toContain('Pick a subject');
+    expect(httpMock.match(req => req.method === 'POST')).toEqual([]);
+  });
+
+  it('surfaces load failure on 401', async () => {
+    httpMock.verify();
+    getAccessTokenSilently.mockReturnValue(of('test-token'));
+
+    const localFixture = TestBed.createComponent(LanguageIgnoredSubjectsComponent);
+    const localComponent = localFixture.componentInstance;
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const initPromise = localComponent.ngOnInit();
+    let languagesReq;
+    let subjectsReq;
+    for (let i = 0; i < 20; i++) {
+      languagesReq = httpMock.match(languagesUrl)[0] ?? languagesReq;
+      subjectsReq = httpMock.match(subjectsUrl)[0] ?? subjectsReq;
+      if (languagesReq && subjectsReq) {
+        break;
+      }
+      await Promise.resolve();
+    }
+    languagesReq!.flush({ error: 'Unauthorized' }, { status: 401, statusText: 'Unauthorized' });
+    subjectsReq!.flush(allSubjects);
+
+    await initPromise;
+    expect(localComponent.isInError()).toBe(true);
+    expect(localComponent.errorMessage()).toContain('Failed to load');
+
+    errorSpy.mockRestore();
+  });
+
+  it('surfaces mutation failure on 403', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    component.newSubject.set('News');
+    const pending = component.addIgnoredSubject();
+
+    const post = await expectOneSoon(frIgnoredSubjectsUrl);
+    post.flush({ error: 'Forbidden' }, { status: 403, statusText: 'Forbidden' });
+
+    await pending;
+    expect(component.isInError()).toBe(true);
+    expect(component.errorMessage()).toBe('Forbidden');
+
+    component.close();
+    expect(dialogRef.close).toHaveBeenCalledWith({ saved: false });
+    errorSpy.mockRestore();
+  });
+
+  it('surfaces mutation failure on 400', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    component.newSubject.set('News');
+    const pending = component.addIgnoredSubject();
+
+    const post = await expectOneSoon(frIgnoredSubjectsUrl);
+    post.flush({ error: 'Subject already ignored.' }, { status: 400, statusText: 'Bad Request' });
+
+    await pending;
+    expect(component.isInError()).toBe(true);
+    expect(component.errorMessage()).toBe('Subject already ignored.');
+    errorSpy.mockRestore();
+  });
+
+  it('surfaces mutation failure on 5xx', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const pending = component.deleteIgnoredSubject(0);
+
+    const delUrl = new URL(
+      '/title-casing-rules/fr/ignored-subjects/Comedy',
+      environment.api
+    ).toString();
+    const del = await expectOneSoon(delUrl);
+    del.flush({ error: 'Server error' }, { status: 500, statusText: 'Internal Server Error' });
+
+    await pending;
+    expect(component.isInError()).toBe(true);
+    expect(component.errorMessage()).toBe('Server error');
+    errorSpy.mockRestore();
+  });
+
+  it('shows token error when admin scope token is unavailable', async () => {
+    httpMock.verify();
+    getAccessTokenSilently.mockReturnValue(throwError(() => new Error('login_required')));
+
+    const localFixture = TestBed.createComponent(LanguageIgnoredSubjectsComponent);
+    const localComponent = localFixture.componentInstance;
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    await localComponent.ngOnInit();
+
+    expect(localComponent.isInError()).toBe(true);
+    expect(localComponent.errorMessage()).toBe('Could not get admin token.');
+    expect(httpMock.match(() => true)).toEqual([]);
+
+    errorSpy.mockRestore();
+  });
+});

--- a/cultpodcasts/src/app/language-ignored-subjects/language-ignored-subjects.component.ts
+++ b/cultpodcasts/src/app/language-ignored-subjects/language-ignored-subjects.component.ts
@@ -1,0 +1,358 @@
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { ChangeDetectionStrategy, Component, computed, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { MatAutocompleteModule } from '@angular/material/autocomplete';
+import { MatButtonModule } from '@angular/material/button';
+import { MatOptionModule } from '@angular/material/core';
+import { MatDialog, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatSelectModule } from '@angular/material/select';
+import { firstValueFrom } from 'rxjs';
+import { environment } from '../../environments/environment';
+import { AuthServiceWrapper } from '../auth-service-wrapper.class';
+import { ConfirmComponent } from '../confirm/confirm.component';
+import { Subject } from '../subject.interface';
+import { LanguageTitleCasingRulesResponse } from '../title-casing-rules/title-casing-rules.interface';
+
+interface LanguageOption {
+  code: string;
+  name: string;
+}
+
+@Component({
+  selector: 'app-language-ignored-subjects',
+  imports: [
+    MatDialogModule,
+    MatProgressSpinnerModule,
+    MatButtonModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
+    MatIconModule,
+    MatAutocompleteModule,
+    MatOptionModule,
+    FormsModule
+  ],
+  templateUrl: './language-ignored-subjects.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  styleUrl: './language-ignored-subjects.component.sass'
+})
+export class LanguageIgnoredSubjectsComponent {
+  isLoading = signal(true);
+  isMutating = signal(false);
+  isInError = signal(false);
+  errorMessage = signal('');
+  addError = signal('');
+  isDefault = signal(false);
+  languageOptions = signal<LanguageOption[]>([]);
+  selectedLanguage = signal('');
+  ignoredSubjects = signal<string[]>([]);
+  allSubjects = signal<string[]>([]);
+  subjectFilter = signal('');
+  newSubject = signal('');
+  private didMutate = false;
+
+  readonly filteredIgnoredSubjects = computed(() => {
+    const q = this.subjectFilter().trim().toLowerCase();
+    return this.ignoredSubjects()
+      .map((term, index) => ({ term, index }))
+      .filter(item => !q || item.term.toLowerCase().includes(q));
+  });
+
+  readonly pickerSubjects = computed(() => {
+    const ignored = new Set(this.ignoredSubjects().map(s => s.toLowerCase()));
+    const q = this.newSubject().trim().toLowerCase();
+    return this.allSubjects()
+      .filter(name => !ignored.has(name.toLowerCase()))
+      .filter(name => !q || name.toLowerCase().includes(q));
+  });
+
+  constructor(
+    private auth: AuthServiceWrapper,
+    private http: HttpClient,
+    private dialog: MatDialog,
+    private dialogRef: MatDialogRef<LanguageIgnoredSubjectsComponent, { saved?: boolean }>
+  ) { }
+
+  async ngOnInit() {
+    await this.load();
+  }
+
+  close() {
+    this.dialogRef.close({ saved: this.didMutate });
+  }
+
+  async onLanguageChange(code: string) {
+    if (code === this.selectedLanguage() && !this.isLoading()) {
+      return;
+    }
+
+    this.selectedLanguage.set(code);
+    this.subjectFilter.set('');
+    this.newSubject.set('');
+    this.addError.set('');
+    this.isDefault.set(false);
+    this.isLoading.set(true);
+    try {
+      await this.loadLanguageRules(code);
+    } finally {
+      this.isLoading.set(false);
+    }
+  }
+
+  async addIgnoredSubject() {
+    const term = this.newSubject().trim();
+    const lang = this.selectedLanguage();
+    if (!term || !lang || this.isMutating()) {
+      return;
+    }
+
+    if (!this.allSubjects().some(s => s.toLowerCase() === term.toLowerCase())) {
+      this.addError.set('Pick a subject from the list.');
+      return;
+    }
+
+    if (this.ignoredSubjects().some(s => s.toLowerCase() === term.toLowerCase())) {
+      return;
+    }
+
+    await this.mutate(async headers => {
+      const resp = await firstValueFrom(
+        this.http.post<LanguageTitleCasingRulesResponse>(
+          this.ignoredSubjectsUrl(lang),
+          { term },
+          { headers, observe: 'response' }
+        )
+      );
+      if (resp.status === 200 && resp.body) {
+        this.applyRules(resp.body);
+        this.newSubject.set('');
+        this.addError.set('');
+        return;
+      }
+      throw Object.assign(new Error('Add failed.'), { error: { error: 'Add failed.' } });
+    });
+  }
+
+  async deleteIgnoredSubject(index: number) {
+    const lang = this.selectedLanguage();
+    const subjects = this.ignoredSubjects();
+    if (!lang || this.isMutating()) {
+      return;
+    }
+    const term = subjects[index];
+    if (!term) {
+      return;
+    }
+
+    if (!(await this.confirm('Remove ignored subject', `Stop ignoring “${term}” for ${lang}?`))) {
+      return;
+    }
+
+    await this.mutate(async headers => {
+      const resp = await firstValueFrom(
+        this.http.delete<LanguageTitleCasingRulesResponse>(
+          this.ignoredSubjectUrl(lang, term),
+          { headers, observe: 'response' }
+        )
+      );
+      if (resp.status === 200 && resp.body) {
+        this.applyRules(resp.body);
+        return;
+      }
+      throw Object.assign(new Error('Delete failed.'), { error: { error: 'Delete failed.' } });
+    });
+  }
+
+  private async mutate(action: (headers: HttpHeaders) => Promise<void>) {
+    this.isMutating.set(true);
+    this.isInError.set(false);
+    this.errorMessage.set('');
+
+    try {
+      const headers = await this.authHeaders();
+      if (!headers) {
+        this.isInError.set(true);
+        this.errorMessage.set('Could not get admin token.');
+        return;
+      }
+
+      await action(headers);
+      this.didMutate = true;
+    } catch (error: any) {
+      console.error(error);
+      this.isInError.set(true);
+      this.errorMessage.set(error?.error?.error ?? 'Update failed.');
+    } finally {
+      this.isMutating.set(false);
+    }
+  }
+
+  private async load() {
+    this.isLoading.set(true);
+    this.isInError.set(false);
+    this.errorMessage.set('');
+
+    try {
+      const headers = await this.authHeaders();
+      if (!headers) {
+        this.isInError.set(true);
+        this.errorMessage.set('Could not get admin token.');
+        this.isLoading.set(false);
+        return;
+      }
+
+      const [languagesResp, subjectsResp] = await Promise.all([
+        firstValueFrom(
+          this.http.get<{ [key: string]: string }>(
+            new URL('/languages', environment.api).toString(),
+            { headers, observe: 'response' }
+          )
+        ),
+        firstValueFrom(
+          this.http.get<Subject[]>(
+            new URL('/subjects', environment.api).toString(),
+            { headers, observe: 'response' }
+          )
+        )
+      ]);
+
+      if (languagesResp.status !== 200 || !languagesResp.body) {
+        this.isInError.set(true);
+        this.errorMessage.set('Failed to load languages.');
+        this.isLoading.set(false);
+        return;
+      }
+
+      if (subjectsResp.status !== 200 || !subjectsResp.body) {
+        this.isInError.set(true);
+        this.errorMessage.set('Failed to load subjects.');
+        this.isLoading.set(false);
+        return;
+      }
+
+      const options = Object.entries(languagesResp.body)
+        .map(([code, name]) => ({ code, name }))
+        .filter(o => o.code !== 'en')
+        .sort((a, b) => a.name.localeCompare(b.name));
+      this.languageOptions.set(options);
+      this.allSubjects.set(
+        [...subjectsResp.body]
+          .map(s => s.name)
+          .sort((a, b) => a.localeCompare(b))
+      );
+
+      const initialLang = options[0]?.code ?? '';
+      this.selectedLanguage.set(initialLang);
+      if (initialLang) {
+        await this.loadLanguageRules(initialLang, headers);
+      }
+    } catch (error) {
+      console.error(error);
+      this.isInError.set(true);
+      this.errorMessage.set('Failed to load language ignored subjects.');
+    } finally {
+      this.isLoading.set(false);
+    }
+  }
+
+  private async loadLanguageRules(code: string, headers?: HttpHeaders) {
+    this.isInError.set(false);
+    this.errorMessage.set('');
+    try {
+      const authHeaders = headers ?? await this.authHeaders();
+      if (!authHeaders) {
+        this.isInError.set(true);
+        this.errorMessage.set('Could not get admin token.');
+        return;
+      }
+
+      const resp = await firstValueFrom(
+        this.http.get<LanguageTitleCasingRulesResponse>(
+          this.rulesUrl(code),
+          { headers: authHeaders, observe: 'response' }
+        )
+      );
+
+      if (resp.status === 200 && resp.body) {
+        this.applyRules(resp.body);
+        return;
+      }
+
+      if (resp.status === 404) {
+        this.isDefault.set(false);
+        this.ignoredSubjects.set([]);
+        return;
+      }
+
+      throw new Error('Failed to load ignored subjects.');
+    } catch (error: any) {
+      if (error?.status === 404) {
+        this.isDefault.set(false);
+        this.ignoredSubjects.set([]);
+        return;
+      }
+      console.error(error);
+      this.isInError.set(true);
+      this.errorMessage.set('Failed to load ignored subjects.');
+    }
+  }
+
+  private applyRules(rules: LanguageTitleCasingRulesResponse) {
+    this.isDefault.set(rules.isDefault);
+    this.ignoredSubjects.set([...(rules.ignoredSubjects ?? [])]);
+  }
+
+  private rulesUrl(code: string): string {
+    return new URL(
+      `/title-casing-rules/${encodeURIComponent(code)}`,
+      environment.api
+    ).toString();
+  }
+
+  private ignoredSubjectsUrl(code: string): string {
+    return new URL(
+      `/title-casing-rules/${encodeURIComponent(code)}/ignored-subjects`,
+      environment.api
+    ).toString();
+  }
+
+  private ignoredSubjectUrl(code: string, term: string): string {
+    return new URL(
+      `/title-casing-rules/${encodeURIComponent(code)}/ignored-subjects/${encodeURIComponent(term)}`,
+      environment.api
+    ).toString();
+  }
+
+  private async confirm(title: string, question: string): Promise<boolean> {
+    const ref = this.dialog.open(ConfirmComponent, {
+      data: { title, question },
+      disableClose: true,
+      autoFocus: true
+    });
+    const result = await firstValueFrom(ref.afterClosed());
+    return result?.result === true;
+  }
+
+  private async authHeaders(): Promise<HttpHeaders | undefined> {
+    try {
+      const token = await firstValueFrom(this.auth.authService.getAccessTokenSilently({
+        authorizationParams: {
+          audience: `https://api.cultpodcasts.com/`,
+          scope: 'admin'
+        }
+      }));
+      if (!token) {
+        return undefined;
+      }
+      return new HttpHeaders()
+        .set('Authorization', 'Bearer ' + token);
+    } catch (e) {
+      console.error(e);
+      return undefined;
+    }
+  }
+}

--- a/cultpodcasts/src/app/title-casing-rules/title-casing-rules.interface.ts
+++ b/cultpodcasts/src/app/title-casing-rules/title-casing-rules.interface.ts
@@ -15,4 +15,5 @@ export interface LanguageTitleCasingRulesResponse {
   lowerCaseTerms: string[];
   knownTerms: KnownTerm[];
   isDefault: boolean;
+  ignoredSubjects?: string[];
 }

--- a/cultpodcasts/src/app/toolbar/toolbar.component.html
+++ b/cultpodcasts/src/app/toolbar/toolbar.component.html
@@ -54,6 +54,10 @@
           <mat-icon class="material-symbols-outlined">title</mat-icon>
           <span>Title casing</span>
         </a>
+        <a (click)="openLanguageIgnoredSubjects()" mat-menu-item>
+          <mat-icon class="material-symbols-outlined">block</mat-icon>
+          <span>Ignored subjects</span>
+        </a>
         <a (click)="openSupportedLanguages()" mat-menu-item>
           <mat-icon class="material-symbols-outlined">translate</mat-icon>
           <span>Supported languages</span>
@@ -115,6 +119,10 @@
       <a (click)="openTitleCasingRules()" mat-menu-item>
         <mat-icon class="material-symbols-outlined">title</mat-icon>
         <span>Title casing</span>
+      </a>
+      <a (click)="openLanguageIgnoredSubjects()" mat-menu-item>
+        <mat-icon class="material-symbols-outlined">block</mat-icon>
+        <span>Ignored subjects</span>
       </a>
       <a (click)="openSupportedLanguages()" mat-menu-item>
         <mat-icon class="material-symbols-outlined">translate</mat-icon>

--- a/cultpodcasts/src/app/toolbar/toolbar.component.ts
+++ b/cultpodcasts/src/app/toolbar/toolbar.component.ts
@@ -21,6 +21,7 @@ import { PublishHomepageComponent } from '../publish-homepage/publish-homepage.c
 import { DiscoveryScheduleComponent } from '../discovery-schedule/discovery-schedule.component';
 import { SupportedLanguagesComponent } from '../supported-languages/supported-languages.component';
 import { TitleCasingRulesComponent } from '../title-casing-rules/title-casing-rules.component';
+import { LanguageIgnoredSubjectsComponent } from '../language-ignored-subjects/language-ignored-subjects.component';
 import { IndexerState } from '../indexer-state.interface';
 import { SubmitUrlOriginResponseSnackbarComponent } from '../submit-url-origin-response-snackbar/submit-url-origin-response-snackbar.component';
 import { MatBadgeModule } from '@angular/material/badge';
@@ -255,6 +256,23 @@ export class ToolbarComponent {
       .subscribe(result => {
         if (result?.saved) {
           this.snackBar.open('Title casing rules saved', 'Ok', { duration: 5000 });
+        }
+      });
+  }
+
+  openLanguageIgnoredSubjects() {
+    const dialogRef = this.dialog.open(LanguageIgnoredSubjectsComponent, {
+      disableClose: true,
+      autoFocus: true,
+      width: '40em',
+      maxWidth: '95vw',
+      maxHeight: '90vh'
+    });
+    dialogRef.afterClosed()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(result => {
+        if (result?.saved) {
+          this.snackBar.open('Language ignored subjects saved', 'Ok', { duration: 5000 });
         }
       });
   }


### PR DESCRIPTION
## Summary
- New Admin MatDialog to manage non-English language ignored subjects (separate from Title casing rules)
- Toolbar entry; `ignoredSubjects` on title-casing rules interface; Vitest coverage for load/add/delete
- OnPush-safe `newSubject` signal so autocomplete filtering updates while typing

## Test plan
- [ ] `npm test -- --include=src/app/language-ignored-subjects/language-ignored-subjects.component.spec.ts`
- [ ] Open Admin → Language ignored subjects; pick a non-English language; add/remove a subject
- [ ] Confirm English is not offered in the language list
- [ ] Depends on Api + Functions ignored-subjects endpoints being available

Made with [Cursor](https://cursor.com)