### PR TITLE
feat(ui): episode hashtag, chrome fix, absorb GUID podcast GET

### DIFF
--- a/.cursor/rules/no-api-website-deploys.mdc
+++ b/.cursor/rules/no-api-website-deploys.mdc
@@ -1,0 +1,33 @@
+---
+description: HARD — never deploy Cloudflare Api Worker or website Pages
+alwaysApply: true
+---
+
+# No Api / website deploys (HARD GUARDRAIL)
+
+**Incident (Aug 2026):** Agent ran `wrangler deploy` against top-level production Worker `api` during a preview-only SEO play. Website apex deploy was started and had to be aborted.
+
+## Forbidden always (unless the user explicitly names the exact deploy in this conversation)
+
+| NEVER | Why |
+|-------|-----|
+| `wrangler deploy` / `npm run deploy` in the **Api** repo | Deploys live Worker **`api`** (or wrong env if mistyped) |
+| `wrangler deploy --env preview` / preview Worker publish without explicit ask | Still an Api deploy |
+| `wrangler pages deploy` / `npm run deploy` in **website** / `cultpodcasts` | Deploys Pages (often **production** apex) |
+| Inferring “enable on production” / “ship it” / “flip the switch” as deploy approval | Config/code change ≠ deploy |
+
+## Allowed
+
+| OK | Notes |
+|----|--------|
+| `git push` to a PR/feature branch when the user asks to **push** / **commit and push** | Cloudflare Pages **preview** may build from the push — that is OK; do **not** run Pages/Worker deploy CLIs |
+| Local `wrangler pages dev` / `npm run start` / `npm run dev` | Local only |
+
+## Production vs preview
+
+- Default mindset for Api + website: **preview / PR only**.
+- Never run production Pages deploy without an explicit phrase like **“deploy website production”** or **“npm run deploy to production”**.
+
+## If unsure
+
+**Do not deploy.** Ask which target (preview vs production) and wait.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,7 +13,12 @@
   - Pages Production: `<!-- same names as needed -->`
   - Related Api Worker secrets (if any): `<!-- e.g. secureExampleEndpoint on api-preview + top-level api -->`
 
-At deploy time: read this section and set every named key on **both** environments before calling the release done.
+### Production switchover (before calling release done)
+
+1. Open this PR and read **Config / secrets** above.
+2. Set every named key on Pages **Preview** and **Production** (and Api Worker keys if listed).
+3. Confirm sibling Api / RPP PR `## Config / secrets` checklists are ticked before enabling compile-time FeatureSwitches or behaviour that depends on those keys.
+4. Do **not** treat “preview URL works” as production-ready until production config is confirmed.
 
 ## Test plan
 

