### PR TITLE
docs: Cursor Cloud environment setup notes

### DIFF
--- a/cultpodcasts/AGENTS.md
+++ b/cultpodcasts/AGENTS.md
@@ -90,3 +90,25 @@ Build: `ng build`. Mobile/TWA notes: `MOBILE_BUILDS.md`.
 ## Version bumps (HARD for PRs)
 
 Every website PR that changes shipped client code **MUST** bump `cultpodcasts/package.json` (and `package-lock.json` to match) — patch unless the change warrants minor/major. Do this in the same PR before opening or as the last commit before ready-for-review.
+
+## Cursor Cloud specific instructions
+
+Multi-repo workspace: this app is at `/agent/repos/website/cultpodcasts` alongside `/agent/repos/api`
+and `/agent/repos/redditpodcastposter`. The startup update script runs `npm ci` here.
+
+- **Node**: needs Node 22.22.3 (`.nvmrc`, installed via nvm). Login shells (`bash -lc`, tmux) get it
+  from `~/.bashrc`. A sandbox `/exec-daemon/node` (22.14.0) shadows PATH in bare non-login shells —
+  prefer `bash -lc "…"` or prepend `$HOME/.nvm/versions/node/v22.22.3/bin`.
+- **Dev servers**: `npm run dev` (ng serve, `https://local.cultpodcasts.com:4200`) or `npm run start`
+  (wrangler pages, `:8788`) require `.cert/dev-cert.pem` + `.cert/dev-key.pem` (self-signed, gitignored,
+  persisted in the snapshot) and the hosts entry `127.0.0.1 local.cultpodcasts.com`.
+- **Browser cert**: the dev cert is trusted in the snapshot (system CA store + Chrome NSS db at
+  `~/.pki/nssdb`), so a fresh Chrome loads the site without warnings. Dev `environment.ts` points the
+  API at `https://127.0.0.1:8787`; for in-browser API calls run the api worker (accept its cert — it is
+  trusted; otherwise type `thisisunsafe` on the interstitial).
+- **Live data**: the catalogue/search DATA needs the api worker **and** the Azure Functions backend
+  (Cosmos DB + Azure AI Search) + secrets. With only the api worker running, seed its local R2
+  `content/homepage` object to render a working homepage (see api `AGENTS.md`); search/episode detail
+  still require the Azure backend.
+- **Tests**: `npm run test:all` (328 Vitest unit + 50 Playwright e2e). Playwright Chromium is
+  pre-installed in the snapshot; the pre-push hook runs `test:all`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `## Cursor Cloud specific instructions` section to `cultpodcasts/AGENTS.md` capturing durable, non-obvious setup/run notes for the Cloud Agent dev environment.

Notes captured:
- Node 22.22.3 (`.nvmrc`, nvm) and the `/exec-daemon/node` (22.14.0) PATH-shadowing gotcha in non-login shells.
- Dev servers (`npm run dev` :4200 / `npm run start` :8788) need `.cert/dev-cert.pem`/`dev-key.pem` and the `local.cultpodcasts.com` hosts entry.
- The dev cert is trusted in the snapshot (system CA store + Chrome NSS db), so Chrome loads the site cleanly; dev `environment.ts` points the API at `https://127.0.0.1:8787`.
- Live catalogue/search data needs the api worker + Azure Functions backend + secrets; a local homepage render can be produced by seeding the api worker's local R2 `content/homepage` object.

Docs-only change (no shipped client code), so no version bump.

## Config / secrets

- No new Pages/Auth0 keys introduced by this PR.

## Test plan

- `npm run test:all` — 328 Vitest unit tests + 50 Playwright e2e pass.
- `npm run dev` — app builds and serves; homepage renders (hero/discover) against the local api worker.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-535dba73-d0dc-42b4-b1e2-e9f3e29f9fe8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-535dba73-d0dc-42b4-b1e2-e9f3e29f9fe8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

