### PR TITLE
fix(ui): keep guests when creating or adding people in episode dialogs

### DIFF
--- a/cultpodcasts/src/app/add-episode-dialog/add-episode-dialog.component.html
+++ b/cultpodcasts/src/app/add-episode-dialog/add-episode-dialog.component.html
@@ -273,7 +273,7 @@
                     @for (suggestion of guestSuggestions(); track suggestion.person.id) {
                     <div class="guest-row">
                         <span>{{personLabel(suggestion.person)}} ({{suggestion.matchResults[0]?.term}})</span>
-                        <button type="button" matButton="text" (click)="addSuggestedGuest(suggestion.person.name)">Add</button>
+                        <button type="button" matButton="text" (click)="addSuggestedGuest(suggestion.person)">Add</button>
                     </div>
                     }
                 </div>

--- a/cultpodcasts/src/app/add-episode-dialog/add-episode-dialog.component.ts
+++ b/cultpodcasts/src/app/add-episode-dialog/add-episode-dialog.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject, ChangeDetectionStrategy, signal } from '@angular/core';
+import { Component, Inject, ChangeDetectionStrategy, signal, ChangeDetectorRef } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef, MatDialogModule, MatDialog } from '@angular/material/dialog';
 import { AuthServiceWrapper } from '../auth-service-wrapper.class';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
@@ -27,16 +27,18 @@ import { Podcast } from '../podcast.interface';
 import { MatDividerModule } from '@angular/material/divider';
 import { buildEpisodeLanguageOptions } from '../language-options.util';
 import { EditPersonDialogComponent } from '../edit-person-dialog/edit-person-dialog.component';