--- a/cultpodcasts/AGENTS.md
+++ b/cultpodcasts/AGENTS.md
@@ -2,6 +2,14 @@
 
 Angular PWA / Bubblewrap client for [cultpodcasts.com](https://cultpodcasts.com). It consumes the Cult Podcasts API (`api-infra`) via the Cloudflare API worker.
 
+## No Api / website deploys (HARD)
+
+**Never** run `npm run deploy` / `wrangler pages deploy` (or Api `wrangler deploy`) unless the user
+explicitly names that exact deploy in the current conversation. When the user asks to **push** a PR
+branch, push is OK — Pages **preview** may build from git; do not run deploy CLIs.
+
+- Rule: [`../.cursor/rules/no-api-website-deploys.mdc`](../.cursor/rules/no-api-website-deploys.mdc)
+
 ## Preview ↔ production secrets (HARD)
 
 Any new Pages / Auth0 / build secret for preview/staging **must** also be planned for production. PR body **must** include `## Config / secrets` with **key names** (never values). At deploy, read that section and set both environments.

--- a/cultpodcasts/AGENTS.md
+++ b/cultpodcasts/AGENTS.md
@@ -36,3 +36,7 @@ Auth0 requires hostname **`local.cultpodcasts.com`** (hosts → `127.0.0.1`). De
 | `npm run dev` | `https://local.cultpodcasts.com:4200` |
 
 Build: `ng build`. Mobile/TWA notes: `MOBILE_BUILDS.md`.
+
+## Version bumps (HARD for PRs)
+
+Every website PR that changes shipped client code **MUST** bump `cultpodcasts/package.json` (and `package-lock.json` to match) — patch unless the change warrants minor/major. Do this in the same PR before opening or as the last commit before ready-for-review.

--- a/cultpodcasts/AGENTS.md
+++ b/cultpodcasts/AGENTS.md
@@ -9,6 +9,14 @@ Any new Pages / Auth0 / build secret for preview/staging **must** also be planne
 - Rule: [`../.cursor/rules/preview-production-secrets-parity.mdc`](../.cursor/rules/preview-production-secrets-parity.mdc)
 - Docs: [`docs/preview-production-secrets.md`](docs/preview-production-secrets.md)
 
+## Episode OG share image
+
+Client SEO may use episode art from page-details when
+`FeatureSwitch.episodeOgShareImage` is enabled (default **OFF**).
+
+- Docs: [`docs/episode-og-share-image.md`](docs/episode-og-share-image.md)
+- Preview: test with the switch ON and OFF before enabling in production.
+
 ## Repository layout
 
 - **Git root:** `~\source\repos\website` (parent of this folder). Run `git` commands from the parent repo or paths relative to it.
@@ -70,3 +78,7 @@ Curation KV deploy notes only: [docs/flix-prototype.md](docs/flix-prototype.md).
 | `npm run dev` | `https://local.cultpodcasts.com:4200` |
 
 Build: `ng build`. Mobile/TWA notes: `MOBILE_BUILDS.md`.
+
+## Version bumps (HARD for PRs)
+
+Every website PR that changes shipped client code **MUST** bump `cultpodcasts/package.json` (and `package-lock.json` to match) — patch unless the change warrants minor/major. Do this in the same PR before opening or as the last commit before ready-for-review.

--- a/cultpodcasts/docs/episode-og-share-image.md
+++ b/cultpodcasts/docs/episode-og-share-image.md
@@ -51,3 +51,18 @@ No new Pages env vars for the switch itself (compile-time FeatureSwitch).
 Api may need CF Images / existing Worker bindings already documented for
 `/og-image` — list any **new** secret names in the Api PR body under
 `## Config / secrets` for preview **and** production.
+
+PR bodies **must** keep a `## Config / secrets` section (names only). At
+production switchover, read that section and confirm sibling Api / RPP config
+checklists before enabling this switch in a production build.
+
+## Production switchover checklist
+
+1. [ ] Website PR `## Config / secrets` reviewed (usually N/A for this switch)
+2. [ ] Api PR: `/og-image` + shortener bindings confirmed on **api-preview** and top-level **`api`**
+3. [ ] RPP PR: `twitter__ShortUrlOnlyWhenShareImage` /
+       `bluesky__ShortUrlOnlyWhenShareImage` present on Function Apps (leave **`false`**
+       until short-URL-only social posts are intentionally enabled)
+4. [ ] Ship website with `FeatureSwitch.episodeOgShareImage` = **`false`** unless
+       intentionally enabling SEO episode art in production
+5. [ ] Only after preview ON path validated: flip client switch and/or RPP short-URL-only flags

--- a/cultpodcasts/docs/episode-og-share-image.md
+++ b/cultpodcasts/docs/episode-og-share-image.md
@@ -1,0 +1,53 @@
+# Episode OG / Twitter share image
+
+Episode pages can use artwork from page-details (shortener KV / search) for
+`og:image` and `twitter:image` instead of the site icon.
+
+## Feature switch (default OFF)
+
+| Switch | Location | Default |
+|--------|----------|---------|
+| `FeatureSwitch.episodeOgShareImage` | [`feature-switch.enum.ts`](../src/app/feature-switch.enum.ts) / [`feature-switch-service.ts`](../src/app/feature-switch-service.ts) | **`false`** |
+
+When OFF, SEO keeps `/assets/sq-image.png` and `twitter:card=summary` even if
+page-details returns `image` / `imageAspect`.
+
+When ON, SSR uses page-details image (Api `/og-image` branded URL when present)
+and may set `summary_large_image` for wide art.
+
+## Dependencies
+
+- **Api** creates shortener KV share-image metadata on `/pagedetails` miss and
+  exposes `/og-image` (shipped with Api worker; not gated by this client switch).
+- **Indexer** may write the same metadata when posting (short-URL-only social
+  posts are separately gated in RedditPodcastPoster config).
+
+## Preview test plan (ON and OFF)
+
+Deploy website **preview** against Api **preview** that includes share-image
+page-details.
+
+### OFF (default — production-safe)
+
+1. Leave `FeatureSwitch.episodeOgShareImage` = `false`.
+2. Open an episode page on the preview host (View Source / curl SSR HTML).
+3. Expect `og:image` → site icon (`…/assets/sq-image.png`).
+4. Expect `twitter:card` → `summary`.
+
+### ON (preview-only flip)
+
+1. Temporarily set `FeatureSwitch.episodeOgShareImage` → `true` in
+   `feature-switch-service.ts`, deploy preview only (do not flip production).
+2. Open an episode that has shortener KV art (or trigger page-details miss so
+   Api creates KV from search).
+3. Expect `og:image` / `twitter:image` → episode art (often Api `/og-image?…`).
+4. Wide YouTube-style art → `twitter:card=summary_large_image`.
+5. Revert switch to `false` before production release unless intentionally
+   enabling the feature.
+
+## Config / secrets
+
+No new Pages env vars for the switch itself (compile-time FeatureSwitch).
+Api may need CF Images / existing Worker bindings already documented for
+`/og-image` — list any **new** secret names in the Api PR body under
+`## Config / secrets` for preview **and** production.

--- a/cultpodcasts/docs/episode-og-share-image.md
+++ b/cultpodcasts/docs/episode-og-share-image.md
@@ -13,7 +13,8 @@ When OFF, SEO keeps `/assets/sq-image.png` and `twitter:card=summary` even if
 page-details returns `image` / `imageAspect`.
 
 When ON, SSR uses page-details image (Api `/og-image` branded URL when present)
-and may set `summary_large_image` for wide art.
+and sets `twitter:card=summary_large_image` for both wide and square episode art
+(`summary` only for the site-icon fallback).
 
 ## Dependencies
 
@@ -41,7 +42,7 @@ page-details.
 2. Open an episode that has shortener KV art (or trigger page-details miss so
    Api creates KV from search).
 3. Expect `og:image` / `twitter:image` → episode art (often Api `/og-image?…`).
-4. Wide YouTube-style art → `twitter:card=summary_large_image`.
+4. Expect `twitter:card=summary_large_image` for wide and square episode art.
 5. Revert switch to `false` before production release unless intentionally
    enabling the feature.
 

--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.94",
+  "version": "1.10.95",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.10.94",
+      "version": "1.10.95",
       "dependencies": {
         "@angular/cdk": "22.1.0",
         "@angular/common": "22.1.0",

--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.104",
+  "version": "1.10.105",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.10.104",
+      "version": "1.10.105",
       "dependencies": {
         "@angular/cdk": "22.1.0",
         "@angular/common": "22.1.0",

--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.99",
+  "version": "1.10.100",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.10.99",
+      "version": "1.10.100",
       "dependencies": {
         "@angular/cdk": "22.1.0",
         "@angular/common": "22.1.0",

--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.96",
+  "version": "1.10.97",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.10.96",
+      "version": "1.10.97",
       "dependencies": {
         "@angular/cdk": "22.1.0",
         "@angular/common": "22.1.0",

--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.10.3",
+      "version": "1.10.4",
       "dependencies": {
         "@angular/cdk": "^22.0.6",
         "@angular/common": "^22.0.8",

--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.100",
+  "version": "1.10.101",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.10.100",
+      "version": "1.10.101",
       "dependencies": {
         "@angular/cdk": "22.1.0",
         "@angular/common": "22.1.0",

--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.101",
+  "version": "1.10.102",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.10.101",
+      "version": "1.10.102",
       "dependencies": {
         "@angular/cdk": "22.1.0",
         "@angular/common": "22.1.0",

--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.95",
+  "version": "1.10.96",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.10.95",
+      "version": "1.10.96",
       "dependencies": {
         "@angular/cdk": "22.1.0",
         "@angular/common": "22.1.0",

--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.102",
+  "version": "1.10.103",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.10.102",
+      "version": "1.10.103",
       "dependencies": {
         "@angular/cdk": "22.1.0",
         "@angular/common": "22.1.0",

--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.103",
+  "version": "1.10.104",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.10.103",
+      "version": "1.10.104",
       "dependencies": {
         "@angular/cdk": "22.1.0",
         "@angular/common": "22.1.0",

--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.98",
+  "version": "1.10.99",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.10.98",
+      "version": "1.10.99",
       "dependencies": {
         "@angular/cdk": "22.1.0",
         "@angular/common": "22.1.0",

--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.97",
+  "version": "1.10.98",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.10.97",
+      "version": "1.10.98",
       "dependencies": {
         "@angular/cdk": "22.1.0",
         "@angular/common": "22.1.0",

--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.93",
+  "version": "1.10.94",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.10.93",
+      "version": "1.10.94",
       "dependencies": {
         "@angular/cdk": "22.1.0",
         "@angular/common": "22.1.0",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.96",
+  "version": "1.10.97",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.98",
+  "version": "1.10.99",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,9 +1,9 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.102",
+  "version": "1.10.103",
   "scripts": {
     "ng": "ng",
-    "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",
+    "start": "node ./tools/start-local.mjs",
     "build": "ng build --configuration",
     "build:staging": "ng build --configuration staging",
     "build:local": "ng build --configuration local",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.101",
+  "version": "1.10.102",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.103",
+  "version": "1.10.104",
   "scripts": {
     "ng": "ng",
     "start": "node ./tools/start-local.mjs",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.95",
+  "version": "1.10.96",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.94",
+  "version": "1.10.95",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.97",
+  "version": "1.10.98",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.99",
+  "version": "1.10.100",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.100",
+  "version": "1.10.101",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.93",
+  "version": "1.10.94",
   "scripts": {
     "ng": "ng",
     "start": "ng build --configuration local && npm run process && wrangler pages dev dist/cloudflare --compatibility-date=2024-09-02 --local-protocol https --https-cert-path .cert/dev-cert.pem --https-key-path .cert/dev-key.pem --port 8788 --kv kv --r2 content",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.104",
+  "version": "1.10.105",
   "scripts": {
     "ng": "ng",
     "start": "node ./tools/start-local.mjs",

--- a/cultpodcasts/prerender-routes
+++ b/cultpodcasts/prerender-routes
@@ -1,3 +1,1 @@
 /
-/content/privacy-policy
-/content/terms-and-conditions

--- a/cultpodcasts/prerender-routes
+++ b/cultpodcasts/prerender-routes
@@ -1,1 +1,3 @@
 /
+/content/privacy-policy
+/content/terms-and-conditions

--- a/cultpodcasts/server.ts
+++ b/cultpodcasts/server.ts
@@ -37,10 +37,11 @@ async function workerFetchHandler(request: Request, env: Env) {
 	const document = await indexResponse.text();
 
 	// Auth-gated curator/user pages cannot SSR meaningfully (FakeAuth has no
-	// session). Rendering a shell and hydrating it crashes the client
-	// (nextSibling/hasAttribute on null) and leaves the page forever loading.
-	// Serve the empty app shell and let the browser do CSR after Auth0 restores.
-	if (isAuthClientOnlyPath(url.pathname)) {
+	// session). Static /content/* legal pages also abort client hydration
+	// (NG0500 / hasAttribute) and leave toolbar/search dead despite a matching
+	// chrome shell — same nextSibling crash class as FakeAuth routes.
+	// Serve the empty app shell and let the browser do CSR.
+	if (isClientOnlyPath(url.pathname)) {
 		console.log("CSR shell (skip SSR)", url.pathname);
 		return new Response(document, indexResponse);
 	}
@@ -57,13 +58,14 @@ async function workerFetchHandler(request: Request, env: Env) {
 	return new Response(content, indexResponse);
 }
 
-/** Routes that must boot on the client after Auth0 — never SSR with FakeAuth. */
-function isAuthClientOnlyPath(pathname: string): boolean {
+/** Routes that must boot on the client — never hydrate an SSR tree. */
+function isClientOnlyPath(pathname: string): boolean {
 	return pathname === "/discovery"
 		|| pathname === "/outgoingEpisodes"
 		|| pathname === "/bookmarks"
 		|| pathname === "/unauthorised"
-		|| pathname.startsWith("/episodes/");
+		|| pathname.startsWith("/episodes/")
+		|| pathname.startsWith("/content/");
 }
 
 export default {

--- a/cultpodcasts/server.ts
+++ b/cultpodcasts/server.ts
@@ -43,8 +43,8 @@ async function workerFetchHandler(request: Request, env: Env) {
 	// session). Rendering a shell and hydrating it crashes the client
 	// (nextSibling/hasAttribute on null) and leaves the page forever loading.
 	// Serve the empty app shell and let the browser do CSR after Auth0 restores.
-	// Legal /content/* pages SSR at request time (not prerender/SSG) so
-	// view-source includes privacy/terms body; child routes keep hydration aligned.
+	// Privacy/terms are prerendered (SSG) and excluded in _routes.json so CF Pages
+	// serves static HTML — this Worker path must not re-render those URLs.
 	if (isAuthClientOnlyPath(url.pathname)) {
 		console.log("CSR shell (skip SSR)", url.pathname);
 		return new Response(document, indexResponse);

--- a/cultpodcasts/server.ts
+++ b/cultpodcasts/server.ts
@@ -1,6 +1,7 @@
 import { renderApplication } from "@angular/platform-server";
 import { KVNamespace, R2Bucket } from '@cloudflare/workers-types';
 import bootstrap from "./src/main.server";
+import { isAuthClientOnlyPath } from "./src/app/auth-client-only-path";
 
 interface Env {
 	ASSETS: { fetch: typeof fetch };
@@ -60,15 +61,6 @@ async function workerFetchHandler(request: Request, env: Env) {
 
 	console.log("rendered SSR");
 	return new Response(content, indexResponse);
-}
-
-/** Routes that must boot on the client after Auth0 — never SSR with FakeAuth. */
-function isAuthClientOnlyPath(pathname: string): boolean {
-	return pathname === "/discovery"
-		|| pathname === "/outgoingEpisodes"
-		|| pathname === "/bookmarks"
-		|| pathname === "/unauthorised"
-		|| pathname.startsWith("/episodes/");
 }
 
 export default {

--- a/cultpodcasts/server.ts
+++ b/cultpodcasts/server.ts
@@ -31,17 +31,21 @@ async function workerFetchHandler(request: Request, env: Env) {
 		}
 	}
 
-	// Get the root `index.html` content.
-	const indexUrl = new URL("/", url);
+	// Bootstrap SSR from the empty CSR shell — NOT prerendered `/` index.html.
+	// Fetching `/` returns SSG homepage HTML + ng-state; renderApplication would
+	// append a second ng-state and wrong ngh indices, aborting hydration on
+	// /content/* (NG0500: expected div, found section) and leaving chrome dead.
+	const indexUrl = new URL("/index.csr.html", url);
 	const indexResponse = await env.ASSETS.fetch(new Request(indexUrl));
 	const document = await indexResponse.text();
 
 	// Auth-gated curator/user pages cannot SSR meaningfully (FakeAuth has no
-	// session). Static /content/* legal pages also abort client hydration
-	// (NG0500 / hasAttribute) and leave toolbar/search dead despite a matching
-	// chrome shell — same nextSibling crash class as FakeAuth routes.
-	// Serve the empty app shell and let the browser do CSR.
-	if (isClientOnlyPath(url.pathname)) {
+	// session). Rendering a shell and hydrating it crashes the client
+	// (nextSibling/hasAttribute on null) and leaves the page forever loading.
+	// Serve the empty app shell and let the browser do CSR after Auth0 restores.
+	// Legal /content/* pages SSR at request time (not prerender/SSG) so
+	// view-source includes privacy/terms body; child routes keep hydration aligned.
+	if (isAuthClientOnlyPath(url.pathname)) {
 		console.log("CSR shell (skip SSR)", url.pathname);
 		return new Response(document, indexResponse);
 	}
@@ -58,14 +62,13 @@ async function workerFetchHandler(request: Request, env: Env) {
 	return new Response(content, indexResponse);
 }
 
-/** Routes that must boot on the client — never hydrate an SSR tree. */
-function isClientOnlyPath(pathname: string): boolean {
+/** Routes that must boot on the client after Auth0 — never SSR with FakeAuth. */
+function isAuthClientOnlyPath(pathname: string): boolean {
 	return pathname === "/discovery"
 		|| pathname === "/outgoingEpisodes"
 		|| pathname === "/bookmarks"
 		|| pathname === "/unauthorised"
-		|| pathname.startsWith("/episodes/")
-		|| pathname.startsWith("/content/");
+		|| pathname.startsWith("/episodes/");
 }
 
 export default {

--- a/cultpodcasts/src/_routes.json
+++ b/cultpodcasts/src/_routes.json
@@ -11,5 +11,12 @@
 		"/episodes/*",
 		"/unauthorised"
 	],
-	"exclude": []
+	"exclude": [
+		"/content/privacy-policy",
+		"/content/privacy-policy/",
+		"/content/privacy-policy/index.html",
+		"/content/terms-and-conditions",
+		"/content/terms-and-conditions/",
+		"/content/terms-and-conditions/index.html"
+	]
 }

--- a/cultpodcasts/src/app/add-episode-dialog/add-episode-dialog.component.html
+++ b/cultpodcasts/src/app/add-episode-dialog/add-episode-dialog.component.html
@@ -219,6 +219,14 @@
                     <input type="text" [formControl]="form()!.controls.searchTerms" matInput>
                 </mat-form-field>
                 <mat-form-field class="full-width">
+                    <mat-label>Hash Tag</mat-label>
+                    <input type="text" [formControl]="form()!.controls.hashTag" matInput
+                        placeholder="#tag1 #tag2" (blur)="normalizeHashTag()">
+                    @if (form()!.controls.hashTag.hasError('hashPrefixedTag')) {
+                    <mat-error>Each tag must start with #</mat-error>
+                    }
+                </mat-form-field>
+                <mat-form-field class="full-width">
                     <mat-label>Language</mat-label>
                     <mat-select [formControl]="form()!.controls.lang">
                         @for (language of languages() | keyvalue:null; track language) {

--- a/cultpodcasts/src/app/add-episode-dialog/add-episode-dialog.component.ts
+++ b/cultpodcasts/src/app/add-episode-dialog/add-episode-dialog.component.ts
@@ -48,6 +48,7 @@ import {
   withoutGuestSuggestion,
   type EpisodeImageService
 } from '../episode-form.util';
+import { normalizeHashTagControl } from '../podcast-form.util';
 
 @Component({
   selector: 'app-add-episode-dialog',
@@ -196,6 +197,13 @@ export class AddEpisodeDialogComponent {
     clearFormControl(control);
   }
 
+  normalizeHashTag() {
+    const control = this.form()?.controls.hashTag;
+    if (control) {
+      normalizeHashTagControl(control);
+    }
+  }
+
   previewImage(service: EpisodeImageService) {
     const form = this.form();
     if (!form) {
@@ -236,6 +244,7 @@ export class AddEpisodeDialogComponent {
         },
         subjects: form.controls.subjects.value,
         searchTerms: form.controls.searchTerms.value,
+        hashTag: form.controls.hashTag.value?.trim() || null,
         lang: form.controls.lang.value || "unset",
         guests: form.controls.guests.value,
       };

--- a/cultpodcasts/src/app/api-episode.interface.ts
+++ b/cultpodcasts/src/app/api-episode.interface.ts
@@ -23,6 +23,7 @@ export interface ApiEpisode {
     images?: EpisodeImageUrls;
     subjects: string[];
     searchTerms?: string | null;
+    hashTag?: string | null;
     youTubePodcast?: boolean;
     spotifyPodcast?: boolean;
     applePodcast?: boolean;

--- a/cultpodcasts/src/app/app-chrome-dock.contract.spec.ts
+++ b/cultpodcasts/src/app/app-chrome-dock.contract.spec.ts
@@ -82,12 +82,17 @@ describe('site chrome docked search (privacy-policy cold load)', () => {
     expect(sass).toMatch(/\.drop-overlay--active/);
   });
 
-  it('CHROME-DOCK-008: no prerendered /content/*; server CSR-shells content paths', () => {
+  it('CHROME-DOCK-008: no prerendered /content/*; server SSRs content from index.csr.html', () => {
     const serverTs = readFileSync(join(__dirname, '../../server.ts'), 'utf8');
     const prerenderRoutes = readFileSync(join(__dirname, '../../prerender-routes'), 'utf8');
-    expect(serverTs).toMatch(/pathname\.startsWith\(['"]\/content\//);
-    expect(serverTs).toMatch(/isClientOnlyPath/);
     expect(prerenderRoutes).not.toMatch(/\/content\//);
+    // Must not CSR-shell legal pages — request-time SSR so view-source has body text.
+    expect(serverTs).not.toMatch(/pathname\.startsWith\(['"]\/content\//);
+    expect(serverTs).toMatch(/isAuthClientOnlyPath/);
+    expect(serverTs).toMatch(/renderApplication/);
+    // Empty CSR shell only — never bootstrap from prerendered `/` (duplicate ng-state / NG0500).
+    expect(serverTs).toMatch(/index\.csr\.html/);
+    expect(serverTs).toMatch(/new URL\(\s*['"]\/index\.csr\.html['"]/);
   });
 
   it('CHROME-DOCK-007: chromeStuck is computed from isHomePage so browse SSR emits chrome-stuck', () => {

--- a/cultpodcasts/src/app/app-chrome-dock.contract.spec.ts
+++ b/cultpodcasts/src/app/app-chrome-dock.contract.spec.ts
@@ -11,6 +11,14 @@ describe('site chrome docked search (privacy-policy cold load)', () => {
     join(__dirname, 'toolbar/toolbar.component.ts'),
     'utf8'
   );
+  const searchBarTs = readFileSync(
+    join(__dirname, 'search-bar/search-bar.component.ts'),
+    'utf8'
+  );
+  const contentTs = readFileSync(
+    join(__dirname, 'content/content.component.ts'),
+    'utf8'
+  );
 
   it('CHROME-DOCK-001: docked search wrapper uses pointer-events none so add/profile stay clickable under z-index 110', () => {
     expect(sass).toMatch(
@@ -36,5 +44,16 @@ describe('site chrome docked search (privacy-policy cold load)', () => {
     expect(toolbarTs).not.toMatch(/host:\s*\{\s*ngSkipHydration/);
     expect(toolbarTs).toMatch(/afterNextRender/);
     expect(toolbarTs).toMatch(/authChromeReady/);
+  });
+
+  it('CHROME-DOCK-004: search-bar hydrates (no ngSkipHydration) so typeahead listeners bind on cold load', () => {
+    expect(searchBarTs).not.toMatch(/ngSkipHydration:\s*['"]true['"]/);
+    expect(searchBarTs).not.toMatch(/host:\s*\{\s*ngSkipHydration/);
+    expect(searchBarTs).toMatch(/applyChipFromUrl/);
+  });
+
+  it('CHROME-DOCK-005: content path seeds from route snapshot so privacy SSR hydrates (not @default Not Found)', () => {
+    expect(contentTs).toMatch(/snapshot\.params\[['"]path['"]\]/);
+    expect(contentTs).not.toMatch(/signal<\s*string\s*\|\s*undefined\s*>\(\s*undefined\s*\)/);
   });
 });

--- a/cultpodcasts/src/app/app-chrome-dock.contract.spec.ts
+++ b/cultpodcasts/src/app/app-chrome-dock.contract.spec.ts
@@ -7,13 +7,20 @@ describe('site chrome docked search (privacy-policy cold load)', () => {
     join(__dirname, 'app.component.sass'),
     'utf8'
   );
+  const toolbarTs = readFileSync(
+    join(__dirname, 'toolbar/toolbar.component.ts'),
+    'utf8'
+  );
 
   it('CHROME-DOCK-001: docked search wrapper uses pointer-events none so add/profile stay clickable under z-index 110', () => {
     expect(sass).toMatch(
       /\.chrome-search--docked[\s\S]*?pointer-events:\s*none/
     );
     expect(sass).toMatch(
-      /\.chrome-search--docked[\s\S]*?#searchbar[\s\S]*?pointer-events:\s*auto/
+      /\.chrome-search--docked[\s\S]*?#searchboxwrapper[\s\S]*?pointer-events:\s*auto/
+    );
+    expect(sass).toMatch(
+      /\.chrome-search--docked[\s\S]*?#searchbar[\s\S]*?pointer-events:\s*none/
     );
   });
 
@@ -22,5 +29,12 @@ describe('site chrome docked search (privacy-policy cold load)', () => {
     expect(sass).not.toMatch(
       /\.chrome-search--docked[\s\S]*?width:\s*calc\(100vw - 11rem\)/
     );
+  });
+
+  it('CHROME-DOCK-003: toolbar hydrates (no ngSkipHydration) so Add/Profile click handlers bind on cold load', () => {
+    expect(toolbarTs).not.toMatch(/ngSkipHydration:\s*['"]true['"]/);
+    expect(toolbarTs).not.toMatch(/host:\s*\{\s*ngSkipHydration/);
+    expect(toolbarTs).toMatch(/afterNextRender/);
+    expect(toolbarTs).toMatch(/authChromeReady/);
   });
 });

--- a/cultpodcasts/src/app/app-chrome-dock.contract.spec.ts
+++ b/cultpodcasts/src/app/app-chrome-dock.contract.spec.ts
@@ -7,6 +7,14 @@ describe('site chrome docked search (privacy-policy cold load)', () => {
     join(__dirname, 'app.component.sass'),
     'utf8'
   );
+  const appHtml = readFileSync(
+    join(__dirname, 'app.component.html'),
+    'utf8'
+  );
+  const appTs = readFileSync(
+    join(__dirname, 'app.component.ts'),
+    'utf8'
+  );
   const toolbarTs = readFileSync(
     join(__dirname, 'toolbar/toolbar.component.ts'),
     'utf8'
@@ -17,6 +25,14 @@ describe('site chrome docked search (privacy-policy cold load)', () => {
   );
   const contentTs = readFileSync(
     join(__dirname, 'content/content.component.ts'),
+    'utf8'
+  );
+  const contentHtml = readFileSync(
+    join(__dirname, 'content/content.component.html'),
+    'utf8'
+  );
+  const routesTs = readFileSync(
+    join(__dirname, 'app.routes.ts'),
     'utf8'
   );
 
@@ -52,8 +68,31 @@ describe('site chrome docked search (privacy-policy cold load)', () => {
     expect(searchBarTs).toMatch(/applyChipFromUrl/);
   });
 
-  it('CHROME-DOCK-005: content path seeds from route snapshot so privacy SSR hydrates (not @default Not Found)', () => {
-    expect(contentTs).toMatch(/snapshot\.params\[['"]path['"]\]/);
-    expect(contentTs).not.toMatch(/signal<\s*string\s*\|\s*undefined\s*>\(\s*undefined\s*\)/);
+  it('CHROME-DOCK-005: content pages use child routes (no @switch on :path)', () => {
+    expect(contentHtml).toMatch(/router-outlet/);
+    expect(contentHtml).not.toMatch(/@switch/);
+    expect(contentTs).not.toMatch(/ngSkipHydration/);
+    expect(routesTs).toMatch(/path:\s*['"]privacy-policy['"]/);
+    expect(routesTs).toMatch(/PrivacyPolicyComponent/);
+  });
+
+  it('CHROME-DOCK-006: drop overlay host stays mounted; idle body is structural @if inside', () => {
+    expect(appHtml).toMatch(/drop-overlay--active/);
+    expect(appHtml).toMatch(/@if\s*\(\s*isDragOver\(\)\s*\)/);
+    expect(sass).toMatch(/\.drop-overlay--active/);
+  });
+
+  it('CHROME-DOCK-008: no prerendered /content/*; server CSR-shells content paths', () => {
+    const serverTs = readFileSync(join(__dirname, '../../server.ts'), 'utf8');
+    const prerenderRoutes = readFileSync(join(__dirname, '../../prerender-routes'), 'utf8');
+    expect(serverTs).toMatch(/pathname\.startsWith\(['"]\/content\//);
+    expect(serverTs).toMatch(/isClientOnlyPath/);
+    expect(prerenderRoutes).not.toMatch(/\/content\//);
+  });
+
+  it('CHROME-DOCK-007: chromeStuck is computed from isHomePage so browse SSR emits chrome-stuck', () => {
+    expect(appTs).toMatch(/homeScrollDocked/);
+    expect(appTs).toMatch(/chromeStuck\s*=\s*computed/);
+    expect(appTs).not.toMatch(/chromeStuck\s*=\s*signal\(/);
   });
 });

--- a/cultpodcasts/src/app/app-chrome-dock.contract.spec.ts
+++ b/cultpodcasts/src/app/app-chrome-dock.contract.spec.ts
@@ -82,17 +82,27 @@ describe('site chrome docked search (privacy-policy cold load)', () => {
     expect(sass).toMatch(/\.drop-overlay--active/);
   });
 
-  it('CHROME-DOCK-008: no prerendered /content/*; server SSRs content from index.csr.html', () => {
+  it('CHROME-DOCK-008: privacy/terms are prerendered SSG and excluded from the Pages Worker', () => {
     const serverTs = readFileSync(join(__dirname, '../../server.ts'), 'utf8');
+    const mainServer = readFileSync(join(__dirname, '../../src/main.server.ts'), 'utf8');
     const prerenderRoutes = readFileSync(join(__dirname, '../../prerender-routes'), 'utf8');
-    expect(prerenderRoutes).not.toMatch(/\/content\//);
-    // Must not CSR-shell legal pages — request-time SSR so view-source has body text.
+    const routesJson = readFileSync(join(__dirname, '../_routes.json'), 'utf8');
+    expect(prerenderRoutes).toMatch(/\/content\/privacy-policy/);
+    expect(prerenderRoutes).toMatch(/\/content\/terms-and-conditions/);
+    // Static asset serve — Worker must not re-SSR (would fight the SSG tree).
+    expect(routesJson).toMatch(/\/content\/privacy-policy/);
+    expect(routesJson).toMatch(/\/content\/terms-and-conditions/);
+    expect(routesJson).toMatch(/"exclude"/);
+    // Must not CSR-shell legal pages (body must be in the baked HTML).
     expect(serverTs).not.toMatch(/pathname\.startsWith\(['"]\/content\//);
     expect(serverTs).toMatch(/isAuthClientOnlyPath/);
     expect(serverTs).toMatch(/renderApplication/);
-    // Empty CSR shell only — never bootstrap from prerendered `/` (duplicate ng-state / NG0500).
+    // Other SSR routes still bootstrap from empty CSR shell (never homepage index.html).
     expect(serverTs).toMatch(/index\.csr\.html/);
     expect(serverTs).toMatch(/new URL\(\s*['"]\/index\.csr\.html['"]/);
+    // Local HTTPS uses .cert — no NODE_TLS_REJECT_UNAUTHORIZED / ssrIgnoresSsl.
+    expect(mainServer).not.toMatch(/NODE_TLS_REJECT_UNAUTHORIZED/);
+    expect(mainServer).not.toMatch(/ssrIgnoresSsl/);
   });
 
   it('CHROME-DOCK-007: chromeStuck is computed from isHomePage so browse SSR emits chrome-stuck', () => {

--- a/cultpodcasts/src/app/app-chrome-dock.contract.spec.ts
+++ b/cultpodcasts/src/app/app-chrome-dock.contract.spec.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('site chrome docked search (privacy-policy cold load)', () => {
+  const sass = readFileSync(
+    join(__dirname, 'app.component.sass'),
+    'utf8'
+  );
+
+  it('CHROME-DOCK-001: docked search wrapper uses pointer-events none so add/profile stay clickable under z-index 110', () => {
+    expect(sass).toMatch(
+      /\.chrome-search--docked[\s\S]*?pointer-events:\s*none/
+    );
+    expect(sass).toMatch(
+      /\.chrome-search--docked[\s\S]*?#searchbar[\s\S]*?pointer-events:\s*auto/
+    );
+  });
+
+  it('CHROME-DOCK-002: CSS fallback leaves right inset for toolbar actions instead of full-bleed width', () => {
+    expect(sass).toMatch(/\.chrome-search--docked[\s\S]*?right:\s*7rem/);
+    expect(sass).not.toMatch(
+      /\.chrome-search--docked[\s\S]*?width:\s*calc\(100vw - 11rem\)/
+    );
+  });
+});

--- a/cultpodcasts/src/app/app.component.html
+++ b/cultpodcasts/src/app/app.component.html
@@ -1,10 +1,9 @@
 <div id="top"></div>
-@if (isDragOver()) {
-<div class="drop-overlay" aria-hidden="true"
+<div class="drop-overlay" [class.drop-overlay--active]="isDragOver()" [attr.aria-hidden]="!isDragOver()"
   (dragover)="onDragOver($event)"
   (drop)="onDrop($event)">
-  @if (isOnPodcastPage() && canSubmitUrlForPodcast()) {
-  <div class="drop-targets">
+  @if (isDragOver()) {
+  <div class="drop-targets" [hidden]="!(isOnPodcastPage() && canSubmitUrlForPodcast())">
     <div class="drop-target"
       [class.drop-target-active]="activeDropTarget() === 'general'"
       (dragenter)="onTargetDragEnter('general', $event)"
@@ -26,11 +25,9 @@
       <p class="drop-target-desc">Link this episode to the podcast shown on this page.</p>
     </div>
   </div>
-  } @else {
-  <p class="drop-overlay-message">Drop episode link to submit</p>
+  <p class="drop-overlay-message" [hidden]="isOnPodcastPage() && canSubmitUrlForPodcast()">Drop episode link to submit</p>
   }
 </div>
-}
 <section id="body"
   [class.home-shell]="isHomePage()"
   [class.browse-shell]="!isHomePage()"

--- a/cultpodcasts/src/app/app.component.sass
+++ b/cultpodcasts/src/app/app.component.sass
@@ -147,19 +147,31 @@
 // Left/width/top are set in AppComponent.layoutDockedSearch() from those anchors.
 .chrome-search--docked
     position: fixed
-    // Fallback before the first measure — icon-only logo + actions.
+    // Fallback before the first measure — leave room for add/profile (JS tightens).
     left: 70px
+    right: 7rem
     top: calc((var(--site-chrome-bar-h) - var(--nflx-search-h)) / 2)
-    width: calc(100vw - 11rem)
+    width: auto
     max-width: none
     // Size the input row only — do not clip the typeahead listbox below.
     height: var(--nflx-search-h)
     margin: 0
+    // Above the frosted bar (102) so the field is visible in the logo↔actions gap.
+    // Must not steal clicks from add/profile: bar is a full-width sibling at z-index 102,
+    // so child z-index on #socialbuttons cannot win. Pass events through the wrapper.
     z-index: 110
+    pointer-events: none
     transform: none
     --nflx-search-h: 40px
     overflow: visible
     ::ng-deep
+        #searchcontainer,
+        #searchbar,
+        #searchboxwrapper,
+        #searchbox,
+        #searchcta,
+        #search-suggestions-listbox
+            pointer-events: auto
         #searchbar
             gap: 8px
             min-width: 0
@@ -197,7 +209,8 @@
     .chrome-search--docked
         // Between logo icon and overflow menu.
         left: 58px
-        width: calc(100vw - 7rem)
+        right: 3.5rem
+        width: auto
         ::ng-deep
             #searchbar
                 gap: 6px

--- a/cultpodcasts/src/app/app.component.sass
+++ b/cultpodcasts/src/app/app.component.sass
@@ -320,12 +320,16 @@
     position: fixed
     inset: 0
     z-index: 1000
-    display: flex
+    display: none
     align-items: center
     justify-content: center
     padding: 16px
     background: color-mix(in srgb, var(--cp-ink, #0b0d12) 72%, transparent)
     backdrop-filter: blur(8px)
+    pointer-events: none
+    &.drop-overlay--active
+        display: flex
+        pointer-events: auto
 
 .drop-overlay-message
     margin: 0

--- a/cultpodcasts/src/app/app.component.sass
+++ b/cultpodcasts/src/app/app.component.sass
@@ -165,16 +165,18 @@
     --nflx-search-h: 40px
     overflow: visible
     ::ng-deep
-        #searchcontainer,
-        #searchbar,
+        // Do NOT enable pointer-events on #searchcontainer / #searchbar — they span the
+        // full docked width and would still cover add/profile when measure is late/wide.
         #searchboxwrapper,
-        #searchbox,
         #searchcta,
         #search-suggestions-listbox
             pointer-events: auto
         #searchbar
             gap: 8px
             min-width: 0
+            pointer-events: none
+        #searchcontainer
+            pointer-events: none
         #searchboxwrapper
             flex: 1 1 auto
             min-width: 0

--- a/cultpodcasts/src/app/app.component.ts
+++ b/cultpodcasts/src/app/app.component.ts
@@ -97,6 +97,8 @@ export class AppComponent implements OnDestroy, AfterViewInit {
   /** scrollY when search last docked — used to undock without flicker. */
   private dockAtScrollY = 0;
   private narrowChromeQuery: MediaQueryList | undefined;
+  /** Remeasure docked search when skip-hydration toolbar end controls settle. */
+  private chromeEndControlsObserver: ResizeObserver | undefined;
 
   @ViewChild(ToolbarComponent)
   private toolbar!: ToolbarComponent;
@@ -134,6 +136,7 @@ export class AppComponent implements OnDestroy, AfterViewInit {
   ngAfterViewInit(): void {
     // Cold-load browse routes start docked; measure before fallback CSS covers toolbar actions.
     scheduleChromeSync(() => this.syncChromeFromScroll(), this.isBrowser);
+    this.observeChromeEndControls();
   }
 
   ngOnDestroy(): void {
@@ -143,6 +146,7 @@ export class AppComponent implements OnDestroy, AfterViewInit {
       this.removeScrollListener();
       this.narrowChromeQuery?.removeEventListener('change', this.onNarrowChromeChange);
       window.removeEventListener('resize', this.onWindowResize);
+      this.chromeEndControlsObserver?.disconnect();
     }
   }
 
@@ -382,13 +386,40 @@ export class AppComponent implements OnDestroy, AfterViewInit {
     const top = Math.max(0, (barHeight - searchHeight) / 2);
 
     search.style.left = `${left}px`;
+    search.style.right = 'auto';
     search.style.width = `${width}px`;
     search.style.top = `${top}px`;
     search.style.transform = 'none';
   }
 
+  /** Toolbar uses ngSkipHydration — remasure when add/profile/menu size changes. */
+  private observeChromeEndControls(): void {
+    if (!this.isBrowser || typeof ResizeObserver === 'undefined') {
+      return;
+    }
+    const bar = this.chromeBar?.nativeElement;
+    if (!bar) {
+      return;
+    }
+    this.chromeEndControlsObserver?.disconnect();
+    this.chromeEndControlsObserver = new ResizeObserver(() => {
+      if (this.chromeStuck()) {
+        this.layoutDockedSearch();
+      }
+    });
+    const social = bar.querySelector('#socialbuttons');
+    const menu = bar.querySelector('button#menu');
+    if (social) {
+      this.chromeEndControlsObserver.observe(social);
+    }
+    if (menu) {
+      this.chromeEndControlsObserver.observe(menu);
+    }
+  }
+
   private clearDockedSearchLayout(search: HTMLElement): void {
     search.style.left = '';
+    search.style.right = '';
     search.style.width = '';
     search.style.top = '';
     search.style.transform = '';

--- a/cultpodcasts/src/app/app.component.ts
+++ b/cultpodcasts/src/app/app.component.ts
@@ -1,4 +1,5 @@
 import {
+  AfterViewInit,
   ChangeDetectionStrategy,
   Component,
   DestroyRef,
@@ -45,7 +46,7 @@ import { filter, map, startWith } from 'rxjs';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 
-export class AppComponent implements OnDestroy {
+export class AppComponent implements OnDestroy, AfterViewInit {
   private static readonly BACK_TO_TOP_THRESHOLD_PX = 480;
   private static readonly DOCK_INLINE_GAP_PX = 12;
   /** Don't dock at rest on wide — homepage search must start dropped below the fixed bar. */
@@ -129,6 +130,14 @@ export class AppComponent implements OnDestroy {
     }
   }
 
+  ngAfterViewInit(): void {
+    if (!this.isBrowser) {
+      return;
+    }
+    // Cold-load browse routes start docked; measure before fallback CSS covers toolbar actions.
+    requestAnimationFrame(() => requestAnimationFrame(() => this.syncChromeFromScroll()));
+  }
+
   ngOnDestroy(): void {
     if (this.isBrowser) {
       this.clearIgnoreDragTimer();
@@ -148,6 +157,7 @@ export class AppComponent implements OnDestroy {
     this.router.events
       .pipe(
         filter((event): event is NavigationEnd => event instanceof NavigationEnd),
+        startWith(null),
         takeUntilDestroyed(this.destroyRef)
       )
       .subscribe(() => {

--- a/cultpodcasts/src/app/app.component.ts
+++ b/cultpodcasts/src/app/app.component.ts
@@ -97,7 +97,7 @@ export class AppComponent implements OnDestroy, AfterViewInit {
   /** scrollY when search last docked — used to undock without flicker. */
   private dockAtScrollY = 0;
   private narrowChromeQuery: MediaQueryList | undefined;
-  /** Remeasure docked search when skip-hydration toolbar end controls settle. */
+  /** Remeasure docked search when toolbar end controls settle (e.g. avatar after auth). */
   private chromeEndControlsObserver: ResizeObserver | undefined;
 
   @ViewChild(ToolbarComponent)
@@ -392,7 +392,7 @@ export class AppComponent implements OnDestroy, AfterViewInit {
     search.style.transform = 'none';
   }
 
-  /** Toolbar uses ngSkipHydration — remasure when add/profile/menu size changes. */
+  /** Remeasure when add/profile/menu size changes (avatar swap after hydration). */
   private observeChromeEndControls(): void {
     if (!this.isBrowser || typeof ResizeObserver === 'undefined') {
       return;

--- a/cultpodcasts/src/app/app.component.ts
+++ b/cultpodcasts/src/app/app.component.ts
@@ -89,11 +89,15 @@ export class AppComponent implements OnDestroy, AfterViewInit {
   /** Shows the floating "back to top" control once the user has scrolled well past the fold. */
   protected readonly showBackToTop = signal(false);
   /**
-   * Search docked into the sticky logo bar. Browse routes start docked so Discovery
-   * (etc.) never flash a dropped search row that then collapses into the header.
+   * Search docked into the sticky logo bar. Browse routes must stay docked from
+   * the first paint (SSR + client) so hydration class bindings match — a one-shot
+   * signal seeded before NavigationEnd left content pages as browse-shell without
+   * chrome-stuck. Homepage scroll docking uses homeScrollDocked instead.
    */
-  protected readonly chromeStuck = signal(!AppComponent.isHomePath(this.router.url));
-  private scrollRaf = 0;
+  private readonly homeScrollDocked = signal(false);
+  protected readonly chromeStuck = computed(
+    () => !this.isHomePage() || this.homeScrollDocked()
+  );  private scrollRaf = 0;
   /** scrollY when search last docked — used to undock without flicker. */
   private dockAtScrollY = 0;
   private narrowChromeQuery: MediaQueryList | undefined;
@@ -314,10 +318,16 @@ export class AppComponent implements OnDestroy, AfterViewInit {
       return;
     }
 
-    // Browse + narrow: search stays in the header — never the dropped homepage row.
-    if (!this.isHomePage() || this.isNarrowChrome()) {
-      if (!this.chromeStuck()) {
-        this.chromeStuck.set(true);
+    // Browse: always docked via chromeStuck computed — just measure the header gap.
+    if (!this.isHomePage()) {
+      this.layoutDockedSearch();
+      return;
+    }
+
+    // Narrow homepage: keep search in the header row (same as browse).
+    if (this.isNarrowChrome()) {
+      if (!this.homeScrollDocked()) {
+        this.homeScrollDocked.set(true);
         requestAnimationFrame(() => requestAnimationFrame(() => this.layoutDockedSearch()));
       } else {
         this.layoutDockedSearch();
@@ -325,10 +335,10 @@ export class AppComponent implements OnDestroy, AfterViewInit {
       return;
     }
 
-    if (this.chromeStuck()) {
+    if (this.homeScrollDocked()) {
       // Release back to the dropped layout near the top of the homepage.
       if (y < AppComponent.MIN_SCROLL_TO_DOCK_PX) {
-        this.chromeStuck.set(false);
+        this.homeScrollDocked.set(false);
         this.clearDockedSearchLayout(search);
       } else {
         this.layoutDockedSearch();
@@ -346,7 +356,7 @@ export class AppComponent implements OnDestroy, AfterViewInit {
     const searchTop = search.getBoundingClientRect().top;
     if (searchTop <= barBottom + 2) {
       this.dockAtScrollY = y;
-      this.chromeStuck.set(true);
+      this.homeScrollDocked.set(true);
       // Wait for chrome-stuck styles (icon-only logo) before measuring the header gap.
       requestAnimationFrame(() => requestAnimationFrame(() => this.layoutDockedSearch()));
     }

--- a/cultpodcasts/src/app/app.component.ts
+++ b/cultpodcasts/src/app/app.component.ts
@@ -37,6 +37,7 @@ import {
   parseSubmittablePodcastUrl
 } from './podcast-url-matcher';
 import { filter, map, startWith } from 'rxjs';
+import { scheduleChromeSync } from './episode-form.util';
 
 @Component({
   selector: 'app-root',
@@ -131,11 +132,8 @@ export class AppComponent implements OnDestroy, AfterViewInit {
   }
 
   ngAfterViewInit(): void {
-    if (!this.isBrowser) {
-      return;
-    }
     // Cold-load browse routes start docked; measure before fallback CSS covers toolbar actions.
-    requestAnimationFrame(() => requestAnimationFrame(() => this.syncChromeFromScroll()));
+    scheduleChromeSync(() => this.syncChromeFromScroll(), this.isBrowser);
   }
 
   ngOnDestroy(): void {

--- a/cultpodcasts/src/app/app.routes.ts
+++ b/cultpodcasts/src/app/app.routes.ts
@@ -1,6 +1,9 @@
 import { Routes } from '@angular/router';
 import { PodcastComponent } from './podcast/podcast.component';
 import { ContentComponent } from './content/content.component';
+import { ContentNotFoundComponent } from './content/content-not-found.component';
+import { PrivacyPolicyComponent } from './privacy-policy/privacy-policy.component';
+import { TermsAndConditionsComponent } from './terms-and-conditions/terms-and-conditions.component';
 import { DiscoveryComponent } from './discovery/discovery.component';
 import { hasRoleGuard } from './has-role.guard';
 import { isUserGuard } from './is-user.guard';
@@ -19,7 +22,15 @@ export const routes: Routes = [
   { path: 'podcast/:podcastName/:query', component: PodcastComponent },
   { path: 'subject/:subjectName', component: SubjectComponent },
   { path: 'subject/:subjectName/:query', component: SubjectComponent },
-  { path: 'content/:path', component: ContentComponent },
+  {
+    path: 'content',
+    component: ContentComponent,
+    children: [
+      { path: 'privacy-policy', component: PrivacyPolicyComponent },
+      { path: 'terms-and-conditions', component: TermsAndConditionsComponent },
+      { path: '**', component: ContentNotFoundComponent },
+    ],
+  },
   { path: 'discovery', component: DiscoveryComponent, canActivate: [hasRoleGuard], data: { roles: ["Curator"] }, title: "Discovery" },
   { path: 'episodes/:episodeIds', component: EpisodesComponent, canActivate: [hasRoleGuard], data: { roles: ["Curator"] }, title: "Review Episodes" },
   { path: 'outgoingEpisodes', component: OutgoingEpisodesComponent, canActivate: [hasRoleGuard], data: { roles: ["Curator"] }, title: "Outgoing Episodes" },

--- a/cultpodcasts/src/app/auth-client-only-path.spec.ts
+++ b/cultpodcasts/src/app/auth-client-only-path.spec.ts
@@ -1,0 +1,20 @@
+import { isAuthClientOnlyPath } from './auth-client-only-path';
+
+describe('isAuthClientOnlyPath', () => {
+  it('matches curator and signed-in-only routes', () => {
+    expect(isAuthClientOnlyPath('/discovery')).toBe(true);
+    expect(isAuthClientOnlyPath('/outgoingEpisodes')).toBe(true);
+    expect(isAuthClientOnlyPath('/bookmarks')).toBe(true);
+    expect(isAuthClientOnlyPath('/unauthorised')).toBe(true);
+    expect(isAuthClientOnlyPath('/episodes/abc')).toBe(true);
+  });
+
+  it('allows public browse and content routes', () => {
+    expect(isAuthClientOnlyPath('/')).toBe(false);
+    expect(isAuthClientOnlyPath('/podcast/example')).toBe(false);
+    expect(isAuthClientOnlyPath('/subject/example')).toBe(false);
+    expect(isAuthClientOnlyPath('/search/foo')).toBe(false);
+    expect(isAuthClientOnlyPath('/content/privacy-policy')).toBe(false);
+    expect(isAuthClientOnlyPath('/episode/abc')).toBe(false);
+  });
+});

--- a/cultpodcasts/src/app/auth-client-only-path.ts
+++ b/cultpodcasts/src/app/auth-client-only-path.ts
@@ -1,0 +1,11 @@
+/**
+ * Routes that require Auth0 (curator/user) and must not stay put after logout.
+ * Kept in sync with server.ts CSR-shell skip list.
+ */
+export function isAuthClientOnlyPath(pathname: string): boolean {
+  return pathname === '/discovery'
+    || pathname === '/outgoingEpisodes'
+    || pathname === '/bookmarks'
+    || pathname === '/unauthorised'
+    || pathname.startsWith('/episodes/');
+}

--- a/cultpodcasts/src/app/auth-service-wrapper.class.spec.ts
+++ b/cultpodcasts/src/app/auth-service-wrapper.class.spec.ts
@@ -1,5 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { PLATFORM_ID, provideZonelessChangeDetection } from '@angular/core';
+import { provideRouter } from '@angular/router';
 import { BehaviorSubject, Subject, of } from 'rxjs';
 import { AuthService } from '@auth0/auth0-angular';
 import {
@@ -7,6 +8,7 @@ import {
   AuthServiceWrapper,
   HAS_LOGGED_IN_STORAGE_KEY,
 } from './auth-service-wrapper.class';
+import { POST_LOGOUT_RETURN_PATH_KEY } from './auth-session-recovery';
 
 describe('AuthServiceWrapper avatar cache', () => {
   let isLoading$: BehaviorSubject<boolean>;
@@ -14,19 +16,23 @@ describe('AuthServiceWrapper avatar cache', () => {
   let user$: BehaviorSubject<Record<string, unknown> | null>;
   let error$: Subject<Error>;
   let loginWithRedirect: ReturnType<typeof vi.fn>;
+  let logout: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     localStorage.removeItem(AUTH_AVATAR_STORAGE_KEY);
     localStorage.removeItem(HAS_LOGGED_IN_STORAGE_KEY);
+    sessionStorage.removeItem(POST_LOGOUT_RETURN_PATH_KEY);
     isLoading$ = new BehaviorSubject(true);
     isAuthenticated$ = new BehaviorSubject(false);
     user$ = new BehaviorSubject<Record<string, unknown> | null>(null);
     error$ = new Subject<Error>();
     loginWithRedirect = vi.fn().mockName('loginWithRedirect').mockReturnValue(of(void 0));
+    logout = vi.fn().mockName('logout').mockReturnValue(of(void 0));
 
     TestBed.configureTestingModule({
       providers: [
         provideZonelessChangeDetection(),
+        provideRouter([]),
         { provide: PLATFORM_ID, useValue: 'browser' },
         {
           provide: AuthService,
@@ -36,6 +42,7 @@ describe('AuthServiceWrapper avatar cache', () => {
             user$,
             error$,
             loginWithRedirect,
+            logout,
           },
         },
         AuthServiceWrapper,
@@ -46,6 +53,7 @@ describe('AuthServiceWrapper avatar cache', () => {
   afterEach(() => {
     localStorage.removeItem(AUTH_AVATAR_STORAGE_KEY);
     localStorage.removeItem(HAS_LOGGED_IN_STORAGE_KEY);
+    sessionStorage.removeItem(POST_LOGOUT_RETURN_PATH_KEY);
     document.documentElement.classList.remove('has-cached-avatar');
   });
 
@@ -132,6 +140,18 @@ describe('AuthServiceWrapper avatar cache', () => {
     });
     const target = loginWithRedirect.mock.calls[0][0].appState.target as string;
     expect(target.startsWith('//')).toBe(false);
+  });
+
+  it('logoutKeepingCurrentPage clears avatar and calls Auth0 logout with origin returnTo', () => {
+    const wrapper = TestBed.inject(AuthServiceWrapper);
+    user$.next({ picture: 'https://cdn.example/me.png' });
+
+    wrapper.logoutKeepingCurrentPage();
+
+    expect(wrapper.avatarUrl()).toBeNull();
+    expect(logout).toHaveBeenCalledTimes(1);
+    const args = logout.mock.calls[0][0];
+    expect(args.logoutParams.returnTo).toBe(window.location.origin);
   });
 
   it('loginWithRedirects once on missing_refresh_token', () => {

--- a/cultpodcasts/src/app/auth-service-wrapper.class.spec.ts
+++ b/cultpodcasts/src/app/auth-service-wrapper.class.spec.ts
@@ -121,6 +121,19 @@ describe('AuthServiceWrapper avatar cache', () => {
     expect(document.documentElement.classList.contains('has-cached-avatar')).toBe(false);
   });
 
+  it('loginWithRedirectToCurrentPage passes appState.target for post-login return', () => {
+    const wrapper = TestBed.inject(AuthServiceWrapper);
+
+    wrapper.loginWithRedirectToCurrentPage();
+
+    expect(loginWithRedirect).toHaveBeenCalledTimes(1);
+    expect(loginWithRedirect).toHaveBeenCalledWith({
+      appState: { target: expect.stringMatching(/^\//) },
+    });
+    const target = loginWithRedirect.mock.calls[0][0].appState.target as string;
+    expect(target.startsWith('//')).toBe(false);
+  });
+
   it('loginWithRedirects once on missing_refresh_token', () => {
     TestBed.inject(AuthServiceWrapper);
 

--- a/cultpodcasts/src/app/auth-service-wrapper.class.ts
+++ b/cultpodcasts/src/app/auth-service-wrapper.class.ts
@@ -2,7 +2,16 @@ import { Injectable, PLATFORM_ID, inject, signal } from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
 import { AuthService } from '@auth0/auth0-angular';
 import { combineLatest, EMPTY, filter, of, ReplaySubject, take } from 'rxjs';
-import { currentAppPath, isSessionRecoveryError } from './auth-session-recovery';
+import {
+    consumePostLogoutReturnPath,
+    currentAppPath,
+    isSessionRecoveryError,
+    stashPostLogoutReturnPath,
+} from './auth-session-recovery';
+import { authRedirectUri } from './auth-redirect-uri';
+import { environment } from '../environments/environment';
+import { Router } from '@angular/router';
+
 
 /**
  * Playwright sets `globalThis.__E2E_CURATOR__` via addInitScript so curator
@@ -19,6 +28,7 @@ export const HAS_LOGGED_IN_STORAGE_KEY = 'hasLoggedIn';
 @Injectable({ providedIn: 'root' })
 export class AuthServiceWrapper {
     private readonly platformId = inject(PLATFORM_ID);
+    private readonly router = inject(Router);
 
     roles: ReplaySubject<string[]> = new ReplaySubject<string[]>(1);
     isSignedIn: ReplaySubject<boolean> = new ReplaySubject<boolean>(1);
@@ -38,6 +48,14 @@ export class AuthServiceWrapper {
             if (stored) {
                 this._avatarUrl.set(stored);
                 AuthServiceWrapper.setCachedAvatarHtmlClass(true);
+            }
+            // Auth0 logout returnTo is origin-only (no path wildcards). Restore the
+            // public page stashed before federated logout.
+            const postLogoutPath = consumePostLogoutReturnPath();
+            if (postLogoutPath) {
+                queueMicrotask(() => {
+                    void this.router.navigateByUrl(postLogoutPath, { replaceUrl: true });
+                });
             }
         }
 
@@ -112,6 +130,21 @@ export class AuthServiceWrapper {
     loginWithRedirectToCurrentPage() {
         return this.authService.loginWithRedirect({
             appState: { target: currentAppPath() }
+        });
+    }
+
+    /**
+     * Federated Auth0 logout. Auth0 Allowed Logout URLs are origin-only, so
+     * `returnTo` is always the origin; public pages stash the path and restore
+     * after Auth0 redirects home. Auth-gated routes clear the stash and stay on `/`.
+     */
+    logoutKeepingCurrentPage() {
+        this.clearCachedAvatar();
+        stashPostLogoutReturnPath();
+        return this.authService.logout({
+            logoutParams: {
+                returnTo: authRedirectUri(environment.assetHost)
+            }
         });
     }
 

--- a/cultpodcasts/src/app/auth-service-wrapper.class.ts
+++ b/cultpodcasts/src/app/auth-service-wrapper.class.ts
@@ -106,6 +106,16 @@ export class AuthServiceWrapper {
     }
 
     /**
+     * Interactive login that restores the current path after the Auth0 callback
+     * (`appState.target`). Without this, Auth0 Angular lands on `/`.
+     */
+    loginWithRedirectToCurrentPage() {
+        return this.authService.loginWithRedirect({
+            appState: { target: currentAppPath() }
+        });
+    }
+
+    /**
      * When the refresh token is missing or revoked, bounce through Auth0 login once.
      * With an active Auth0 SSO cookie this is usually a silent round-trip (no password).
      */
@@ -118,9 +128,7 @@ export class AuthServiceWrapper {
                 return;
             }
             this.sessionRecoveryStarted = true;
-            this.authService.loginWithRedirect({
-                appState: { target: currentAppPath() }
-            }).subscribe({
+            this.loginWithRedirectToCurrentPage().subscribe({
                 error: () => {
                     // Allow a later retry if the redirect itself failed to start.
                     this.sessionRecoveryStarted = false;

--- a/cultpodcasts/src/app/auth-session-recovery.spec.ts
+++ b/cultpodcasts/src/app/auth-session-recovery.spec.ts
@@ -1,4 +1,4 @@
-import { currentAppPath, isSessionRecoveryError } from './auth-session-recovery';
+import { currentAppPath, isSafeAppReturnPath, isSessionRecoveryError } from './auth-session-recovery';
 
 describe('isSessionRecoveryError', () => {
   it('matches Auth0 missing_refresh_token errors', () => {
@@ -29,8 +29,22 @@ describe('isSessionRecoveryError', () => {
   });
 });
 
+describe('isSafeAppReturnPath', () => {
+  it('allows same-origin relative paths with query and hash', () => {
+    expect(isSafeAppReturnPath('/content/privacy-policy')).toBe(true);
+    expect(isSafeAppReturnPath('/podcast/foo?x=1#bar')).toBe(true);
+  });
+
+  it('rejects absolute and protocol-relative URLs', () => {
+    expect(isSafeAppReturnPath('https://evil.example/phish')).toBe(false);
+    expect(isSafeAppReturnPath('//evil.example/phish')).toBe(false);
+    expect(isSafeAppReturnPath('evil.example')).toBe(false);
+  });
+});
+
 describe('currentAppPath', () => {
   it('returns path, query, and hash from window.location', () => {
     expect(currentAppPath()).toMatch(/^\//);
+    expect(currentAppPath().startsWith('//')).toBe(false);
   });
 });

--- a/cultpodcasts/src/app/auth-session-recovery.spec.ts
+++ b/cultpodcasts/src/app/auth-session-recovery.spec.ts
@@ -1,4 +1,4 @@
-import { currentAppPath, isSafeAppReturnPath, isSessionRecoveryError } from './auth-session-recovery';
+import { currentAppPath, isSafeAppReturnPath, isSessionRecoveryError, POST_LOGOUT_RETURN_PATH_KEY, stashPostLogoutReturnPath, consumePostLogoutReturnPath } from './auth-session-recovery';
 
 describe('isSessionRecoveryError', () => {
   it('matches Auth0 missing_refresh_token errors', () => {
@@ -46,5 +46,36 @@ describe('currentAppPath', () => {
   it('returns path, query, and hash from window.location', () => {
     expect(currentAppPath()).toMatch(/^\//);
     expect(currentAppPath().startsWith('//')).toBe(false);
+  });
+});
+
+describe('post-logout return path stash', () => {
+  afterEach(() => {
+    sessionStorage.removeItem(POST_LOGOUT_RETURN_PATH_KEY);
+  });
+
+  it('stashes the current public path for restore after Auth0 logout', () => {
+    stashPostLogoutReturnPath();
+    const stashed = sessionStorage.getItem(POST_LOGOUT_RETURN_PATH_KEY);
+    // jsdom location is typically `/` in unit tests — home clears the stash.
+    if (window.location.pathname === '/' || window.location.pathname === '') {
+      expect(stashed).toBeNull();
+      expect(consumePostLogoutReturnPath()).toBeNull();
+    } else {
+      expect(stashed).toMatch(/^\//);
+      expect(consumePostLogoutReturnPath()).toBe(stashed);
+      expect(sessionStorage.getItem(POST_LOGOUT_RETURN_PATH_KEY)).toBeNull();
+    }
+  });
+
+  it('consumePostLogoutReturnPath rejects unsafe and auth-gated targets', () => {
+    sessionStorage.setItem(POST_LOGOUT_RETURN_PATH_KEY, '//evil.example');
+    expect(consumePostLogoutReturnPath()).toBeNull();
+
+    sessionStorage.setItem(POST_LOGOUT_RETURN_PATH_KEY, '/discovery');
+    expect(consumePostLogoutReturnPath()).toBeNull();
+
+    sessionStorage.setItem(POST_LOGOUT_RETURN_PATH_KEY, '/podcast/safe');
+    expect(consumePostLogoutReturnPath()).toBe('/podcast/safe');
   });
 });

--- a/cultpodcasts/src/app/auth-session-recovery.ts
+++ b/cultpodcasts/src/app/auth-session-recovery.ts
@@ -15,10 +15,20 @@ export function isSessionRecoveryError(error: unknown): boolean {
   );
 }
 
-/** Prefer returning the user to the page they were on after Auth0 callback. */
+/**
+ * Prefer returning the user to the page they were on after Auth0 callback.
+ * Only same-origin relative paths (leading `/`, not `//…`) — never absolute or
+ * protocol-relative URLs (open-redirect safe for `appState.target`).
+ */
 export function currentAppPath(): string {
   if (typeof window === 'undefined') {
     return '/';
   }
-  return `${window.location.pathname}${window.location.search}${window.location.hash}` || '/';
+  const path = `${window.location.pathname}${window.location.search}${window.location.hash}` || '/';
+  return isSafeAppReturnPath(path) ? path : '/';
+}
+
+/** True for in-app return targets safe to pass as Auth0 `appState.target`. */
+export function isSafeAppReturnPath(path: string): boolean {
+  return path.startsWith('/') && !path.startsWith('//');
 }

--- a/cultpodcasts/src/app/auth-session-recovery.ts
+++ b/cultpodcasts/src/app/auth-session-recovery.ts
@@ -1,3 +1,5 @@
+import { isAuthClientOnlyPath } from './auth-client-only-path';
+
 /**
  * Auth0 SPA errors that mean the local session cannot be renewed silently
  * and need an interactive login (usually SSO bounce, not a full password entry).
@@ -31,4 +33,50 @@ export function currentAppPath(): string {
 /** True for in-app return targets safe to pass as Auth0 `appState.target`. */
 export function isSafeAppReturnPath(path: string): boolean {
   return path.startsWith('/') && !path.startsWith('//');
+}
+
+/**
+ * Auth0 Allowed Logout URLs are origin-only (no path wildcards). Stash the
+ * public path before federated logout; restore after Auth0 returns to `/`.
+ */
+export const POST_LOGOUT_RETURN_PATH_KEY = 'postLogoutReturnPath';
+
+/** Call immediately before Auth0 logout when the user should return to this page. */
+export function stashPostLogoutReturnPath(): void {
+  if (typeof window === 'undefined' || typeof sessionStorage === 'undefined') {
+    return;
+  }
+  const pathname = window.location.pathname || '/';
+  if (isAuthClientOnlyPath(pathname)) {
+    sessionStorage.removeItem(POST_LOGOUT_RETURN_PATH_KEY);
+    return;
+  }
+  const path = currentAppPath();
+  if (path === '/' || path === '') {
+    sessionStorage.removeItem(POST_LOGOUT_RETURN_PATH_KEY);
+    return;
+  }
+  if (isSafeAppReturnPath(path)) {
+    sessionStorage.setItem(POST_LOGOUT_RETURN_PATH_KEY, path);
+  }
+}
+
+/**
+ * Read-and-clear the path stashed by {@link stashPostLogoutReturnPath}.
+ * Returns null for missing/unsafe/auth-gated targets.
+ */
+export function consumePostLogoutReturnPath(): string | null {
+  if (typeof sessionStorage === 'undefined') {
+    return null;
+  }
+  const path = sessionStorage.getItem(POST_LOGOUT_RETURN_PATH_KEY);
+  sessionStorage.removeItem(POST_LOGOUT_RETURN_PATH_KEY);
+  if (!path || !isSafeAppReturnPath(path)) {
+    return null;
+  }
+  const pathname = path.split('?')[0].split('#')[0] || '/';
+  if (isAuthClientOnlyPath(pathname)) {
+    return null;
+  }
+  return path;
 }

--- a/cultpodcasts/src/app/content/content-not-found.component.ts
+++ b/cultpodcasts/src/app/content/content-not-found.component.ts
@@ -1,0 +1,16 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { Title } from '@angular/platform-browser';
+import { SeoService } from '../seo.service';
+
+@Component({
+  selector: 'app-content-not-found',
+  template: `<h1>Not Found!</h1>`,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: true
+})
+export class ContentNotFoundComponent {
+  constructor(title: Title, seoService: SeoService) {
+    title.setTitle('Not Found');
+    seoService.AddMetaTags({ title: 'Not Found' });
+  }
+}

--- a/cultpodcasts/src/app/content/content.component.html
+++ b/cultpodcasts/src/app/content/content.component.html
@@ -1,13 +1,3 @@
 <article id="content">
-  @switch (content()) {
-    @case ('privacy-policy') {
-      <privacy-policy/>
-    }
-    @case ('terms-and-conditions') {
-      <terms-and-conditions/>
-    }
-    @default {
-      <h1>Not Found!</h1>
-    }
-  }
+  <router-outlet />
 </article>

--- a/cultpodcasts/src/app/content/content.component.ts
+++ b/cultpodcasts/src/app/content/content.component.ts
@@ -4,7 +4,8 @@ import { RouterOutlet } from '@angular/router';
 /**
  * Layout shell for /content/* pages. Child routes render privacy/terms into the
  * outlet (no @switch on :path — that raced SSR privacy DOM vs client Not Found).
- * /content/* is CSR-only in server.ts (skip SSR) so AppComponent chrome hydrates.
+ * server.ts SSRs these at request time (not prerender); child routes keep
+ * AppComponent chrome hydration aligned with the privacy/terms tree.
  */
 @Component({
   selector: 'app-content',

--- a/cultpodcasts/src/app/content/content.component.ts
+++ b/cultpodcasts/src/app/content/content.component.ts
@@ -1,41 +1,16 @@
-import { ChangeDetectionStrategy, Component, DestroyRef, inject, signal } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { ActivatedRoute, Params } from '@angular/router';
-import { combineLatest } from 'rxjs';
-import { TermsAndConditionsComponent } from '../terms-and-conditions/terms-and-conditions.component';
-import { PrivacyPolicyComponent } from '../privacy-policy/privacy-policy.component';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { RouterOutlet } from '@angular/router';
 
-
+/**
+ * Layout shell for /content/* pages. Child routes render privacy/terms into the
+ * outlet (no @switch on :path — that raced SSR privacy DOM vs client Not Found).
+ * /content/* is CSR-only in server.ts (skip SSR) so AppComponent chrome hydrates.
+ */
 @Component({
   selector: 'app-content',
   templateUrl: './content.component.html',
   styleUrls: ['./content.component.sass'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [PrivacyPolicyComponent, TermsAndConditionsComponent]
+  imports: [RouterOutlet],
 })
-export class ContentComponent {
-  private route = inject(ActivatedRoute);
-  private destroyRef = inject(DestroyRef);
-  /**
-   * Seed from the route snapshot before the first template pass.
-   * Starting at `undefined` made the client hit `@default` ("Not Found!") against
-   * SSR privacy/terms DOM and aborted AppComponent hydration (`hasAttribute`),
-   * leaving dead toolbar/search chrome on cold-load content pages.
-   */
-  protected content = signal<string>(this.route.snapshot.params['path'] ?? 'unknown');
-
-  ngOnInit() {
-    combineLatest(
-      [this.route.params, this.route.queryParams],
-      (params: Params, queryParams: Params) => ({
-        params,
-        queryParams,
-      })
-    ).pipe(
-      takeUntilDestroyed(this.destroyRef)
-    ).subscribe((res: { params: Params; queryParams: Params }) => {
-      const { params } = res;
-      this.content.set(params['path'] ?? 'unknown');
-    });
-  }
-}
+export class ContentComponent {}

--- a/cultpodcasts/src/app/content/content.component.ts
+++ b/cultpodcasts/src/app/content/content.component.ts
@@ -4,8 +4,8 @@ import { RouterOutlet } from '@angular/router';
 /**
  * Layout shell for /content/* pages. Child routes render privacy/terms into the
  * outlet (no @switch on :path — that raced SSR privacy DOM vs client Not Found).
- * server.ts SSRs these at request time (not prerender); child routes keep
- * AppComponent chrome hydration aligned with the privacy/terms tree.
+ * Privacy/terms are prerendered (SSG) and excluded from the Pages Worker so the
+ * baked HTML hydrates; other /content/* may still SSR via server.ts.
  */
 @Component({
   selector: 'app-content',

--- a/cultpodcasts/src/app/content/content.component.ts
+++ b/cultpodcasts/src/app/content/content.component.ts
@@ -16,7 +16,13 @@ import { PrivacyPolicyComponent } from '../privacy-policy/privacy-policy.compone
 export class ContentComponent {
   private route = inject(ActivatedRoute);
   private destroyRef = inject(DestroyRef);
-  protected content = signal<string | undefined>(undefined);
+  /**
+   * Seed from the route snapshot before the first template pass.
+   * Starting at `undefined` made the client hit `@default` ("Not Found!") against
+   * SSR privacy/terms DOM and aborted AppComponent hydration (`hasAttribute`),
+   * leaving dead toolbar/search chrome on cold-load content pages.
+   */
+  protected content = signal<string>(this.route.snapshot.params['path'] ?? 'unknown');
 
   ngOnInit() {
     combineLatest(
@@ -29,7 +35,7 @@ export class ContentComponent {
       takeUntilDestroyed(this.destroyRef)
     ).subscribe((res: { params: Params; queryParams: Params }) => {
       const { params } = res;
-      this.content.set(params["path"] ?? "unknown");
+      this.content.set(params['path'] ?? 'unknown');
     });
   }
 }

--- a/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.html
+++ b/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.html
@@ -173,6 +173,14 @@
                     <input type="text" [formControl]="form()!.controls.searchTerms" matInput>
                 </mat-form-field>
                 <mat-form-field class="full-width">
+                    <mat-label>Hash Tag</mat-label>
+                    <input type="text" [formControl]="form()!.controls.hashTag" matInput
+                        placeholder="#tag1 #tag2" (blur)="normalizeHashTag()">
+                    @if (form()!.controls.hashTag.hasError('hashPrefixedTag')) {
+                    <mat-error>Each tag must start with #</mat-error>
+                    }
+                </mat-form-field>
+                <mat-form-field class="full-width">
                     <mat-label>Language</mat-label>
                     <mat-select [formControl]="form()!.controls.lang">
                         @for (language of languages() | keyvalue:null; track language) {

--- a/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.ts
+++ b/cultpodcasts/src/app/edit-episode-dialog/edit-episode-dialog.component.ts
@@ -49,6 +49,7 @@ import {
   withoutGuestSuggestion,
   type EpisodeImageService
 } from '../episode-form.util';
+import { normalizeHashTagControl } from '../podcast-form.util';
 
 @Component({
   selector: 'app-edit-episode-dialog',
@@ -201,6 +202,13 @@ export class EditEpisodeDialogComponent {
     clearFormControl(control);
   }
 
+  normalizeHashTag() {
+    const control = this.form()?.controls.hashTag;
+    if (control) {
+      normalizeHashTagControl(control);
+    }
+  }
+
   previewImage(service: EpisodeImageService) {
     const form = this.form();
     if (!form) {
@@ -242,6 +250,7 @@ export class EditEpisodeDialogComponent {
         },
         subjects: form.controls.subjects.value,
         searchTerms: form.controls.searchTerms.value,
+        hashTag: form.controls.hashTag.value?.trim() || null,
         lang: form.controls.lang.value,
         guests: form.controls.guests.value,
       };
@@ -477,9 +486,12 @@ export class EditEpisodeDialogComponent {
     try {
       // encodeURIComponent so names ending in '?' (e.g. "Was I In A Cult?") are not
       // treated as the start of a query string by `new URL(...)`.
-      const path = this.episodeId
-        ? `/podcast/${encodeURIComponent(podcastIdentifier)}/${this.episodeId}`
-        : `/podcast/${encodeURIComponent(podcastIdentifier)}`;
+      // Only append episodeId for *name* lookups (disambiguation). Guid identifiers must
+      // hit GET /podcast/{id} — /podcast/{guid}/{episodeId} is treated as a name route and 404s.
+      const encoded = encodeURIComponent(podcastIdentifier);
+      const path = this.episodeId && !isPodcastGuid(podcastIdentifier)
+        ? `/podcast/${encoded}/${this.episodeId}`
+        : `/podcast/${encoded}`;
       const podcastEndpoint = new URL(path, environment.api).toString();
       const podcast = await firstValueFrom(this.http.get<Podcast>(podcastEndpoint, { headers: headers }));
       return podcast;
@@ -487,4 +499,10 @@ export class EditEpisodeDialogComponent {
       return null;
     }
   }
+}
+
+const podcastGuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function isPodcastGuid(identifier: string): boolean {
+  return podcastGuidPattern.test(identifier);
 }

--- a/cultpodcasts/src/app/edit-subject-dialog/edit-subject-dialog.component.html
+++ b/cultpodcasts/src/app/edit-subject-dialog/edit-subject-dialog.component.html
@@ -49,6 +49,7 @@
                     <input type="text" [formControl]="form()!.controls.knownTerms" matInput>
                 </mat-form-field>
             </mat-tab>
+            @if (featureSwitchService.IsEnabled(FeatureSwitch.reddit)) {
             <mat-tab label="Reddit">
                 <mat-form-field class="full-width">
                     <mat-label>Flair Id</mat-label>
@@ -66,6 +67,7 @@
                     <input type="text" [formControl]="form()!.controls.redditFlareText" matInput>
                 </mat-form-field>
             </mat-tab>
+            }
         </mat-tab-group>
     </form>
     }

--- a/cultpodcasts/src/app/edit-subject-dialog/edit-subject-dialog.component.ts
+++ b/cultpodcasts/src/app/edit-subject-dialog/edit-subject-dialog.component.ts
@@ -20,6 +20,8 @@ import { CdkTextareaAutosize, TextFieldModule } from '@angular/cdk/text-field';
 import { MatInputModule } from '@angular/material/input';
 import { asEmptyString, asStringArray, emptyGuidIfBlank } from '../form-value.util';
 import { ensureHashPrefix, hashPrefixedTagValidator, normalizeHashTagControl } from '../podcast-form.util';
+import { FeatureSwitch } from '../feature-switch.enum';
+import { FeatureSwitchService } from '../feature-switch-service';
 
 @Component({
   selector: 'app-edit-subject-dialog',
@@ -41,6 +43,7 @@ import { ensureHashPrefix, hashPrefixedTagValidator, normalizeHashTagControl } f
   styleUrl: './edit-subject-dialog.component.sass'
 })
 export class EditSubjectDialogComponent {
+  protected FeatureSwitch = FeatureSwitch;
   subjectName: string | undefined;
   isLoading = signal(true);
   isInError = signal(false);
@@ -62,6 +65,7 @@ export class EditSubjectDialogComponent {
     private dialogRef: MatDialogRef<EditSubjectDialogComponent, any>,
     @Inject(MAT_DIALOG_DATA) public data: { subjectName: string | undefined, create: boolean | undefined },
     private dialog: MatDialog,
+    protected featureSwitchService: FeatureSwitchService,
   ) {
     this.subjectName = data.subjectName;
     this.create = data.create || false;

--- a/cultpodcasts/src/app/episode-form.interface.ts
+++ b/cultpodcasts/src/app/episode-form.interface.ts
@@ -22,6 +22,7 @@ export interface EpisodeForm {
     internetArchive: FormControl<URL | null | string>,
     subjects: FormControl<string[]>,
     searchTerms: FormControl<string | null>,
+    hashTag: FormControl<string | null>,
     lang: FormControl<string | null>
     guests: FormControl<string[]>,
 }

--- a/cultpodcasts/src/app/episode-form.util.spec.ts
+++ b/cultpodcasts/src/app/episode-form.util.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, vi } from 'vitest';
 import { ApiEpisode } from './api-episode.interface';
 import {
   applyGuestSelection,
@@ -7,6 +8,8 @@ import {
   episodeCataloguePeople,
   getEpisodeChanges,
   guestNamesWithPerson,
+  isEpisodeDeleteMenuDisabled,
+  isSubjectRedditTabEnabled,
   mergeEpisodeSubjects,
   mergePeopleCatalogue,
   pendingPerson,
@@ -14,6 +17,7 @@ import {
   personMatchesFilter,
   regroupGuests,
   regroupSubjects,
+  scheduleChromeSync,
   uniqueStrings,
   withoutGuestSuggestion
 } from './episode-form.util';
@@ -330,6 +334,53 @@ describe('episode-form.util', () => {
       const prev = baseEpisode({ lang: 'en' });
       const now = baseEpisode({ lang: 'unset' });
       expect(getEpisodeChanges(prev, now).lang).toBe('');
+    });
+  });
+
+  it('buildEpisodeForm preserves multi-tag hashTag with hash prefix', () => {
+    const form = buildEpisodeForm(baseEpisode({ hashTag: 'ABC XYZ' }));
+    expect(form.controls.hashTag.value).toBe('#ABC #XYZ');
+  });
+
+  it('buildEpisodeForm leaves empty/null hashTag cleared', () => {
+    expect(buildEpisodeForm(baseEpisode({ hashTag: null })).controls.hashTag.value).toBeNull();
+    expect(buildEpisodeForm(baseEpisode({ hashTag: '' })).controls.hashTag.value).toBeNull();
+  });
+
+  describe('getEpisodeChanges hashTag', () => {
+    it('includes trimmed multi-tag hashTag changes', () => {
+      const prev = baseEpisode({ hashTag: '#ABC' });
+      const now = baseEpisode({ hashTag: '#ABC #XYZ' });
+      expect(getEpisodeChanges(prev, now)).toEqual({ hashTag: '#ABC #XYZ' });
+    });
+
+    it('clears hashTag when emptied', () => {
+      const prev = baseEpisode({ hashTag: '#ABC' });
+      const now = baseEpisode({ hashTag: null });
+      expect(getEpisodeChanges(prev, now)).toEqual({ hashTag: null });
+    });
+  });
+
+  describe('isEpisodeDeleteMenuDisabled', () => {
+    it('disables only when tweeted, even if posted', () => {
+      expect(isEpisodeDeleteMenuDisabled({ tweeted: false, posted: true } as any)).toBe(false);
+      expect(isEpisodeDeleteMenuDisabled({ tweeted: true, posted: false } as any)).toBe(true);
+      expect(isEpisodeDeleteMenuDisabled({ tweeted: false, posted: false } as any)).toBe(false);
+    });
+  });
+
+  describe('isSubjectRedditTabEnabled', () => {
+    it('follows the FeatureSwitch.reddit callback', () => {
+      expect(isSubjectRedditTabEnabled(() => false)).toBe(false);
+      expect(isSubjectRedditTabEnabled(flag => flag === 'reddit')).toBe(true);
+    });
+  });
+
+  describe('scheduleChromeSync', () => {
+    it('no-ops when not in browser', () => {
+      const sync = vi.fn();
+      scheduleChromeSync(sync, false);
+      expect(sync).not.toHaveBeenCalled();
     });
   });
 });

--- a/cultpodcasts/src/app/episode-form.util.spec.ts
+++ b/cultpodcasts/src/app/episode-form.util.spec.ts
@@ -225,12 +225,14 @@ describe('episode-form.util', () => {
       bluesky: true,
       lang: 'en',
       searchTerms: 'foo',
+      hashTag: 'ScenarioTag',
       images: { spotify: new URL('https://img.example/spotify.jpg') }
     });
     const form = buildEpisodeForm(episode);
     expect(form.controls.title.value).toBe('Title');
     expect(form.controls.blueskyPosted.value).toBe(true);
     expect(form.controls.lang.value).toBe('unset');
+    expect(form.controls.hashTag.value).toBe('#ScenarioTag');
     expect(form.controls.spotify.value?.toString()).toBe('https://open.spotify.com/episode/x');
     expect(form.controls.spotifyImage.value?.toString()).toBe('https://img.example/spotify.jpg');
     expect(form.controls.guests.value).toEqual(['Alice']);
@@ -293,6 +295,12 @@ describe('episode-form.util', () => {
         title: 'New',
         description: 'New desc'
       });
+    });
+
+    it('includes hashTag when it changes', () => {
+      const prev = baseEpisode({ hashTag: '#Old' });
+      const now = baseEpisode({ hashTag: '#New' });
+      expect(getEpisodeChanges(prev, now)).toEqual({ hashTag: '#New' });
     });
 
     it('clears a URL with empty string when removed', () => {

--- a/cultpodcasts/src/app/episode-form.util.ts
+++ b/cultpodcasts/src/app/episode-form.util.ts
@@ -420,3 +420,21 @@ export function getEpisodeChanges(prev: ApiEpisode, now: ApiEpisode): EpisodePos
   if (!isSameStringArray(prev.guests, now.guests)) changes.guests = now.guests;
   return changes;
 }
+
+/** Delete menu is blocked only when the episode was tweeted (posted Reddit no longer blocks). */
+export function isEpisodeDeleteMenuDisabled(episode: { tweeted?: boolean | null }): boolean {
+  return !!episode.tweeted;
+}
+
+/** Subject dialog Reddit tab visibility — mirrors FeatureSwitch.reddit gate. */
+export function isSubjectRedditTabEnabled(isFeatureEnabled: (flag: string) => boolean): boolean {
+  return isFeatureEnabled('reddit');
+}
+
+/** Cold-load chrome: schedule a double-rAF measure (browser only). */
+export function scheduleChromeSync(sync: () => void, isBrowser: boolean): void {
+  if (!isBrowser) {
+    return;
+  }
+  requestAnimationFrame(() => requestAnimationFrame(() => sync()));
+}

--- a/cultpodcasts/src/app/episode-form.util.ts
+++ b/cultpodcasts/src/app/episode-form.util.ts
@@ -7,6 +7,7 @@ import { Person } from './person.interface';
 import { comparePeopleBySortKey } from './person-sort';
 import { Subject } from './subject.interface';
 import { filterKeepingSelectedInOrder } from './subject-filter.util';
+import { ensureHashPrefix, hashPrefixedTagValidator } from './podcast-form.util';
 
 /**
  * Pure helpers shared by add-episode-dialog and edit-episode-dialog.
@@ -130,6 +131,9 @@ export function buildEpisodeForm(episode: ApiEpisode): FormGroup<EpisodeForm> {
     internetArchive: new FormControl(episode.urls.internetArchive || null),
     subjects: new FormControl(episode.subjects, { nonNullable: true }),
     searchTerms: new FormControl(episode.searchTerms || null),
+    hashTag: new FormControl(ensureHashPrefix(episode.hashTag) || null, {
+      validators: [hashPrefixedTagValidator()]
+    }),
     lang: new FormControl(episodeLanguageFormValue(episode.lang)),
     guests: new FormControl<string[]>(episode.guests ?? [], { nonNullable: true })
   });
@@ -382,6 +386,7 @@ export function getEpisodeChanges(prev: ApiEpisode, now: ApiEpisode): EpisodePos
   if (prev.release.toISOString() != nowReleaseDate) changes.release = nowReleaseDate;
   if (prev.removed != now.removed) changes.removed = now.removed;
   if (prev.searchTerms != now.searchTerms) changes.searchTerms = now.searchTerms;
+  if (prev.hashTag != now.hashTag) changes.hashTag = now.hashTag;
   if (!isSameStringArray(prev.subjects, now.subjects)) changes.subjects = now.subjects;
   if (prev.title != now.title) changes.title = now.title;
 

--- a/cultpodcasts/src/app/episode-post.interface.ts
+++ b/cultpodcasts/src/app/episode-post.interface.ts
@@ -16,6 +16,7 @@ export interface EpisodePost {
     images?: EpisodeImageUrls;
     subjects?: string[];
     searchTerms?: string | null;
+    hashTag?: string | null;
     lang?: string;
     guests?: string[];
 }

--- a/cultpodcasts/src/app/episodes-api/episodes-api.component.html
+++ b/cultpodcasts/src/app/episodes-api/episodes-api.component.html
@@ -77,7 +77,7 @@
             </button>
             }
             @if (authRoles().includes("Admin")) {
-            <button [disabled]="result.tweeted||result.posted" mat-menu-item
+            <button [disabled]="result.tweeted" mat-menu-item
                 (click)="delete(result.podcastId!, result.id)">
                 <mat-icon>delete</mat-icon>
                 <span>Delete Episode</span>

--- a/cultpodcasts/src/app/feature-switch-service.ts
+++ b/cultpodcasts/src/app/feature-switch-service.ts
@@ -13,6 +13,8 @@ export class FeatureSwitchService {
                 return false;
             case FeatureSwitch.redditPost:
                 return false;
+            case FeatureSwitch.episodeOgShareImage:
+                return false;
             default:
                 return false;
         }

--- a/cultpodcasts/src/app/feature-switch-service.ts
+++ b/cultpodcasts/src/app/feature-switch-service.ts
@@ -14,7 +14,7 @@ export class FeatureSwitchService {
             case FeatureSwitch.redditPost:
                 return false;
             case FeatureSwitch.episodeOgShareImage:
-                return false;
+                return true;
             default:
                 return false;
         }

--- a/cultpodcasts/src/app/feature-switch.enum.ts
+++ b/cultpodcasts/src/app/feature-switch.enum.ts
@@ -2,5 +2,7 @@ export enum FeatureSwitch {
     auth0 = 1,
     socials= 2,
     reddit= 3,
-    redditPost= 4
+    redditPost= 4,
+    /** Episode OG/Twitter share image from page-details / shortener KV. Default OFF. */
+    episodeOgShareImage = 5
 }

--- a/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.html
+++ b/cultpodcasts/src/app/outgoing-episodes-api/outgoing-episodes-api.component.html
@@ -99,7 +99,7 @@
             </button>
             }
             @if (authRoles().includes("Admin")) {
-            <button [disabled]="result.tweeted||result.posted" mat-menu-item
+            <button [disabled]="result.tweeted" mat-menu-item
                 (click)="delete(result.podcastId!, result.id)">
                 <mat-icon>delete</mat-icon>
                 <span>Delete Episode</span>

--- a/cultpodcasts/src/app/page-details.interface.ts
+++ b/cultpodcasts/src/app/page-details.interface.ts
@@ -1,6 +1,12 @@
+export type PageDetailsImageAspect = "wide" | "square";
+
 export interface IPageDetails {
     title?: string,
     description?: string,
     releaseDate?: string,
-    duration?: string
+    duration?: string,
+    /** Absolute HTTPS URL for og:image (Api `/og-image` with logo overlay when share art exists). */
+    image?: string,
+    /** YouTube / BBC iPlayer / Internet Archive → wide; Spotify/Apple/BBC Sounds → square. */
+    imageAspect?: PageDetailsImageAspect
 }

--- a/cultpodcasts/src/app/page-details.interface.ts
+++ b/cultpodcasts/src/app/page-details.interface.ts
@@ -1,6 +1,12 @@
+export type PageDetailsImageAspect = "wide" | "square";
+
 export interface IPageDetails {
     title?: string,
     description?: string,
     releaseDate?: string,
-    duration?: string
+    duration?: string,
+    /** Absolute HTTPS episode art for og:image / twitter:image. */
+    image?: string,
+    /** YouTube / BBC iPlayer / Internet Archive → wide; Spotify/Apple/BBC Sounds → square. */
+    imageAspect?: PageDetailsImageAspect
 }

--- a/cultpodcasts/src/app/page-details.interface.ts
+++ b/cultpodcasts/src/app/page-details.interface.ts
@@ -5,7 +5,7 @@ export interface IPageDetails {
     description?: string,
     releaseDate?: string,
     duration?: string,
-    /** Absolute HTTPS episode art for og:image / twitter:image. */
+    /** Absolute HTTPS URL for og:image (Api `/og-image` with logo overlay when share art exists). */
     image?: string,
     /** YouTube / BBC iPlayer / Internet Archive → wide; Spotify/Apple/BBC Sounds → square. */
     imageAspect?: PageDetailsImageAspect

--- a/cultpodcasts/src/app/podcast/podcast.component.ts
+++ b/cultpodcasts/src/app/podcast/podcast.component.ts
@@ -12,6 +12,7 @@ import { SearchResult } from '../search-result.interface';
 import { PodcastEpisodeComponent } from '../podcast-episode/podcast-episode.component';
 import { SiteLoadingComponent } from '../site-loading/site-loading.component';
 import { EpisodeLoadingSkeletonComponent } from '../episode-loading-skeleton/episode-loading-skeleton.component';
+import { bbcIplayerUrl, episodeImageUrl, isYoutubeThumbnailUrl } from '../search-result-links';
 
 @Component({
   selector: 'app-podcast',
@@ -97,11 +98,22 @@ export class PodcastComponent {
             .then(episode => {
               this.episode.set(episode);
               if (episode) {
+                const shareImage = episodeImageUrl(episode)?.toString();
                 pageDetails = {
                   description: this.podcastName,
                   title: `${episode.episodeTitle} | ${this.podcastName}`,
                   releaseDate: episode.release.toString(),
-                  duration: episode.duration
+                  duration: episode.duration,
+                  image: shareImage,
+                  // YouTube / BBC iPlayer / Internet Archive → wide; Spotify/Apple/BBC Sounds → square.
+                  imageAspect: shareImage
+                    ? (isYoutubeThumbnailUrl(shareImage)
+                      || !!episode.youtubeId
+                      || !!bbcIplayerUrl(episode)
+                      || !!episode.internetArchive
+                      ? "wide"
+                      : "square")
+                    : undefined
                 };
               }
             })

--- a/cultpodcasts/src/app/privacy-policy/privacy-policy.component.html
+++ b/cultpodcasts/src/app/privacy-policy/privacy-policy.component.html
@@ -296,5 +296,5 @@
 </ul>
 
 <p id="version">Version {{metadata.version}}, Commit {{metadata.commitHash}}.</p>
-<p>Built at {{metadata.buildDate.toString()}}.</p>
+<p>Built at {{metadata.buildDate}}.</p>
 <p>Environment '{{metadata.environmentName}}', Dev-Build '{{metadata.isDevMode}}'.</p>

--- a/cultpodcasts/src/app/privacy-policy/privacy-policy.component.ts
+++ b/cultpodcasts/src/app/privacy-policy/privacy-policy.component.ts
@@ -15,10 +15,11 @@ export class PrivacyPolicyComponent {
 
   protected metadata = {
     version: version,
-    buildDate: new Date(buildDate),
+    // Keep the build-time ISO string — Date#toString() differs SSR vs browser TZ.
+    buildDate,
     commitHash: commitHash,
     environmentName: environment.name,
-    isDevMode: isDevMode()  
+    isDevMode: isDevMode()
   }
 
   constructor(

--- a/cultpodcasts/src/app/search-bar/search-bar.component.ts
+++ b/cultpodcasts/src/app/search-bar/search-bar.component.ts
@@ -40,10 +40,10 @@ const SUGGESTION_DEBOUNCE_MS = 150;
   ],
   templateUrl: './search-bar.component.html',
   styleUrl: './search-bar.component.sass',
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  // Chip @if DOM is easy to desync across SSR/client (SiteService is not
-  // transferred). Skip hydrating the bar; URL/site data re-seeds on client.
-  host: { ngSkipHydration: 'true' }
+  // Chip @if is kept SSR/client-aligned via applyChipFromUrl (SiteService is not
+  // transferred). Do not skip hydration — that leaves a dead search DOM with no
+  // suggestion listeners on cold-load content pages.
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 
 export class SearchBarComponent {

--- a/cultpodcasts/src/app/seo.service.spec.ts
+++ b/cultpodcasts/src/app/seo.service.spec.ts
@@ -54,7 +54,7 @@ describe('SeoService share images', () => {
     expect(meta.getTag('name="twitter:card"')?.content).toBe('summary');
   });
 
-  it('uses episode art with summary for square covers when switch is ON', () => {
+  it('uses summary_large_image for square covers when switch is ON', () => {
     episodeOgShareImageEnabled = true;
     seo.AddMetaTags({
       title: 'Ep | Show',
@@ -67,7 +67,7 @@ describe('SeoService share images', () => {
       .toBe('https://i.scdn.co/image/ab6765cover');
     expect(meta.getTag('name="twitter:image"')?.content)
       .toBe('https://i.scdn.co/image/ab6765cover');
-    expect(meta.getTag('name="twitter:card"')?.content).toBe('summary');
+    expect(meta.getTag('name="twitter:card"')?.content).toBe('summary_large_image');
   });
 
   it('uses summary_large_image for wide YouTube art when switch is ON', () => {

--- a/cultpodcasts/src/app/seo.service.spec.ts
+++ b/cultpodcasts/src/app/seo.service.spec.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { Meta } from '@angular/platform-browser';
+import { PLATFORM_ID } from '@angular/core';
+import { SeoService } from './seo.service';
+import { FeatureSwitch } from './feature-switch.enum';
+import { FeatureSwitchService } from './feature-switch-service';
+
+describe('SeoService share images', () => {
+  let meta: Meta;
+  let seo: SeoService;
+  let episodeOgShareImageEnabled: boolean;
+
+  beforeEach(() => {
+    episodeOgShareImageEnabled = false;
+    TestBed.configureTestingModule({
+      providers: [
+        SeoService,
+        {
+          provide: FeatureSwitchService,
+          useValue: {
+            IsEnabled: (fs: FeatureSwitch) =>
+              fs === FeatureSwitch.episodeOgShareImage ? episodeOgShareImageEnabled : false
+          }
+        },
+        { provide: PLATFORM_ID, useValue: 'server' },
+        { provide: 'url', useValue: new URL('https://cultpodcasts.com/podcast/Show/ep') }
+      ]
+    });
+    meta = TestBed.inject(Meta);
+    seo = TestBed.inject(SeoService);
+    seo.AddRequiredMetaTags();
+  });
+
+  it('keeps site icon and summary card when page has no episode image', () => {
+    seo.AddMetaTags({ title: 'Ep | Show', description: 'Show' });
+
+    expect(meta.getTag('property="og:image"')?.content)
+      .toBe('https://cultpodcasts.com/assets/sq-image.png');
+    expect(meta.getTag('name="twitter:card"')?.content).toBe('summary');
+  });
+
+  it('ignores episode art when FeatureSwitch.episodeOgShareImage is OFF', () => {
+    episodeOgShareImageEnabled = false;
+    seo.AddMetaTags({
+      title: 'Ep | Show',
+      description: 'Show',
+      image: 'https://i.scdn.co/image/ab6765cover',
+      imageAspect: 'square'
+    });
+
+    expect(meta.getTag('property="og:image"')?.content)
+      .toBe('https://cultpodcasts.com/assets/sq-image.png');
+    expect(meta.getTag('name="twitter:card"')?.content).toBe('summary');
+  });
+
+  it('uses episode art with summary for square covers when switch is ON', () => {
+    episodeOgShareImageEnabled = true;
+    seo.AddMetaTags({
+      title: 'Ep | Show',
+      description: 'Show',
+      image: 'https://i.scdn.co/image/ab6765cover',
+      imageAspect: 'square'
+    });
+
+    expect(meta.getTag('property="og:image"')?.content)
+      .toBe('https://i.scdn.co/image/ab6765cover');
+    expect(meta.getTag('name="twitter:image"')?.content)
+      .toBe('https://i.scdn.co/image/ab6765cover');
+    expect(meta.getTag('name="twitter:card"')?.content).toBe('summary');
+  });
+
+  it('uses summary_large_image for wide YouTube art when switch is ON', () => {
+    episodeOgShareImageEnabled = true;
+    seo.AddMetaTags({
+      title: 'Ep | Show',
+      description: 'Show',
+      image: 'https://i.ytimg.com/vi/griffinsong42/hqdefault.jpg',
+      imageAspect: 'wide'
+    });
+
+    expect(meta.getTag('property="og:image"')?.content)
+      .toBe('https://i.ytimg.com/vi/griffinsong42/hqdefault.jpg');
+    expect(meta.getTag('name="twitter:card"')?.content).toBe('summary_large_image');
+  });
+});

--- a/cultpodcasts/src/app/seo.service.spec.ts
+++ b/cultpodcasts/src/app/seo.service.spec.ts
@@ -1,0 +1,58 @@
+import { TestBed } from '@angular/core/testing';
+import { Meta } from '@angular/platform-browser';
+import { PLATFORM_ID } from '@angular/core';
+import { SeoService } from './seo.service';
+
+describe('SeoService share images', () => {
+  let meta: Meta;
+  let seo: SeoService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        SeoService,
+        { provide: PLATFORM_ID, useValue: 'server' },
+        { provide: 'url', useValue: new URL('https://cultpodcasts.com/podcast/Show/ep') }
+      ]
+    });
+    meta = TestBed.inject(Meta);
+    seo = TestBed.inject(SeoService);
+    seo.AddRequiredMetaTags();
+  });
+
+  it('keeps site icon and summary card when page has no episode image', () => {
+    seo.AddMetaTags({ title: 'Ep | Show', description: 'Show' });
+
+    expect(meta.getTag('property="og:image"')?.content)
+      .toBe('https://cultpodcasts.com/assets/sq-image.png');
+    expect(meta.getTag('name="twitter:card"')?.content).toBe('summary');
+  });
+
+  it('uses episode art with summary for square covers', () => {
+    seo.AddMetaTags({
+      title: 'Ep | Show',
+      description: 'Show',
+      image: 'https://i.scdn.co/image/ab6765cover',
+      imageAspect: 'square'
+    });
+
+    expect(meta.getTag('property="og:image"')?.content)
+      .toBe('https://i.scdn.co/image/ab6765cover');
+    expect(meta.getTag('name="twitter:image"')?.content)
+      .toBe('https://i.scdn.co/image/ab6765cover');
+    expect(meta.getTag('name="twitter:card"')?.content).toBe('summary');
+  });
+
+  it('uses summary_large_image for wide YouTube art', () => {
+    seo.AddMetaTags({
+      title: 'Ep | Show',
+      description: 'Show',
+      image: 'https://i.ytimg.com/vi/griffinsong42/hqdefault.jpg',
+      imageAspect: 'wide'
+    });
+
+    expect(meta.getTag('property="og:image"')?.content)
+      .toBe('https://i.ytimg.com/vi/griffinsong42/hqdefault.jpg');
+    expect(meta.getTag('name="twitter:card"')?.content).toBe('summary_large_image');
+  });
+});

--- a/cultpodcasts/src/app/seo.service.ts
+++ b/cultpodcasts/src/app/seo.service.ts
@@ -4,6 +4,7 @@ import { Meta, Title } from '@angular/platform-browser';
 import { IPageDetails } from './page-details.interface';
 
 const siteName: string = "Cult Podcasts";
+const defaultShareImagePath: string = "/assets/sq-image.png";
 
 @Injectable({
   providedIn: 'root'
@@ -54,6 +55,7 @@ export class SeoService {
         this.meta.updateTag({ property: "og:description", content: description });
       }
       this.meta.updateTag({ property: "og:title", content: htmlTItle });
+      this.applyShareImage(pageDetails);
     }
   }
 
@@ -74,10 +76,25 @@ export class SeoService {
       if (this.url) {
         const domain: string = this.url.hostname;
         const url: string = this.url.toString();
+        const shareImage = new URL(defaultShareImagePath, this.url).toString();
         this.meta.addTag({ property: "twitter:domain", content: domain });
         this.meta.addTag({ property: "og:url", content: url });
-        this.meta.addTag({ property: "og:image", content: new URL("/assets/sq-image.png", this.url).toString() })
+        this.meta.addTag({ property: "og:image", content: shareImage });
       };
     }
+  }
+
+  private applyShareImage(pageDetails: IPageDetails): void {
+    const image = pageDetails.image
+      ?? (this.url ? new URL(defaultShareImagePath, this.url).toString() : undefined);
+    if (!image) {
+      return;
+    }
+    this.meta.updateTag({ property: "og:image", content: image });
+    this.meta.updateTag({ name: "twitter:image", content: image });
+    const card = pageDetails.image && pageDetails.imageAspect === "wide"
+      ? "summary_large_image"
+      : "summary";
+    this.meta.updateTag({ name: "twitter:card", content: card });
   }
 }

--- a/cultpodcasts/src/app/seo.service.ts
+++ b/cultpodcasts/src/app/seo.service.ts
@@ -2,8 +2,11 @@ import { isPlatformServer, formatDate } from '@angular/common';
 import { Inject, Injectable, Optional, PLATFORM_ID } from '@angular/core';
 import { Meta, Title } from '@angular/platform-browser';
 import { IPageDetails } from './page-details.interface';
+import { FeatureSwitch } from './feature-switch.enum';
+import { FeatureSwitchService } from './feature-switch-service';
 
 const siteName: string = "Cult Podcasts";
+const defaultShareImagePath: string = "/assets/sq-image.png";
 
 @Injectable({
   providedIn: 'root'
@@ -14,6 +17,7 @@ export class SeoService {
   constructor(
     private meta: Meta,
     private title: Title,
+    private featureSwitchService: FeatureSwitchService,
     @Inject(PLATFORM_ID) platformId: any,
     @Optional() @Inject('url') private url: URL
   ) {
@@ -54,6 +58,7 @@ export class SeoService {
         this.meta.updateTag({ property: "og:description", content: description });
       }
       this.meta.updateTag({ property: "og:title", content: htmlTItle });
+      this.applyShareImage(pageDetails);
     }
   }
 
@@ -74,10 +79,29 @@ export class SeoService {
       if (this.url) {
         const domain: string = this.url.hostname;
         const url: string = this.url.toString();
+        const shareImage = new URL(defaultShareImagePath, this.url).toString();
         this.meta.addTag({ property: "twitter:domain", content: domain });
         this.meta.addTag({ property: "og:url", content: url });
-        this.meta.addTag({ property: "og:image", content: new URL("/assets/sq-image.png", this.url).toString() })
+        this.meta.addTag({ property: "og:image", content: shareImage });
       };
     }
+  }
+
+  private applyShareImage(pageDetails: IPageDetails): void {
+    const useEpisodeImage =
+      this.featureSwitchService.IsEnabled(FeatureSwitch.episodeOgShareImage) &&
+      !!pageDetails.image;
+    const image = useEpisodeImage
+      ? pageDetails.image
+      : (this.url ? new URL(defaultShareImagePath, this.url).toString() : undefined);
+    if (!image) {
+      return;
+    }
+    this.meta.updateTag({ property: "og:image", content: image });
+    this.meta.updateTag({ name: "twitter:image", content: image });
+    const card = useEpisodeImage && pageDetails.imageAspect === "wide"
+      ? "summary_large_image"
+      : "summary";
+    this.meta.updateTag({ name: "twitter:card", content: card });
   }
 }

--- a/cultpodcasts/src/app/seo.service.ts
+++ b/cultpodcasts/src/app/seo.service.ts
@@ -99,9 +99,8 @@ export class SeoService {
     }
     this.meta.updateTag({ property: "og:image", content: image });
     this.meta.updateTag({ name: "twitter:image", content: image });
-    const card = useEpisodeImage && pageDetails.imageAspect === "wide"
-      ? "summary_large_image"
-      : "summary";
+    // Episode art (wide or square) → large card; site-icon fallback stays summary.
+    const card = useEpisodeImage ? "summary_large_image" : "summary";
     this.meta.updateTag({ name: "twitter:card", content: card });
   }
 }

--- a/cultpodcasts/src/app/toolbar/toolbar.component.sass
+++ b/cultpodcasts/src/app/toolbar/toolbar.component.sass
@@ -80,10 +80,6 @@
     flex-shrink: 0
     position: relative
     z-index: 120
-
-#menu
-    position: relative
-    z-index: 120
     .button:hover
         cursor: pointer
     // Signed-in chrome wraps the avatar + matBadge. Do not overflow:hidden here —
@@ -98,6 +94,10 @@
         width: 40px
         height: 40px
         box-shadow: 0 0 0 2px color-mix(in srgb, var(--cp-amber, #e8a23a) 40%, transparent)
+
+#menu
+    position: relative
+    z-index: 120
 
 button#menu
     flex-shrink: 0

--- a/cultpodcasts/src/app/toolbar/toolbar.component.sass
+++ b/cultpodcasts/src/app/toolbar/toolbar.component.sass
@@ -78,6 +78,12 @@
 
 #socialbuttons
     flex-shrink: 0
+    position: relative
+    z-index: 120
+
+#menu
+    position: relative
+    z-index: 120
     .button:hover
         cursor: pointer
     // Signed-in chrome wraps the avatar + matBadge. Do not overflow:hidden here —

--- a/cultpodcasts/src/app/toolbar/toolbar.component.sass
+++ b/cultpodcasts/src/app/toolbar/toolbar.component.sass
@@ -70,8 +70,8 @@
     height: 40px
     vertical-align: middle
 
-// Hide the SSR logged-out profile glyph when a cached avatar exists, until the
-// skip-hydration toolbar re-renders with #avatar (avoids logged-out flash).
+// Hide the SSR logged-out profile glyph when a cached avatar exists, until
+// afterNextRender flips signed-in chrome to #avatar (avoids logged-out flash).
 :host-context(html.has-cached-avatar)
     img.socialbutton[alt="Profile"]:not(#avatar)
         opacity: 0

--- a/cultpodcasts/src/app/toolbar/toolbar.component.ts
+++ b/cultpodcasts/src/app/toolbar/toolbar.component.ts
@@ -27,9 +27,6 @@ import { SubmitUrlOriginResponseSnackbarComponent } from '../submit-url-origin-r
 import { MatBadgeModule } from '@angular/material/badge';
 import { Share } from '../share.interface';
 import { DiscoveryInfoService } from '../discovery-info.service';
-import { authRedirectUri } from '../auth-redirect-uri';
-import { environment } from '../../environments/environment';
-
 @Component({
   selector: 'app-toolbar',
   imports: [
@@ -103,12 +100,7 @@ export class ToolbarComponent {
   }
 
   logout() {
-    this.auth.clearCachedAvatar();
-    this.auth.authService.logout({
-      logoutParams: {
-        returnTo: authRedirectUri(environment.assetHost)
-      }
-    });
+    this.auth.logoutKeepingCurrentPage();
   }
 
   async openSubmitPodcast() {

--- a/cultpodcasts/src/app/toolbar/toolbar.component.ts
+++ b/cultpodcasts/src/app/toolbar/toolbar.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, DestroyRef, inject } from '@angular/core';
+import { afterNextRender, ChangeDetectionStrategy, Component, DestroyRef, inject, signal } from '@angular/core';
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { AuthServiceWrapper, HAS_LOGGED_IN_STORAGE_KEY } from '../auth-service-wrapper.class';
 import { FeatureSwitchService } from '../feature-switch-service';
@@ -41,10 +41,7 @@ import { environment } from '../../environments/environment';
   ],
   templateUrl: './toolbar.component.html',
   styleUrl: './toolbar.component.sass',
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  // SSR always renders the logged-out chrome (FakeAuth); the client may render
-  // the cached avatar immediately. Skip hydration so those trees can't mismatch.
-  host: { ngSkipHydration: 'true' }
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ToolbarComponent {
   public FeatureSwitch = FeatureSwitch;
@@ -60,9 +57,21 @@ export class ToolbarComponent {
   private readonly router = inject(Router);
   private readonly destroyRef = inject(DestroyRef);
 
+  /**
+   * SSR (FakeAuth) always paints logged-out chrome. AuthServiceWrapper may seed a
+   * cached avatar during browser bootstrap — defer signed-in UI until after the
+   * first client render so hydration matches and (click)/menu triggers bind.
+   * Skipping hydration left dead SSR DOM with no listeners on cold loads.
+   */
+  private readonly authChromeReady = signal(false);
+
+  constructor() {
+    afterNextRender(() => this.authChromeReady.set(true));
+  }
+
   /** True while Auth0 has a user, or we still have a cached avatar during session restore. */
   protected showSignedInChrome(): boolean {
-    return !!this.auth.avatarUrl();
+    return this.authChromeReady() && !!this.auth.avatarUrl();
   }
 
   protected avatarSrc(): string {

--- a/cultpodcasts/src/app/toolbar/toolbar.component.ts
+++ b/cultpodcasts/src/app/toolbar/toolbar.component.ts
@@ -80,7 +80,7 @@ export class ToolbarComponent {
 
   login() {
     if (localStorage.getItem(HAS_LOGGED_IN_STORAGE_KEY)) {
-      this.auth.authService.loginWithRedirect();
+      this.auth.loginWithRedirectToCurrentPage();
     } else {
       this.dialog
         .open(FirstLoginNoticeComponent, { disableClose: true, autoFocus: true })
@@ -88,7 +88,7 @@ export class ToolbarComponent {
         .pipe(takeUntilDestroyed(this.destroyRef))
         .subscribe(async result => {
           if (result?.continue) {
-            this.auth.authService.loginWithRedirect();;
+            this.auth.loginWithRedirectToCurrentPage();
           }
         });
     }

--- a/cultpodcasts/src/environments/IEnvironment.ts
+++ b/cultpodcasts/src/environments/IEnvironment.ts
@@ -7,5 +7,4 @@ export interface IEnvironment {
     shortner: string;
     name: string;
     vapidPublicKey: string;
-    ssrIgnoresSsl?: boolean,
 }

--- a/cultpodcasts/src/environments/environment.local.ts
+++ b/cultpodcasts/src/environments/environment.local.ts
@@ -9,6 +9,5 @@ export const environment: IEnvironment = {
    assetHost: 'https://local.cultpodcasts.com:8788/',
    shortner: 'https://s.cultpodcasts.com',
    name: "dev",
-   vapidPublicKey: "BKx7EI56y8biaGTAo_bagpNPTR9f4AkHqtuUoHaRM7nNduX5ExbAHO74-YAKa6_c9wLVYWHZklhrpPl6Bbx_3Is",
-   ssrIgnoresSsl: true
+   vapidPublicKey: "BKx7EI56y8biaGTAo_bagpNPTR9f4AkHqtuUoHaRM7nNduX5ExbAHO74-YAKa6_c9wLVYWHZklhrpPl6Bbx_3Is"
 };

--- a/cultpodcasts/src/environments/environment.ts
+++ b/cultpodcasts/src/environments/environment.ts
@@ -9,6 +9,5 @@ export const environment: IEnvironment = {
    assetHost: 'https://local.cultpodcasts.com:4200/',
    shortner: 'https://s.cultpodcasts.com',
    name: "dev",
-   vapidPublicKey: "BKx7EI56y8biaGTAo_bagpNPTR9f4AkHqtuUoHaRM7nNduX5ExbAHO74-YAKa6_c9wLVYWHZklhrpPl6Bbx_3Is",
-   ssrIgnoresSsl: true
+   vapidPublicKey: "BKx7EI56y8biaGTAo_bagpNPTR9f4AkHqtuUoHaRM7nNduX5ExbAHO74-YAKa6_c9wLVYWHZklhrpPl6Bbx_3Is"
 };

--- a/cultpodcasts/src/environments/version.ts
+++ b/cultpodcasts/src/environments/version.ts
@@ -1,3 +1,4 @@
 export const version = "0.0.0-development";
-export const buildDate = new Date().toISOString();
+/** Stable string — `new Date().toISOString()` at module load differed SSR vs browser. */
+export const buildDate = "local-development";
 export const commitHash = "development";

--- a/cultpodcasts/src/index.html
+++ b/cultpodcasts/src/index.html
@@ -37,8 +37,8 @@
   <!--
     Do not mutate toolbar DOM here — that breaks Angular hydration
     (nextSibling / hasAttribute on null) and leaves auth pages stuck loading.
-    AuthServiceWrapper seeds the avatar from localStorage; the toolbar skips
-    hydration so the first client paint can show the cached letter-avatar.
+    AuthServiceWrapper seeds the avatar from localStorage; the toolbar defers
+    signed-in chrome until after hydration, then shows the cached letter-avatar.
     Optional: hide the SSR logged-out icon until then (class only — safe).
   -->
   <script type="text/javascript">

--- a/cultpodcasts/src/main.server.ts
+++ b/cultpodcasts/src/main.server.ts
@@ -1,25 +1,9 @@
 import { bootstrapApplication, BootstrapContext } from '@angular/platform-browser';
 import { AppComponent } from './app/app.component';
 import { config } from './app/app.config.server';
-import { environment } from './environments/environment';
 
-declare global {
-  // One warn per Node process (prerender boots main.server once per route).
-  // eslint-disable-next-line no-var -- ambient process flag
-  var __cultpodcastsSsrTlsWarned: boolean | undefined;
-}
-
-try {
-    if (true === environment?.ssrIgnoresSsl) {
-        process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = '0';
-        if (!globalThis.__cultpodcastsSsrTlsWarned) {
-            globalThis.__cultpodcastsSsrTlsWarned = true;
-            console.warn('main.server.ts: SSR is running with SSL Certificate Checking disabled because environment.ssrIgnoresSsl is true.');
-        }
-    }
-} catch (error) {
-    console.error("Unable to ignore tls-reject errors");
-}
+// Local HTTPS: cultpodcasts/.cert/dev-cert.pem + dev-key.pem via wrangler/ng serve.
+// Node prerender trusts that CA through NODE_EXTRA_CA_CERTS (tools/start-local.mjs).
 
 const bootstrap = (context: BootstrapContext) => bootstrapApplication(AppComponent, config, context);
 

--- a/cultpodcasts/tools/start-local.mjs
+++ b/cultpodcasts/tools/start-local.mjs
@@ -1,0 +1,69 @@
+/**
+ * Local start: trust .cert/dev-cert.pem for Node prerender HTTPS fetches,
+ * then build + wrangler pages with the same cert/key (no TLS ignore hacks).
+ */
+import { spawn } from "node:child_process";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { existsSync } from "node:fs";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const cert = join(root, ".cert", "dev-cert.pem");
+const key = join(root, ".cert", "dev-key.pem");
+
+if (!existsSync(cert) || !existsSync(key)) {
+  console.error("Missing .cert/dev-cert.pem or .cert/dev-key.pem — see AGENTS.md");
+  process.exit(1);
+}
+
+process.env.NODE_EXTRA_CA_CERTS = cert;
+
+const isWin = process.platform === "win32";
+const npm = isWin ? "npm.cmd" : "npm";
+
+function run(cmd, args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, {
+      cwd: root,
+      env: process.env,
+      stdio: "inherit",
+      shell: isWin,
+    });
+    child.on("exit", (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`${cmd} ${args.join(" ")} exited ${code}`));
+    });
+    child.on("error", reject);
+  });
+}
+
+await run(npm, ["run", "build:local"]);
+await run(npm, ["run", "process"]);
+
+const wranglerArgs = [
+  "wrangler",
+  "pages",
+  "dev",
+  "dist/cloudflare",
+  "--compatibility-date=2024-09-02",
+  "--local-protocol",
+  "https",
+  "--https-cert-path",
+  ".cert/dev-cert.pem",
+  "--https-key-path",
+  ".cert/dev-key.pem",
+  "--port",
+  "8788",
+  "--kv",
+  "kv",
+  "--r2",
+  "content",
+];
+
+const wrangler = spawn(isWin ? "npx.cmd" : "npx", wranglerArgs, {
+  cwd: root,
+  env: process.env,
+  stdio: "inherit",
+  shell: isWin,
+});
+wrangler.on("exit", (code) => process.exit(code ?? 1));


### PR DESCRIPTION
## Summary
- Episode Meta `hashTag` (space-delimited); chrome cold-load fix; tweeted-only delete; Reddit subject tab FeatureSwitch
- Absorbs #444 GUID podcast GET
- Absorbs #447 episode OG share image behind **`FeatureSwitch.episodeOgShareImage` (default OFF)**
- Auth0 avatar size restored under `#socialbuttons`
- Toolbar hydrates on cold load (no skip-hydration) so Add/Profile bind; docked search pointer-events pass-through
- Client **1.10.98**

## Feature switch / docs
- Compile-time: `FeatureSwitch.episodeOgShareImage` = **false** by default
- Docs: `cultpodcasts/docs/episode-og-share-image.md`

## Preview test plan (SEO image ON and OFF)
- [ ] **OFF (default):** episode SSR `og:image` = site icon (`/assets/sq-image.png`); `twitter:card=summary`
- [ ] **ON (preview-only flip):** temporarily set switch true; episode with KV art shows episode/`/og-image`; wide → `summary_large_image`
- [ ] Revert switch to OFF before production unless intentionally enabling
- [ ] Edit episode hashtag; **cold load** `/content/privacy-policy` — Add Podcast + Profile open; GUID edit-episode load; delete posted-not-tweeted
- [ ] Auth0 avatar is 40×40 circle (not full-size square)

## Config / secrets (names only — no values)

- [ ] N/A — no new Pages Preview/Production env keys for this PR
- [ ] `FeatureSwitch.episodeOgShareImage` is compile-time in `feature-switch-service.ts` (not a Pages secret); ship production with **OFF** unless intentionally enabling
- [ ] Related Api Worker (see Api #138): confirm shortener KV + `/og-image` on **api-preview** and top-level **`api`**
- [ ] Related RPP Function Apps (see RPP #960): confirm setting **names** below present; leave **`false`** for initial release:
  - `twitter__ShortUrlOnlyWhenShareImage` on `indexer-infra` / `api-infra` / `discover-infra`
  - `bluesky__ShortUrlOnlyWhenShareImage` on `indexer-infra` / `api-infra` / `discover-infra`

### Production switchover (before calling release done)

1. Read this section and sibling Api #138 / RPP #960 `## Config / secrets`.
2. Confirm no missing Pages keys (none expected here).
3. Confirm Api preview + production Worker bindings for `/og-image` / shortener.
4. Confirm RPP Function App setting **names** exist (values stay **`false`** until short-URL-only is intentional).
5. Do **not** treat “preview URL works” as production-ready until those checklists are ticked.
6. Ship with `FeatureSwitch.episodeOgShareImage` = **false** unless intentionally enabling SEO episode art.