-import { comparePeopleBySortKey } from '../person-sort';
 import { FeatureSwitch } from '../feature-switch.enum';
 import { FeatureSwitchService } from '../feature-switch-service';
 import { MatIconModule } from '@angular/material/icon';
 import { ImagePreviewDialogComponent } from '../image-preview-dialog/image-preview-dialog.component';
 import {
   buildEpisodeForm,
+  catalogueAfterPersonChange,
   clearFormControl,
   collectEpisodeImagePreviews,
+  episodeCataloguePeople,
   getEpisodeChanges,
+  guestNamesWithPerson,
   hasNonEmptyUrlValue,
   mergeEpisodeSubjects,
   noCompareFunction,
@@ -110,6 +112,7 @@ export class AddEpisodeDialogComponent {
     @Inject(MAT_DIALOG_DATA) public data: { podcastId: string, episodeId: string, isNewPodcast: boolean },
     private dialog: MatDialog,
     protected featureSwitchService: FeatureSwitchService,
+    private cdr: ChangeDetectorRef,
   ) {
     this.podcastId = data.podcastId;
     this.episodeId = data.episodeId;
@@ -158,7 +161,11 @@ export class AddEpisodeDialogComponent {
       // Bluesky state is set by a real network post (or cleared via un-post elsewhere),
       // not by flipping this form flag.
       this.form()!.controls.blueskyPosted.disable({ emitEvent: false });
-      this.allPeople = resp.people.sort(comparePeopleBySortKey);
+      this.allPeople = episodeCataloguePeople(
+        resp.people,
+        resp.episode.guestPeople,
+        resp.episode.guestSuggestions
+      );
       this.guestSuggestions.set(resp.episode.guestSuggestions ?? []);
       this.regroupGuests(resp.episode.guests ?? []);
       const { subjects, allSubjects } = mergeEpisodeSubjects(resp.episode.subjects, resp.subjects, this.podcastDefaultSubject);
@@ -348,14 +355,12 @@ export class AddEpisodeDialogComponent {
     this.otherPeople.set(otherPeople);
   }
 
-  addSuggestedGuest(personName: string) {
-    const current = this.form()?.controls.guests.value ?? [];
-    if (current.includes(personName)) {
+  addSuggestedGuest(person: Person) {
+    if (!person?.name) {
       return;
     }
-    this.form()?.controls.guests.setValue([...current, personName]);
-    this.guestSuggestions.set(this.guestSuggestions().filter(x => x.person.name !== personName));
-    this.regroupGuests(this.form()?.controls.guests.value);
+    this.commitGuestSelection(person.name, person);
+    this.guestSuggestions.set(this.guestSuggestions().filter(x => x.person.name !== person.name));
   }
 
   openAddPerson() {
@@ -387,6 +392,7 @@ export class AddEpisodeDialogComponent {
   }
 
   private async refreshPeopleAndSelect(personName: string, created?: Person) {
+    let fetched: Person[] | undefined;
     try {
       const token = await firstValueFrom(this.auth.authService.getAccessTokenSilently({
         authorizationParams: {
@@ -397,27 +403,26 @@ export class AddEpisodeDialogComponent {
       let headers: HttpHeaders = new HttpHeaders();
       headers = headers.set("Authorization", "Bearer " + token);
       const peopleEndpoint = new URL("/people", environment.api).toString();
-      const people = await firstValueFrom(
+      fetched = await firstValueFrom(
         this.http.get<Person[]>(peopleEndpoint, { headers: headers }).pipe(
           catchError(err => err?.status === 404 ? of([] as Person[]) : throwError(() => err))
         )
       );
-      this.allPeople = people.sort(comparePeopleBySortKey);
-      if (created && !this.allPeople.some(x => x.name === created.name)) {
-        this.allPeople = [...this.allPeople, created].sort(comparePeopleBySortKey);
-      }
     } catch {
-      if (created) {
-        this.allPeople = [...this.allPeople.filter(x => x.name !== created.name), created]
-          .sort(comparePeopleBySortKey);
-      }
+      fetched = undefined;
     }
 
-    const current = this.form()?.controls.guests.value ?? [];
-    if (!current.includes(personName)) {
-      this.form()?.controls.guests.setValue([...current, personName]);
-    }
-    this.regroupGuests(this.form()?.controls.guests.value);
+    this.allPeople = catalogueAfterPersonChange(this.allPeople, fetched, personName, created);
+    this.commitGuestSelection(personName, created);
+  }
+
+  private commitGuestSelection(personName: string, person?: Person) {
+    this.allPeople = catalogueAfterPersonChange(this.allPeople, undefined, personName, person);
+    this.guestsFilterTerm.set('');
+    const next = guestNamesWithPerson(this.form()?.controls.guests.value, personName);
+    this.regroupGuests(next);
+    this.cdr.detectChanges();
+    this.form()?.controls.guests.setValue(next);
   }
 
   onSubjectsDropdownOpenChange(opened: boolean) {

--- a/cultpodcasts/src/app/add-episode-dialog/add-episode-dialog.component.ts
+++ b/cultpodcasts/src/app/add-episode-dialog/add-episode-dialog.component.ts
@@ -33,12 +33,11 @@ import { MatIconModule } from '@angular/material/icon';
 import { ImagePreviewDialogComponent } from '../image-preview-dialog/image-preview-dialog.component';
 import {
   buildEpisodeForm,
-  catalogueAfterPersonChange,
   clearFormControl,
   collectEpisodeImagePreviews,
   episodeCataloguePeople,
+  applyGuestSelection,
   getEpisodeChanges,
-  guestNamesWithPerson,
   hasNonEmptyUrlValue,
   mergeEpisodeSubjects,
   noCompareFunction,
@@ -46,6 +45,7 @@ import {
   personLabel,
   regroupGuests as regroupGuestsPure,
   regroupSubjects as regroupSubjectsPure,
+  withoutGuestSuggestion,
   type EpisodeImageService
 } from '../episode-form.util';
 
@@ -360,7 +360,7 @@ export class AddEpisodeDialogComponent {
       return;
     }
     this.commitGuestSelection(person.name, person);
-    this.guestSuggestions.set(this.guestSuggestions().filter(x => x.person.name !== person.name));
+    this.guestSuggestions.set(withoutGuestSuggestion(this.guestSuggestions(), person.name));
   }
 
   openAddPerson() {
@@ -412,17 +412,29 @@ export class AddEpisodeDialogComponent {
       fetched = undefined;
     }
 
-    this.allPeople = catalogueAfterPersonChange(this.allPeople, fetched, personName, created);
-    this.commitGuestSelection(personName, created);
+    this.applyGuestSelectionState(personName, created, fetched);
   }
 
   private commitGuestSelection(personName: string, person?: Person) {
-    this.allPeople = catalogueAfterPersonChange(this.allPeople, undefined, personName, person);
+    this.applyGuestSelectionState(personName, person);
+  }
+
+  private applyGuestSelectionState(personName: string, person?: Person, fetched?: Person[]) {
+    const result = applyGuestSelection({
+      allPeople: this.allPeople,
+      fetched,
+      currentGuests: this.form()?.controls.guests.value,
+      personName,
+      person,
+      episodeGuestPeople: this.originalEpisode?.guestPeople,
+      filterTerm: ''
+    });
+    this.allPeople = result.allPeople;
     this.guestsFilterTerm.set('');
-    const next = guestNamesWithPerson(this.form()?.controls.guests.value, personName);
-    this.regroupGuests(next);
+    this.selectedGuests.set(result.selectedGuests);
+    this.otherPeople.set(result.otherPeople);
     this.cdr.detectChanges();
-    this.form()?.controls.guests.setValue(next);
+    this.form()?.controls.guests.setValue(result.guests);
   }
 
   onSubjectsDropdownOpenChange(opened: boolean) {

--- a/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.html
+++ b/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.html
@@ -285,7 +285,7 @@
                     @for (suggestion of guestSuggestions(); track suggestion.person.id) {
                     <div class="guest-row">
                         <span>{{personLabel(suggestion.person)}} ({{suggestion.matchResults[0]?.term}})</span>
-                        <button type="button" matButton="text" (click)="addSuggestedGuest(suggestion.person.name)">Add</button>
+                        <button type="button" matButton="text" (click)="addSuggestedGuest(suggestion.person)">Add</button>
                     </div>
                     }
                 </div>

--- a/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.ts
+++ b/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject, ChangeDetectionStrategy, signal } from '@angular/core';
+import { Component, Inject, ChangeDetectionStrategy, signal, ChangeDetectorRef } from '@angular/core';
 import { CdkTextareaAutosize, TextFieldModule } from '@angular/cdk/text-field';
 import { MatInputModule } from '@angular/material/input';
 import { MAT_DIALOG_DATA, MatDialogRef, MatDialogModule, MatDialog } from '@angular/material/dialog';
@@ -28,16 +28,18 @@ import { Podcast } from '../podcast.interface';
 import { MatDividerModule } from '@angular/material/divider';
 import { buildEpisodeLanguageOptions } from '../language-options.util';
 import { EditPersonDialogComponent } from '../edit-person-dialog/edit-person-dialog.component';
-import { comparePeopleBySortKey } from '../person-sort';
 import { FeatureSwitch } from '../feature-switch.enum';
 import { FeatureSwitchService } from '../feature-switch-service';
 import { MatIconModule } from '@angular/material/icon';
 import { ImagePreviewDialogComponent } from '../image-preview-dialog/image-preview-dialog.component';
 import {
   buildEpisodeForm,
+  catalogueAfterPersonChange,
   clearFormControl,
   collectEpisodeImagePreviews,
+  episodeCataloguePeople,
   getEpisodeChanges,
+  guestNamesWithPerson,
   hasNonEmptyUrlValue,
   mergeEpisodeSubjects,
   noCompareFunction,
@@ -113,6 +115,7 @@ export class EditEpisodeDialogComponent {
     @Inject(MAT_DIALOG_DATA) public data: { podcastIdentifier: string, episodeId: string },
     private dialog: MatDialog,
     protected featureSwitchService: FeatureSwitchService,
+    private cdr: ChangeDetectorRef,
   ) {
     this.episodeId = data.episodeId;
     this.podcastIdentifier = data.podcastIdentifier;
@@ -159,7 +162,11 @@ export class EditEpisodeDialogComponent {
       this.form.set(buildEpisodeForm(resp.episode));
       this.blueskyOriginallyPosted.set(!!resp.episode.bluesky);
       this.pendingUnBluesky.set(false);
-      this.allPeople = resp.people.sort(comparePeopleBySortKey);
+      this.allPeople = episodeCataloguePeople(
+        resp.people,
+        resp.episode.guestPeople,
+        resp.episode.guestSuggestions
+      );
       this.guestSuggestions.set(resp.episode.guestSuggestions ?? []);
       this.regroupGuests(resp.episode.guests ?? []);
       const { subjects, allSubjects } = mergeEpisodeSubjects(resp.episode.subjects, resp.subjects, this.podcastDefaultSubject);
@@ -329,14 +336,12 @@ export class EditEpisodeDialogComponent {
     this.otherPeople.set(otherPeople);
   }
 
-  addSuggestedGuest(personName: string) {
-    const current = this.form()?.controls.guests.value ?? [];
-    if (current.includes(personName)) {
+  addSuggestedGuest(person: Person) {
+    if (!person?.name) {
       return;
     }
-    this.form()?.controls.guests.setValue([...current, personName]);
-    this.guestSuggestions.set(this.guestSuggestions().filter(x => x.person.name !== personName));
-    this.regroupGuests(this.form()?.controls.guests.value);
+    this.commitGuestSelection(person.name, person);
+    this.guestSuggestions.set(this.guestSuggestions().filter(x => x.person.name !== person.name));
   }
 
   openAddPerson() {
@@ -368,6 +373,7 @@ export class EditEpisodeDialogComponent {
   }
 
   private async refreshPeopleAndSelect(personName: string, created?: Person) {
+    let fetched: Person[] | undefined;
     try {
       const token = await firstValueFrom(this.auth.authService.getAccessTokenSilently({
         authorizationParams: {
@@ -378,27 +384,26 @@ export class EditEpisodeDialogComponent {
       let headers: HttpHeaders = new HttpHeaders();
       headers = headers.set("Authorization", "Bearer " + token);
       const peopleEndpoint = new URL("/people", environment.api).toString();
-      const people = await firstValueFrom(
+      fetched = await firstValueFrom(
         this.http.get<Person[]>(peopleEndpoint, { headers: headers }).pipe(
           catchError(err => err?.status === 404 ? of([] as Person[]) : throwError(() => err))
         )
       );
-      this.allPeople = people.sort(comparePeopleBySortKey);
-      if (created && !this.allPeople.some(x => x.name === created.name)) {
-        this.allPeople = [...this.allPeople, created].sort(comparePeopleBySortKey);
-      }
     } catch {
-      if (created) {
-        this.allPeople = [...this.allPeople.filter(x => x.name !== created.name), created]
-          .sort(comparePeopleBySortKey);
-      }
+      fetched = undefined;
     }
 
-    const current = this.form()?.controls.guests.value ?? [];
-    if (!current.includes(personName)) {
-      this.form()?.controls.guests.setValue([...current, personName]);
-    }
-    this.regroupGuests(this.form()?.controls.guests.value);
+    this.allPeople = catalogueAfterPersonChange(this.allPeople, fetched, personName, created);
+    this.commitGuestSelection(personName, created);
+  }
+
+  private commitGuestSelection(personName: string, person?: Person) {
+    this.allPeople = catalogueAfterPersonChange(this.allPeople, undefined, personName, person);
+    this.guestsFilterTerm.set('');
+    const next = guestNamesWithPerson(this.form()?.controls.guests.value, personName);
+    this.regroupGuests(next);
+    this.cdr.detectChanges();
+    this.form()?.controls.guests.setValue(next);
   }
 
   onSubjectsDropdownOpenChange(opened: boolean) {

--- a/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.ts
+++ b/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.ts
@@ -34,12 +34,11 @@ import { MatIconModule } from '@angular/material/icon';
 import { ImagePreviewDialogComponent } from '../image-preview-dialog/image-preview-dialog.component';
 import {
   buildEpisodeForm,
-  catalogueAfterPersonChange,
   clearFormControl,
   collectEpisodeImagePreviews,
   episodeCataloguePeople,
+  applyGuestSelection,
   getEpisodeChanges,
-  guestNamesWithPerson,
   hasNonEmptyUrlValue,
   mergeEpisodeSubjects,
   noCompareFunction,
@@ -47,6 +46,7 @@ import {
   personLabel,
   regroupGuests as regroupGuestsPure,
   regroupSubjects as regroupSubjectsPure,
+  withoutGuestSuggestion,
   type EpisodeImageService
 } from '../episode-form.util';
 
@@ -341,7 +341,7 @@ export class EditEpisodeDialogComponent {
       return;
     }
     this.commitGuestSelection(person.name, person);
-    this.guestSuggestions.set(this.guestSuggestions().filter(x => x.person.name !== person.name));
+    this.guestSuggestions.set(withoutGuestSuggestion(this.guestSuggestions(), person.name));
   }
 
   openAddPerson() {
@@ -393,17 +393,29 @@ export class EditEpisodeDialogComponent {
       fetched = undefined;
     }
 
-    this.allPeople = catalogueAfterPersonChange(this.allPeople, fetched, personName, created);
-    this.commitGuestSelection(personName, created);
+    this.applyGuestSelectionState(personName, created, fetched);
   }
 
   private commitGuestSelection(personName: string, person?: Person) {
-    this.allPeople = catalogueAfterPersonChange(this.allPeople, undefined, personName, person);
+    this.applyGuestSelectionState(personName, person);
+  }
+
+  private applyGuestSelectionState(personName: string, person?: Person, fetched?: Person[]) {
+    const result = applyGuestSelection({
+      allPeople: this.allPeople,
+      fetched,
+      currentGuests: this.form()?.controls.guests.value,
+      personName,
+      person,
+      episodeGuestPeople: this.originalEpisode?.guestPeople,
+      filterTerm: ''
+    });
+    this.allPeople = result.allPeople;
     this.guestsFilterTerm.set('');
-    const next = guestNamesWithPerson(this.form()?.controls.guests.value, personName);
-    this.regroupGuests(next);
+    this.selectedGuests.set(result.selectedGuests);
+    this.otherPeople.set(result.otherPeople);
     this.cdr.detectChanges();
-    this.form()?.controls.guests.setValue(next);
+    this.form()?.controls.guests.setValue(result.guests);
   }
 
   onSubjectsDropdownOpenChange(opened: boolean) {

--- a/cultpodcasts/src/app/episode-form.util.spec.ts
+++ b/cultpodcasts/src/app/episode-form.util.spec.ts
@@ -1,9 +1,14 @@
 import { ApiEpisode } from './api-episode.interface';
 import {
   buildEpisodeForm,
+  catalogueAfterPersonChange,
   dateToLocalISO,
+  episodeCataloguePeople,
   getEpisodeChanges,
+  guestNamesWithPerson,
   mergeEpisodeSubjects,
+  mergePeopleCatalogue,
+  pendingPerson,
   personLabel,
   personMatchesFilter,
   regroupGuests,
@@ -87,6 +92,52 @@ describe('episode-form.util', () => {
     const result = regroupGuests(people, undefined, ['Alice'], 'bo');
     expect(result.selectedGuests.map(p => p.name)).toEqual(['Alice']);
     expect(result.otherPeople.map(p => p.name)).toEqual(['Bob']);
+  });
+
+  it('regroupGuests keeps selected names that are missing from the catalogue as stubs', () => {
+    const people: Person[] = [{ id: '2', name: 'Bob' }];
+    const result = regroupGuests(people, undefined, ['Alice', 'Bob'], '');
+    expect(result.selectedGuests.map(p => p.name)).toEqual(['Alice', 'Bob']);
+    expect(result.selectedGuests[0]).toEqual(pendingPerson('Alice'));
+    expect(result.otherPeople.map(p => p.name)).toEqual([]);
+  });
+
+  it('mergePeopleCatalogue keeps locally created people missing from a stale fetch', () => {
+    const existing: Person[] = [
+      { id: '1', name: 'Alice' },
+      { id: 'created-1', name: 'Dana' }
+    ];
+    const fetched: Person[] = [{ id: '1', name: 'Alice' }];
+    const created: Person = { id: 'created-2', name: 'Evan' };
+    const merged = mergePeopleCatalogue(existing, fetched, [created]);
+    expect(merged.map(p => p.name)).toEqual(['Alice', 'Dana', 'Evan']);
+  });
+
+  it('mergePeopleCatalogue does not let a pending stub overwrite a real person', () => {
+    const existing: Person[] = [{ id: '1', name: 'Alice', twitterHandle: '@alice' }];
+    const merged = mergePeopleCatalogue(existing, undefined, [pendingPerson('Alice')]);
+    expect(merged).toEqual([{ id: '1', name: 'Alice', twitterHandle: '@alice' }]);
+  });
+
+  it('catalogueAfterPersonChange upserts a created person onto a stale snapshot', () => {
+    const existing: Person[] = [{ id: 'created-1', name: 'Dana' }];
+    const fetched: Person[] = [{ id: '1', name: 'Alice' }];
+    const created: Person = { id: 'created-2', name: 'Evan' };
+    const people = catalogueAfterPersonChange(existing, fetched, 'Evan', created);
+    expect(people.map(p => p.name)).toEqual(['Alice', 'Dana', 'Evan']);
+  });
+
+  it('guestNamesWithPerson appends a new guest without dropping existing names', () => {
+    expect(guestNamesWithPerson(['Dana'], 'Evan')).toEqual(['Dana', 'Evan']);
+    expect(guestNamesWithPerson(['Dana'], 'Dana')).toEqual(['Dana']);
+  });
+
+  it('episodeCataloguePeople adds suggestion people missing from the published list', () => {
+    const published: Person[] = [{ id: '1', name: 'Host Show' }];
+    const suggestions = [{ person: { id: '2', name: 'Suggested Guest', twitterHandle: '@guest' } }];
+    const people = episodeCataloguePeople(published, undefined, suggestions);
+    expect(people.map(p => p.name)).toEqual(expect.arrayContaining(['Host Show', 'Suggested Guest']));
+    expect(people).toHaveLength(2);
   });
 
   it('regroupGuests filters other people by social handle as well as name', () => {

--- a/cultpodcasts/src/app/episode-form.util.spec.ts
+++ b/cultpodcasts/src/app/episode-form.util.spec.ts
@@ -1,5 +1,6 @@
 import { ApiEpisode } from './api-episode.interface';
 import {
+  applyGuestSelection,
   buildEpisodeForm,
   catalogueAfterPersonChange,
   dateToLocalISO,
@@ -13,9 +14,11 @@ import {
   personMatchesFilter,
   regroupGuests,
   regroupSubjects,
-  uniqueStrings
+  uniqueStrings,
+  withoutGuestSuggestion
 } from './episode-form.util';
 import { Person } from './person.interface';
+import { PersonMatch } from './person-match.interface';
 
 function baseEpisode(overrides: Partial<ApiEpisode> = {}): ApiEpisode {
   return {
@@ -138,6 +141,67 @@ describe('episode-form.util', () => {
     const people = episodeCataloguePeople(published, undefined, suggestions);
     expect(people.map(p => p.name)).toEqual(expect.arrayContaining(['Host Show', 'Suggested Guest']));
     expect(people).toHaveLength(2);
+  });
+
+  describe('applyGuestSelection (add/edit episode dialog contract)', () => {
+    it('keeps the first created guest when a second create refreshes a stale people list', () => {
+      const first: Person = { id: 'c1', name: 'Dana Created', twitterHandle: '@dana' };
+      const afterFirst = applyGuestSelection({
+        allPeople: [{ id: '1', name: 'Host Show' }],
+        currentGuests: [],
+        personName: first.name,
+        person: first
+      });
+      expect(afterFirst.guests).toEqual(['Dana Created']);
+      expect(afterFirst.selectedGuests.map(p => p.name)).toEqual(['Dana Created']);
+
+      const second: Person = { id: 'c2', name: 'Evan Created' };
+      const staleFetch: Person[] = [{ id: '1', name: 'Host Show' }];
+      const afterSecond = applyGuestSelection({
+        allPeople: afterFirst.allPeople,
+        fetched: staleFetch,
+        currentGuests: afterFirst.guests,
+        personName: second.name,
+        person: second
+      });
+
+      expect(afterSecond.guests).toEqual(['Dana Created', 'Evan Created']);
+      expect(afterSecond.selectedGuests.map(p => p.name)).toEqual(['Dana Created', 'Evan Created']);
+      expect(afterSecond.allPeople.map(p => p.name)).toEqual(
+        expect.arrayContaining(['Host Show', 'Dana Created', 'Evan Created'])
+      );
+    });
+
+    it('adds a title/description suggestion missing from the published catalogue into Selected', () => {
+      const suggested: Person = {
+        id: 's1',
+        name: 'Suggested Guest',
+        twitterHandle: '@guest',
+        blueskyHandle: 'guest.bsky.social'
+      };
+      const result = applyGuestSelection({
+        allPeople: [{ id: '1', name: 'Host Show' }],
+        currentGuests: ['Host Show'],
+        personName: suggested.name,
+        person: suggested
+      });
+
+      expect(result.guests).toEqual(['Host Show', 'Suggested Guest']);
+      expect(result.selectedGuests).toEqual([
+        { id: '1', name: 'Host Show' },
+        suggested
+      ]);
+      expect(result.allPeople.some(p => p.name === 'Suggested Guest')).toBe(true);
+    });
+
+    it('removes only the accepted suggestion from the suggestion list', () => {
+      const suggestions: PersonMatch[] = [
+        { person: { id: 's1', name: 'Suggested Guest' }, matchResults: [{ term: 'Suggested Guest', matches: 1 }] },
+        { person: { id: 's2', name: 'Other Guest' }, matchResults: [{ term: 'Other', matches: 1 }] }
+      ];
+      expect(withoutGuestSuggestion(suggestions, 'Suggested Guest').map(x => x.person.name))
+        .toEqual(['Other Guest']);
+    });
   });
 
   it('regroupGuests filters other people by social handle as well as name', () => {

--- a/cultpodcasts/src/app/episode-form.util.ts
+++ b/cultpodcasts/src/app/episode-form.util.ts
@@ -4,6 +4,7 @@ import { EpisodeForm } from './episode-form.interface';
 import { EpisodePost } from './episode-post.interface';
 import { episodeLanguageFormValue } from './language-options.util';
 import { Person } from './person.interface';
+import { comparePeopleBySortKey } from './person-sort';
 import { Subject } from './subject.interface';
 import { filterKeepingSelectedInOrder } from './subject-filter.util';
 
@@ -191,6 +192,87 @@ export interface RegroupedGuests {
   otherPeople: Person[];
 }
 
+export function isPendingPersonId(id: string | undefined): boolean {
+  return !id || id.startsWith('pending:');
+}
+
+export function pendingPerson(name: string): Person {
+  return { id: `pending:${name}`, name };
+}
+
+/**
+ * Merge people lists by name. Existing locals are kept when a fetched snapshot
+ * is stale (GET /people is an R2 publish, often HTTP-cached). Pending stubs
+ * never overwrite a real person.
+ */
+export function mergePeopleCatalogue(
+  existing: Person[],
+  fetched: Person[] | undefined,
+  extras: Person[] = []
+): Person[] {
+  const byName = new Map<string, Person>();
+
+  const put = (person: Person | undefined, mode: 'replace' | 'fill') => {
+    const name = person?.name?.trim();
+    if (!name || !person) {
+      return;
+    }
+    const current = byName.get(name);
+    if (!current) {
+      byName.set(name, person);
+      return;
+    }
+    if (mode === 'fill') {
+      return;
+    }
+    byName.set(name, person);
+  };
+
+  for (const person of existing) {
+    put(person, 'replace');
+  }
+  for (const person of fetched ?? []) {
+    put(person, 'replace');
+  }
+  for (const person of extras) {
+    put(person, isPendingPersonId(person.id) ? 'fill' : 'replace');
+  }
+
+  return [...byName.values()].sort(comparePeopleBySortKey);
+}
+
+export function catalogueAfterPersonChange(
+  existing: Person[],
+  fetched: Person[] | undefined,
+  personName: string,
+  created?: Person
+): Person[] {
+  const extra = created?.name?.trim()
+    ? created
+    : pendingPerson(personName);
+  return mergePeopleCatalogue(existing, fetched, [extra]);
+}
+
+export function guestNamesWithPerson(
+  current: string[] | null | undefined,
+  personName: string
+): string[] {
+  const names = uniqueStrings(current ?? []);
+  return names.includes(personName) ? names : [...names, personName];
+}
+
+/** Published catalogue plus episode guests and title/description suggestions. */
+export function episodeCataloguePeople(
+  published: Person[],
+  guestPeople?: Person[],
+  suggestions?: { person: Person }[]
+): Person[] {
+  return mergePeopleCatalogue(published, undefined, [
+    ...(guestPeople ?? []),
+    ...(suggestions ?? []).map(x => x.person)
+  ]);
+}
+
 export function regroupGuests(
   allPeople: Person[],
   episodeGuestPeople: Person[] | undefined,
@@ -203,9 +285,9 @@ export function regroupGuests(
   for (const guest of episodeGuestPeople ?? []) {
     peopleByName.set(guest.name, guest);
   }
-  const selectedGuests = selectedNames
-    .map(name => peopleByName.get(name))
-    .filter((x): x is Person => !!x);
+  const selectedGuests = selectedNames.map(name =>
+    peopleByName.get(name) ?? pendingPerson(name)
+  );
 
   const otherPeople = allPeople
     .filter(person => !selectedSet.has(person.name))

--- a/cultpodcasts/src/app/episode-form.util.ts
+++ b/cultpodcasts/src/app/episode-form.util.ts
@@ -273,6 +273,51 @@ export function episodeCataloguePeople(
   ]);
 }
 
+export interface ApplyGuestSelectionInput {
+  allPeople: Person[];
+  /** Optional GET /people snapshot (may be stale / cached). */
+  fetched?: Person[];
+  currentGuests: string[] | null | undefined;
+  personName: string;
+  person?: Person;
+  episodeGuestPeople?: Person[];
+  filterTerm?: string;
+}
+
+export interface ApplyGuestSelectionResult extends RegroupedGuests {
+  allPeople: Person[];
+  guests: string[];
+}
+
+/**
+ * Dialog contract for create-person / suggestion Add: merge into catalogue,
+ * append the guest name, then regroup so Material select has matching options
+ * before setValue.
+ */
+export function applyGuestSelection(input: ApplyGuestSelectionInput): ApplyGuestSelectionResult {
+  const allPeople = catalogueAfterPersonChange(
+    input.allPeople,
+    input.fetched,
+    input.personName,
+    input.person
+  );
+  const guests = guestNamesWithPerson(input.currentGuests, input.personName);
+  const { selectedGuests, otherPeople } = regroupGuests(
+    allPeople,
+    input.episodeGuestPeople,
+    guests,
+    input.filterTerm ?? ''
+  );
+  return { allPeople, guests, selectedGuests, otherPeople };
+}
+
+export function withoutGuestSuggestion<T extends { person: { name: string } }>(
+  suggestions: T[],
+  personName: string
+): T[] {
+  return suggestions.filter(x => x.person.name !== personName);
+}
+
 export function regroupGuests(
   allPeople: Person[],
   episodeGuestPeople: Person[] | undefined,


### PR DESCRIPTION
## Summary
- Fix add/edit episode guest dialogs dropping people after create or suggestion Add (stale `/people` catalogue + Material select clearing values without matching options).
- Merge created/suggested people into the local catalogue before selecting; keep selected names visible even when missing from the published list.

## Test plan
- [ ] Add episode: create person A, then create person B — both stay selected and in the guests dropdown
- [ ] Edit episode: click Add on a title/description suggestion not yet in the published people list — guest appears under Selected and in the Guests field
- [ ] Curate panel suggestion Add still works as before
- [ ] `npm run test` for `episode-form.util.spec.ts` green

## Config / secrets
- [ ] N/A — no new Pages / Auth0 / build secrets

Made with [Cursor](https://cursor.com)