### PR TITLE
fix(ui): homepage search width and dock without scroll jump

### DIFF
--- a/cultpodcasts/AGENTS.md
+++ b/cultpodcasts/AGENTS.md
@@ -90,3 +90,25 @@ Build: `ng build`. Mobile/TWA notes: `MOBILE_BUILDS.md`.
 ## Version bumps (HARD for PRs)
 
 Every website PR that changes shipped client code **MUST** bump `cultpodcasts/package.json` (and `package-lock.json` to match) — patch unless the change warrants minor/major. Do this in the same PR before opening or as the last commit before ready-for-review.
+
+## Cursor Cloud specific instructions
+
+Multi-repo workspace: this app is at `/agent/repos/website/cultpodcasts` alongside `/agent/repos/api`
+and `/agent/repos/redditpodcastposter`. The startup update script runs `npm ci` here.
+
+- **Node**: needs Node 22.22.3 (`.nvmrc`, installed via nvm). Login shells (`bash -lc`, tmux) get it
+  from `~/.bashrc`. A sandbox `/exec-daemon/node` (22.14.0) shadows PATH in bare non-login shells —
+  prefer `bash -lc "…"` or prepend `$HOME/.nvm/versions/node/v22.22.3/bin`.
+- **Dev servers**: `npm run dev` (ng serve, `https://local.cultpodcasts.com:4200`) or `npm run start`
+  (wrangler pages, `:8788`) require `.cert/dev-cert.pem` + `.cert/dev-key.pem` (self-signed, gitignored,
+  persisted in the snapshot) and the hosts entry `127.0.0.1 local.cultpodcasts.com`.
+- **Browser cert**: the dev cert is trusted in the snapshot (system CA store + Chrome NSS db at
+  `~/.pki/nssdb`), so a fresh Chrome loads the site without warnings. Dev `environment.ts` points the
+  API at `https://127.0.0.1:8787`; for in-browser API calls run the api worker (accept its cert — it is
+  trusted; otherwise type `thisisunsafe` on the interstitial).
+- **Live data**: the catalogue/search DATA needs the api worker **and** the Azure Functions backend
+  (Cosmos DB + Azure AI Search) + secrets. With only the api worker running, seed its local R2
+  `content/homepage` object to render a working homepage (see api `AGENTS.md`); search/episode detail
+  still require the Azure backend.
+- **Tests**: `npm run test:all` (328 Vitest unit + 50 Playwright e2e). Playwright Chromium is
+  pre-installed in the snapshot; the pre-push hook runs `test:all`.

--- a/cultpodcasts/e2e/chrome-search-layout.spec.ts
+++ b/cultpodcasts/e2e/chrome-search-layout.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect, type Page } from "@playwright/test";
+import { buildChromeSearchLayoutDocument } from "./chrome-search-layout/build-harness";
+
+/**
+ * CHROME-HIT-001: the home overlay field must remain the topmost hit at its
+ * centre while scrolling (not tucked under the fixed logo bar). Previous
+ * checks used computed visibility/opacity, which stay "visible" when the bar
+ * paints over the field.
+ *
+ * Compiles real app.component.sass into a light-DOM harness (no Angular).
+ */
+
+type HitReport = {
+  ok: boolean;
+  reason: string;
+  hit: string | null;
+  visibility?: string;
+  opacity?: string;
+  slotZIndex?: string | null;
+  width: number;
+  top: number;
+  stuck: boolean;
+  scrollY: number;
+};
+
+async function openHarness(page: Page): Promise<void> {
+  await page.setContent(buildChromeSearchLayoutDocument(), { waitUntil: "domcontentloaded" });
+}
+
+async function hit(page: Page): Promise<HitReport> {
+  return page.evaluate(() => (window as unknown as { __chromeSearchHit: () => HitReport }).__chromeSearchHit());
+}
+
+test.describe("home chrome search overlay (CHROME-HIT-001)", () => {
+  test.use({ viewport: { width: 1440, height: 900 } });
+
+  test("CHROME-HIT-001: search stays hittable and 640px-class width through dock and undock", async ({ page }) => {
+    await openHarness(page);
+
+    const rest = await hit(page);
+    expect(rest.ok, `rest: ${JSON.stringify(rest)}`).toBe(true);
+    expect(rest.stuck).toBe(false);
+    expect(rest.slotZIndex).toBe("auto");
+    expect(rest.width).toBeLessThanOrEqual(660);
+    expect(rest.width).toBeGreaterThanOrEqual(480);
+
+    const failures: HitReport[] = [];
+    for (let y = 0; y <= 240; y += 4) {
+      await page.evaluate((sy) => window.scrollTo(0, sy), y);
+      await page.evaluate(() => (window as unknown as { __chromeSearchSync: () => void }).__chromeSearchSync());
+      const report = await hit(page);
+      if (!report.ok || report.width > 700) {
+        failures.push(report);
+      }
+    }
+    expect(failures, failures.map((f) => JSON.stringify(f)).join("\n")).toEqual([]);
+
+    await page.evaluate(() => window.scrollTo(0, 180));
+    await page.evaluate(() => (window as unknown as { __chromeSearchSync: () => void }).__chromeSearchSync());
+    const mid = await hit(page);
+    expect(mid.ok, `mid: ${JSON.stringify(mid)}`).toBe(true);
+    expect(mid.stuck).toBe(true);
+    expect(mid.hit).not.toBe("app-toolbar");
+    expect(mid.slotZIndex).toBe("auto");
+    expect(mid.width).toBeLessThanOrEqual(660);
+
+    await page.evaluate(() => window.scrollTo(0, 0));
+    await page.evaluate(() => (window as unknown as { __chromeSearchSync: () => void }).__chromeSearchSync());
+    const top = await hit(page);
+    expect(top.ok, `top: ${JSON.stringify(top)}`).toBe(true);
+    expect(top.stuck).toBe(false);
+    expect(top.width).toBeLessThanOrEqual(660);
+  });
+
+  test("CHROME-HIT-001: a single jump past the bar still leaves the field hittable", async ({ page }) => {
+    await openHarness(page);
+    await page.evaluate(() => window.scrollTo(0, 96));
+    await page.evaluate(() => (window as unknown as { __chromeSearchSync: () => void }).__chromeSearchSync());
+    const report = await hit(page);
+    expect(report.ok, JSON.stringify(report)).toBe(true);
+    expect(report.stuck).toBe(true);
+    expect(report.width).toBeLessThanOrEqual(660);
+  });
+});

--- a/cultpodcasts/e2e/chrome-search-layout.spec.ts
+++ b/cultpodcasts/e2e/chrome-search-layout.spec.ts
@@ -24,8 +24,8 @@ type HitReport = {
   scrollY: number;
 };
 
-async function openHarness(page: Page): Promise<void> {
-  await page.setContent(buildChromeSearchLayoutDocument(), { waitUntil: "domcontentloaded" });
+async function openHarness(page: Page, shell: "home" | "browse" = "home"): Promise<void> {
+  await page.setContent(buildChromeSearchLayoutDocument(shell), { waitUntil: "domcontentloaded" });
 }
 
 async function hit(page: Page): Promise<HitReport> {
@@ -88,5 +88,21 @@ test.describe("home chrome search overlay (CHROME-HIT-001)", () => {
     expect(report.ok, JSON.stringify(report)).toBe(true);
     expect(report.stuck).toBe(true);
     expect(report.width).toBeLessThanOrEqual(660);
+  });
+});
+
+test.describe("browse chrome search (CHROME-HIT-002)", () => {
+  test.use({ viewport: { width: 1440, height: 900 } });
+
+  test("CHROME-HIT-002: wide browse/podcast search is the same 640px pin, not the logo↔actions gap", async ({ page }) => {
+    await openHarness(page, "browse");
+    const report = await hit(page);
+    expect(report.ok, JSON.stringify(report)).toBe(true);
+    expect(report.stuck).toBe(true);
+    expect(report.position).toBe("fixed");
+    expect(report.width).toBeLessThanOrEqual(660);
+    expect(report.width).toBeGreaterThanOrEqual(480);
+    expect(report.top).toBeLessThan(40);
+    expect(report.hit).not.toBe("app-toolbar");
   });
 });

--- a/cultpodcasts/e2e/chrome-search-layout.spec.ts
+++ b/cultpodcasts/e2e/chrome-search-layout.spec.ts
@@ -106,3 +106,27 @@ test.describe("browse chrome search (CHROME-HIT-002)", () => {
     expect(report.hit).not.toBe("app-toolbar");
   });
 });
+
+test.describe("narrow chrome search slot (CHROME-HIT-003)", () => {
+  test.use({ viewport: { width: 390, height: 844 } });
+
+  test("CHROME-HIT-003: narrow home slot collapses so the hero sits under the bar", async ({ page }) => {
+    await openHarness(page);
+    await page.evaluate(() => {
+      document.getElementById("body")?.classList.add("chrome-stuck");
+      document.getElementById("chromeSearch")?.classList.add("chrome-search--docked");
+    });
+    const geometry = await page.evaluate(() => {
+      const bar = document.getElementById("chromeBar")?.getBoundingClientRect();
+      const slot = document.querySelector(".chrome-search-slot")?.getBoundingClientRect();
+      const nflx = document.querySelector(".nflx")?.getBoundingClientRect();
+      return {
+        slotH: slot ? Math.round(slot.height) : -1,
+        nflxTop: nflx ? Math.round(nflx.top) : -1,
+        barBottom: bar ? Math.round(bar.bottom) : -1
+      };
+    });
+    expect(geometry.slotH, JSON.stringify(geometry)).toBeLessThanOrEqual(1);
+    expect(geometry.nflxTop, JSON.stringify(geometry)).toBeLessThanOrEqual(1);
+  });
+});

--- a/cultpodcasts/e2e/chrome-search-layout.spec.ts
+++ b/cultpodcasts/e2e/chrome-search-layout.spec.ts
@@ -17,6 +17,7 @@ type HitReport = {
   visibility?: string;
   opacity?: string;
   slotZIndex?: string | null;
+  position?: string;
   width: number;
   top: number;
   stuck: boolean;
@@ -40,18 +41,23 @@ test.describe("home chrome search overlay (CHROME-HIT-001)", () => {
     const rest = await hit(page);
     expect(rest.ok, `rest: ${JSON.stringify(rest)}`).toBe(true);
     expect(rest.stuck).toBe(false);
+    expect(rest.position).toBe("sticky");
     expect(rest.slotZIndex).toBe("auto");
     expect(rest.width).toBeLessThanOrEqual(660);
     expect(rest.width).toBeGreaterThanOrEqual(480);
 
     const failures: HitReport[] = [];
+    let prevTop = rest.top;
     for (let y = 0; y <= 240; y += 4) {
       await page.evaluate((sy) => window.scrollTo(0, sy), y);
       await page.evaluate(() => (window as unknown as { __chromeSearchSync: () => void }).__chromeSearchSync());
       const report = await hit(page);
-      if (!report.ok || report.width > 700) {
-        failures.push(report);
+      const jump = report.top - prevTop;
+      // 4px scroll steps: top should ease up or hold — not teleport into the bar.
+      if (!report.ok || report.width > 700 || jump > 3 || jump < -10) {
+        failures.push({ ...report, reason: `${report.reason} jump=${jump}` });
       }
+      prevTop = report.top;
     }
     expect(failures, failures.map((f) => JSON.stringify(f)).join("\n")).toEqual([]);
 
@@ -60,9 +66,11 @@ test.describe("home chrome search overlay (CHROME-HIT-001)", () => {
     const mid = await hit(page);
     expect(mid.ok, `mid: ${JSON.stringify(mid)}`).toBe(true);
     expect(mid.stuck).toBe(true);
+    expect(mid.position).toBe("fixed");
     expect(mid.hit).not.toBe("app-toolbar");
     expect(mid.slotZIndex).toBe("auto");
     expect(mid.width).toBeLessThanOrEqual(660);
+    expect(Math.abs(mid.width - rest.width)).toBeLessThanOrEqual(24);
 
     await page.evaluate(() => window.scrollTo(0, 0));
     await page.evaluate(() => (window as unknown as { __chromeSearchSync: () => void }).__chromeSearchSync());

--- a/cultpodcasts/e2e/chrome-search-layout/build-harness.ts
+++ b/cultpodcasts/e2e/chrome-search-layout/build-harness.ts
@@ -82,59 +82,36 @@ export function buildChromeSearchLayoutDocument(): string {
 </section>
 <script>
 (function () {
-  const HOME_UNDOCK_SCROLL_PX = 8;
   const body = document.getElementById("body");
   const bar = document.getElementById("chromeBar");
   const search = document.getElementById("chromeSearch");
   let docked = false;
 
-  function clearLayout() {
-    search.style.left = "";
-    search.style.right = "";
-    search.style.width = "";
-    search.style.top = "";
-    search.style.transform = "";
-    search.style.marginLeft = "";
-    search.style.marginRight = "";
+  function stickTop() {
+    const barH = Math.max(bar.getBoundingClientRect().height, 52);
+    const searchH = Math.min(search.offsetHeight || 48, barH - 8);
+    return Math.max(0, (barH - searchH) / 2);
   }
 
-  function layoutHomeDocked() {
-    const barHeight = Math.max(bar.getBoundingClientRect().height, 52);
-    const searchHeight = Math.min(search.offsetHeight || 40, barHeight - 8);
-    const top = Math.max(0, (barHeight - searchHeight) / 2);
-    search.style.left = "50%";
-    search.style.right = "auto";
-    search.style.width = "";
-    search.style.marginLeft = "0";
-    search.style.marginRight = "0";
-    search.style.top = top + "px";
-    search.style.transform = "translateX(-50%)";
+  function pinAtScrollY() {
+    const gap = parseFloat(getComputedStyle(body).getPropertyValue("--site-chrome-search-gap")) || 12;
+    return bar.getBoundingClientRect().height + gap - stickTop();
   }
 
   function setDocked(next) {
     docked = next;
     body.classList.toggle("chrome-stuck", next);
-    search.classList.toggle("chrome-search--docked", next);
-    if (next) {
-      layoutHomeDocked();
-    } else {
-      clearLayout();
-    }
   }
 
   function sync() {
     const y = window.scrollY;
     if (docked) {
-      if (y < HOME_UNDOCK_SCROLL_PX) {
+      if (y < pinAtScrollY() - 2) {
         setDocked(false);
-      } else {
-        layoutHomeDocked();
       }
       return;
     }
-    const barBottom = bar.getBoundingClientRect().bottom;
-    const searchTop = search.getBoundingClientRect().top;
-    if (searchTop <= barBottom + 2) {
+    if (search.getBoundingClientRect().top <= stickTop() + 1) {
       setDocked(true);
     }
   }
@@ -160,11 +137,10 @@ export function buildChromeSearchLayoutDocument(): string {
       ok,
       reason: ok ? "hit" : "covered",
       hit: hit ? (hit.id || hit.className || hit.tagName) : null,
-      // visibility/opacity stay "visible"/"1" when the toolbar paints over the
-      // field — they are diagnostic only and must not be treated as pass.
       visibility: cs.visibility,
       opacity: cs.opacity,
       slotZIndex: slot ? getComputedStyle(slot).zIndex : null,
+      position: getComputedStyle(search).position,
       width: Math.round(r.width),
       top: Math.round(r.top),
       stuck: body.classList.contains("chrome-stuck"),

--- a/cultpodcasts/e2e/chrome-search-layout/build-harness.ts
+++ b/cultpodcasts/e2e/chrome-search-layout/build-harness.ts
@@ -1,0 +1,178 @@
+import * as sass from "sass";
+import { join } from "node:path";
+
+const chromeSassPath = join(process.cwd(), "src", "app", "app.component.sass");
+
+/** Compile real app.component.sass for a light-DOM chrome/search harness. */
+export function compileChromeSearchLayoutCss(): string {
+  const compiled = sass.compile(chromeSassPath, { style: "expanded" }).css
+    .replaceAll("::ng-deep", "");
+  return `
+html, body { margin: 0; background: #0b0b0b; color: #fff; }
+.app-toolbar {
+  display: flex;
+  align-items: center;
+  height: var(--site-chrome-bar-h, 58px);
+  padding: 0 12px;
+  background: #111;
+  box-sizing: border-box;
+}
+#site { display: inline-flex; width: 42px; height: 42px; background: #fff; border-radius: 50%; flex-shrink: 0; }
+#socialbuttons { margin-left: auto; display: flex; gap: 8px; }
+#socialbuttons span {
+  width: 40px; height: 40px; border-radius: 50%; background: #444; display: block;
+}
+#searchcontainer { margin: 0; }
+#searchbar { display: flex; align-items: center; gap: 10px; margin: 0; }
+#searchboxwrapper {
+  flex: 1 1 auto;
+  min-width: 0;
+  height: var(--search-bar-control-h, 48px);
+  background: #2a2a2a;
+  border: 1px solid #666;
+  border-radius: 8px;
+  pointer-events: auto;
+}
+#searchcta {
+  flex: 0 0 auto;
+  height: var(--search-bar-control-h, 48px);
+  pointer-events: auto;
+  background: #e8a23a;
+  border: 0;
+  border-radius: 999px;
+  padding: 0 16px;
+}
+.nflx { min-height: 2400px; background: #1a1a1a; }
+${compiled}
+`;
+}
+
+export function buildChromeSearchLayoutDocument(): string {
+  const css = compileChromeSearchLayoutCss();
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Chrome search layout harness</title>
+  <style>${css}</style>
+</head>
+<body>
+<section id="body" class="home-shell">
+  <div class="site-chrome">
+    <div class="site-chrome__bar" id="chromeBar">
+      <div class="app-toolbar">
+        <a id="site" href="#"></a>
+        <div id="socialbuttons"><span></span><span></span></div>
+      </div>
+    </div>
+    <div class="site-chrome__bar-spacer" aria-hidden="true"></div>
+    <div class="chrome-search-slot">
+      <div class="chrome-search" id="chromeSearch">
+        <section id="searchcontainer">
+          <form id="searchbar">
+            <div id="searchboxwrapper"></div>
+            <button type="button" id="searchcta">Search</button>
+          </form>
+        </section>
+      </div>
+    </div>
+  </div>
+  <div class="nflx"></div>
+</section>
+<script>
+(function () {
+  const HOME_UNDOCK_SCROLL_PX = 8;
+  const body = document.getElementById("body");
+  const bar = document.getElementById("chromeBar");
+  const search = document.getElementById("chromeSearch");
+  let docked = false;
+
+  function clearLayout() {
+    search.style.left = "";
+    search.style.right = "";
+    search.style.width = "";
+    search.style.top = "";
+    search.style.transform = "";
+    search.style.marginLeft = "";
+    search.style.marginRight = "";
+  }
+
+  function layoutHomeDocked() {
+    const barHeight = Math.max(bar.getBoundingClientRect().height, 52);
+    const searchHeight = Math.min(search.offsetHeight || 40, barHeight - 8);
+    const top = Math.max(0, (barHeight - searchHeight) / 2);
+    search.style.left = "50%";
+    search.style.right = "auto";
+    search.style.width = "";
+    search.style.marginLeft = "0";
+    search.style.marginRight = "0";
+    search.style.top = top + "px";
+    search.style.transform = "translateX(-50%)";
+  }
+
+  function setDocked(next) {
+    docked = next;
+    body.classList.toggle("chrome-stuck", next);
+    search.classList.toggle("chrome-search--docked", next);
+    if (next) {
+      layoutHomeDocked();
+    } else {
+      clearLayout();
+    }
+  }
+
+  function sync() {
+    const y = window.scrollY;
+    if (docked) {
+      if (y < HOME_UNDOCK_SCROLL_PX) {
+        setDocked(false);
+      } else {
+        layoutHomeDocked();
+      }
+      return;
+    }
+    const barBottom = bar.getBoundingClientRect().bottom;
+    const searchTop = search.getBoundingClientRect().top;
+    if (searchTop <= barBottom + 2) {
+      setDocked(true);
+    }
+  }
+
+  window.addEventListener("scroll", sync, { passive: true });
+  window.__chromeSearchSync = sync;
+  window.__chromeSearchHit = function () {
+    const field = document.getElementById("searchboxwrapper");
+    const slot = document.querySelector(".chrome-search-slot");
+    const r = field.getBoundingClientRect();
+    const cs = getComputedStyle(field);
+    if (r.width < 80 || r.height < 16) {
+      return { ok: false, reason: "zero-size", width: r.width, height: r.height, top: r.top };
+    }
+    if (r.bottom < 1 || r.top > window.innerHeight - 1) {
+      return { ok: false, reason: "offscreen", top: r.top, bottom: r.bottom };
+    }
+    const x = Math.round(r.left + r.width / 2);
+    const y = Math.round(r.top + r.height / 2);
+    const hit = document.elementFromPoint(x, y);
+    const ok = !!(hit && field.contains(hit));
+    return {
+      ok,
+      reason: ok ? "hit" : "covered",
+      hit: hit ? (hit.id || hit.className || hit.tagName) : null,
+      // visibility/opacity stay "visible"/"1" when the toolbar paints over the
+      // field — they are diagnostic only and must not be treated as pass.
+      visibility: cs.visibility,
+      opacity: cs.opacity,
+      slotZIndex: slot ? getComputedStyle(slot).zIndex : null,
+      width: Math.round(r.width),
+      top: Math.round(r.top),
+      stuck: body.classList.contains("chrome-stuck"),
+      scrollY: Math.round(window.scrollY)
+    };
+  };
+})();
+</script>
+</body>
+</html>`;
+}

--- a/cultpodcasts/e2e/chrome-search-layout/build-harness.ts
+++ b/cultpodcasts/e2e/chrome-search-layout/build-harness.ts
@@ -47,8 +47,11 @@ ${compiled}
 `;
 }
 
-export function buildChromeSearchLayoutDocument(): string {
+export type ChromeSearchShell = "home" | "browse";
+
+export function buildChromeSearchLayoutDocument(shell: ChromeSearchShell = "home"): string {
   const css = compileChromeSearchLayoutCss();
+  const bodyClass = shell === "browse" ? "browse-shell chrome-stuck" : "home-shell";
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -58,7 +61,7 @@ export function buildChromeSearchLayoutDocument(): string {
   <style>${css}</style>
 </head>
 <body>
-<section id="body" class="home-shell">
+<section id="body" class="${bodyClass}">
   <div class="site-chrome">
     <div class="site-chrome__bar" id="chromeBar">
       <div class="app-toolbar">
@@ -85,7 +88,8 @@ export function buildChromeSearchLayoutDocument(): string {
   const body = document.getElementById("body");
   const bar = document.getElementById("chromeBar");
   const search = document.getElementById("chromeSearch");
-  let docked = false;
+  const isBrowse = body.classList.contains("browse-shell");
+  let docked = isBrowse;
 
   function stickTop() {
     const barH = Math.max(bar.getBoundingClientRect().height, 52);
@@ -104,6 +108,9 @@ export function buildChromeSearchLayoutDocument(): string {
   }
 
   function sync() {
+    if (isBrowse) {
+      return;
+    }
     const y = window.scrollY;
     if (docked) {
       if (y < pinAtScrollY() - 2) {

--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.105",
+  "version": "1.10.107",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.10.105",
+      "version": "1.10.107",
       "dependencies": {
         "@angular/cdk": "22.1.0",
         "@angular/common": "22.1.0",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.106",
+  "version": "1.10.107",
   "scripts": {
     "ng": "ng",
     "start": "node ./tools/start-local.mjs",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -12,6 +12,7 @@
     "test:watch": "ng test --watch",
     "test:e2e": "playwright test",
     "test:e2e:hero-layout": "playwright test e2e/hero-layout.spec.ts",
+    "test:e2e:chrome-search": "playwright test e2e/chrome-search-layout.spec.ts",
     "test:all": "npm run test && npm run test:e2e",
     "prepare": "node ./tools/install-git-hooks.cjs",
     "serve:ssr:cultpodcasts": "node dist/server/server.mjs",

--- a/cultpodcasts/playwright.config.ts
+++ b/cultpodcasts/playwright.config.ts
@@ -7,6 +7,8 @@ import { defineConfig, devices } from "@playwright/test";
  *
  * Hero layout geometry (`e2e/hero-layout.spec.ts`) compiles real billboard Sass
  * into setContent documents — no Angular server required.
+ * Chrome search overlay (`e2e/chrome-search-layout.spec.ts`) compiles
+ * app.component.sass and hit-tests the field while scrolling.
  */
 export default defineConfig({
 	testDir: "./e2e",

--- a/cultpodcasts/src/app/app-chrome-dock.contract.spec.ts
+++ b/cultpodcasts/src/app/app-chrome-dock.contract.spec.ts
@@ -116,4 +116,22 @@ describe('site chrome docked search (privacy-policy cold load)', () => {
     expect(appTs).toMatch(/chromeStuck\s*=\s*computed/);
     expect(appTs).not.toMatch(/chromeStuck\s*=\s*signal\(/);
   });
+
+  it('CHROME-DOCK-010: home search slot reserves --site-chrome-h so dock cannot collapse flow', () => {
+    expect(appHtml).toMatch(/chrome-search-slot/);
+    expect(sass).toMatch(
+      /\.home-shell\s+\.chrome-search-slot[\s\S]*?min-height:\s*var\(--site-chrome-h\)/
+    );
+    expect(sass).not.toMatch(
+      /\.home-shell\.chrome-stuck\s+\.site-chrome__bar-spacer[\s\S]*?height:\s*var\(--site-chrome-bar-h\)/
+    );
+  });
+
+  it('CHROME-DOCK-011: dropped home search spans the chrome gap (not a 640px centered pill)', () => {
+    expect(sass).toMatch(/\.chrome-search[\s\S]*?margin:\s*var\(--site-chrome-search-gap\)\s+7rem\s+12px\s+70px/);
+    expect(sass).not.toMatch(/width:\s*min\(640px,\s*calc\(100%\s*-\s*2\.5rem\)\)/);
+    expect(appTs).toMatch(/layoutDroppedSearch/);
+    expect(appTs).toMatch(/HOME_UNDOCK_SCROLL_PX/);
+    expect(appTs).not.toMatch(/MIN_SCROLL_TO_DOCK_PX/);
+  });
 });

--- a/cultpodcasts/src/app/app-chrome-dock.contract.spec.ts
+++ b/cultpodcasts/src/app/app-chrome-dock.contract.spec.ts
@@ -134,6 +134,9 @@ describe('site chrome docked search (privacy-policy cold load)', () => {
     expect(sass).not.toMatch(
       /\.home-shell\.chrome-stuck\s+\.site-chrome__bar-spacer[\s\S]*?height:\s*var\(--site-chrome-bar-h\)/
     );
+    expect(sass).toMatch(
+      /@media screen and \(max-width:\s*700px\)[\s\S]*?\.home-shell\s+\.chrome-search-slot[\s\S]*?min-height:\s*0/
+    );
   });
 
   it('CHROME-DOCK-011: dropped overlay is a centered 640px field; wide routes pin via sticky/fixed not a layout swap', () => {

--- a/cultpodcasts/src/app/app-chrome-dock.contract.spec.ts
+++ b/cultpodcasts/src/app/app-chrome-dock.contract.spec.ts
@@ -125,6 +125,12 @@ describe('site chrome docked search (privacy-policy cold load)', () => {
     expect(sass).toMatch(
       /\.home-shell\s+\.chrome-search-slot[\s\S]*?display:\s*flow-root/
     );
+    // Slot must not create a stacking context. z-index here traps
+    // position:fixed .chrome-search below .site-chrome__bar (102).
+    const slotRule =
+      sass.match(/^\.chrome-search-slot\n(?:[ \t].*\n|\n)*/m)?.[0] ?? '';
+    expect(slotRule).toMatch(/pointer-events:\s*none/);
+    expect(slotRule).not.toMatch(/^[ \t]+z-index:/m);
     expect(sass).not.toMatch(
       /\.home-shell\.chrome-stuck\s+\.site-chrome__bar-spacer[\s\S]*?height:\s*var\(--site-chrome-bar-h\)/
     );
@@ -135,6 +141,7 @@ describe('site chrome docked search (privacy-policy cold load)', () => {
     expect(sass).toMatch(/margin:\s*var\(--site-chrome-search-gap\)\s+auto\s+12px/);
     expect(sass).toMatch(/\.home-shell\.chrome-stuck\s+\.chrome-search--docked[\s\S]*?translateX\(-50%\)/);
     expect(appTs).toMatch(/layoutDroppedSearch/);
+    expect(appTs).toMatch(/changeDetector\.detectChanges\(\)/);
     expect(appTs).toMatch(/layoutHomeDockedSearch/);
     expect(appTs).toMatch(/clearDockedSearchLayout/);
     expect(appTs).toMatch(/HOME_UNDOCK_SCROLL_PX/);

--- a/cultpodcasts/src/app/app-chrome-dock.contract.spec.ts
+++ b/cultpodcasts/src/app/app-chrome-dock.contract.spec.ts
@@ -130,10 +130,13 @@ describe('site chrome docked search (privacy-policy cold load)', () => {
     );
   });
 
-  it('CHROME-DOCK-011: dropped home search spans the chrome gap (not a 640px centered pill)', () => {
-    expect(sass).toMatch(/\.chrome-search[\s\S]*?margin:\s*var\(--site-chrome-search-gap\)\s+7rem\s+12px\s+70px/);
-    expect(sass).not.toMatch(/width:\s*min\(640px,\s*calc\(100%\s*-\s*2\.5rem\)\)/);
+  it('CHROME-DOCK-011: dropped overlay is a centered 640px field; docked inline width is cleared at rest', () => {
+    expect(sass).toMatch(/width:\s*min\(640px,\s*calc\(100%\s*-\s*2\.5rem\)\)/);
+    expect(sass).toMatch(/margin:\s*var\(--site-chrome-search-gap\)\s+auto\s+12px/);
+    expect(sass).toMatch(/\.home-shell\.chrome-stuck\s+\.chrome-search--docked[\s\S]*?translateX\(-50%\)/);
     expect(appTs).toMatch(/layoutDroppedSearch/);
+    expect(appTs).toMatch(/layoutHomeDockedSearch/);
+    expect(appTs).toMatch(/clearDockedSearchLayout/);
     expect(appTs).toMatch(/HOME_UNDOCK_SCROLL_PX/);
     expect(appTs).not.toMatch(/MIN_SCROLL_TO_DOCK_PX/);
   });

--- a/cultpodcasts/src/app/app-chrome-dock.contract.spec.ts
+++ b/cultpodcasts/src/app/app-chrome-dock.contract.spec.ts
@@ -122,6 +122,9 @@ describe('site chrome docked search (privacy-policy cold load)', () => {
     expect(sass).toMatch(
       /\.home-shell\s+\.chrome-search-slot[\s\S]*?min-height:\s*var\(--site-chrome-h\)/
     );
+    expect(sass).toMatch(
+      /\.home-shell\s+\.chrome-search-slot[\s\S]*?display:\s*flow-root/
+    );
     expect(sass).not.toMatch(
       /\.home-shell\.chrome-stuck\s+\.site-chrome__bar-spacer[\s\S]*?height:\s*var\(--site-chrome-bar-h\)/
     );

--- a/cultpodcasts/src/app/app-chrome-dock.contract.spec.ts
+++ b/cultpodcasts/src/app/app-chrome-dock.contract.spec.ts
@@ -136,14 +136,16 @@ describe('site chrome docked search (privacy-policy cold load)', () => {
     );
   });
 
-  it('CHROME-DOCK-011: dropped overlay is a centered 640px field; wide home pins via sticky not a layout swap', () => {
+  it('CHROME-DOCK-011: dropped overlay is a centered 640px field; wide routes pin via sticky/fixed not a layout swap', () => {
     expect(sass).toMatch(/width:\s*min\(640px,\s*calc\(100%\s*-\s*2\.5rem\)\)/);
     expect(sass).toMatch(/margin:\s*var\(--site-chrome-search-gap\)\s+auto\s+12px/);
     expect(sass).toMatch(/\.home-shell\s+\.chrome-search[\s\S]*?position:\s*sticky/);
     expect(sass).toMatch(
-      /\.home-shell\.chrome-stuck\s+\.chrome-search:not\(\.chrome-search--docked\)[\s\S]*?position:\s*fixed/
+      /\.chrome-stuck\s+\.chrome-search[\s\S]*?position:\s*fixed/
     );
+    expect(sass).toMatch(/\.chrome-stuck\s+\.chrome-search\.chrome-search--docked/);
     expect(appHtml).toMatch(/fillHeaderSearchGap/);
+    expect(appTs).toMatch(/fillHeaderSearchGap\s*=\s*computed\(\(\)\s*=>\s*this\.narrowChrome\(\)\)/);
     expect(appTs).toMatch(/layoutDroppedSearch/);
     expect(appTs).toMatch(/homeStickTop/);
     expect(appTs).toMatch(/homePinAtScrollY/);

--- a/cultpodcasts/src/app/app-chrome-dock.contract.spec.ts
+++ b/cultpodcasts/src/app/app-chrome-dock.contract.spec.ts
@@ -136,15 +136,20 @@ describe('site chrome docked search (privacy-policy cold load)', () => {
     );
   });
 
-  it('CHROME-DOCK-011: dropped overlay is a centered 640px field; docked inline width is cleared at rest', () => {
+  it('CHROME-DOCK-011: dropped overlay is a centered 640px field; wide home pins via sticky not a layout swap', () => {
     expect(sass).toMatch(/width:\s*min\(640px,\s*calc\(100%\s*-\s*2\.5rem\)\)/);
     expect(sass).toMatch(/margin:\s*var\(--site-chrome-search-gap\)\s+auto\s+12px/);
-    expect(sass).toMatch(/\.home-shell\.chrome-stuck\s+\.chrome-search--docked[\s\S]*?translateX\(-50%\)/);
+    expect(sass).toMatch(/\.home-shell\s+\.chrome-search[\s\S]*?position:\s*sticky/);
+    expect(sass).toMatch(
+      /\.home-shell\.chrome-stuck\s+\.chrome-search:not\(\.chrome-search--docked\)[\s\S]*?position:\s*fixed/
+    );
+    expect(appHtml).toMatch(/fillHeaderSearchGap/);
     expect(appTs).toMatch(/layoutDroppedSearch/);
-    expect(appTs).toMatch(/changeDetector\.detectChanges\(\)/);
-    expect(appTs).toMatch(/layoutHomeDockedSearch/);
+    expect(appTs).toMatch(/homeStickTop/);
+    expect(appTs).toMatch(/homePinAtScrollY/);
     expect(appTs).toMatch(/clearDockedSearchLayout/);
-    expect(appTs).toMatch(/HOME_UNDOCK_SCROLL_PX/);
+    expect(appTs).not.toMatch(/HOME_UNDOCK_SCROLL_PX/);
+    expect(appTs).not.toMatch(/layoutHomeDockedSearch/);
     expect(appTs).not.toMatch(/MIN_SCROLL_TO_DOCK_PX/);
   });
 });

--- a/cultpodcasts/src/app/app.component.html
+++ b/cultpodcasts/src/app/app.component.html
@@ -45,7 +45,7 @@
     <div class="site-chrome__bar-spacer" aria-hidden="true"></div>
     <!-- Home: slot keeps dropped-search height when the field is position:fixed (no scroll jump). -->
     <div class="chrome-search-slot">
-      <div class="chrome-search" #chromeSearch [class.chrome-search--docked]="chromeStuck()">
+      <div class="chrome-search" #chromeSearch [class.chrome-search--docked]="chromeStuck() && fillHeaderSearchGap()">
         <app-search-bar></app-search-bar>
       </div>
     </div>

--- a/cultpodcasts/src/app/app.component.html
+++ b/cultpodcasts/src/app/app.component.html
@@ -43,8 +43,11 @@
     </div>
     <!-- Keeps document flow under the fixed logo bar (0 on home — hero pulls under). -->
     <div class="site-chrome__bar-spacer" aria-hidden="true"></div>
-    <div class="chrome-search" #chromeSearch [class.chrome-search--docked]="chromeStuck()">
-      <app-search-bar></app-search-bar>
+    <!-- Home: slot keeps dropped-search height when the field is position:fixed (no scroll jump). -->
+    <div class="chrome-search-slot">
+      <div class="chrome-search" #chromeSearch [class.chrome-search--docked]="chromeStuck()">
+        <app-search-bar></app-search-bar>
+      </div>
     </div>
   </div>
   <router-outlet></router-outlet>

--- a/cultpodcasts/src/app/app.component.sass
+++ b/cultpodcasts/src/app/app.component.sass
@@ -117,7 +117,8 @@
 // collapse document flow and yank the billboard (hero negative-margin pull-up).
 .chrome-search-slot
     position: relative
-    z-index: 101
+    // Do not set z-index here — it would trap position:fixed search below
+    // .site-chrome__bar (z-index 102) so the field paints under the toolbar.
     // Empty after dock — do not intercept billboard clicks under the reserved height.
     pointer-events: none
 

--- a/cultpodcasts/src/app/app.component.sass
+++ b/cultpodcasts/src/app/app.component.sass
@@ -35,9 +35,7 @@
                 background: transparent !important
                 border-bottom-color: transparent !important
     .chrome-search
-        width: auto
-        margin-left: 58px
-        margin-right: 3.5rem
+        width: min(640px, calc(100% - 1.5rem))
 
 // Do not restore .site-chrome__bar-spacer on home dock — that plus position:fixed
 // on .chrome-search collapsed in-flow height and snapped the hero up. Home flow
@@ -130,8 +128,8 @@
     // collapse ~70px through the slot and yank the hero.
     display: flow-root
 
-// Dropped search (in flow) — same logo↔actions width as the docked header field.
-// Scrolls with the page until it meets the fixed logo bar, then --docked pins it.
+// Dropped search (in flow) — centered overlay on the hero. Scrolls until it
+// meets the fixed logo bar, then --docked pins it into the header gap.
 .chrome-search
     --search-bar-control-h: var(--nflx-search-h)
     --mat-form-field-container-height: var(--nflx-search-h)
@@ -139,11 +137,9 @@
     position: relative
     z-index: 101
     pointer-events: auto
-    width: auto
-    max-width: none
+    width: min(640px, calc(100% - 2.5rem))
+    margin: var(--site-chrome-search-gap) auto 12px
     box-sizing: border-box
-    // Fallback before JS measure — match .chrome-search--docked left/right insets.
-    margin: var(--site-chrome-search-gap) 7rem 12px 70px
     ::ng-deep
         #searchcontainer
             --search-bar-control-h: var(--nflx-search-h)
@@ -156,14 +152,14 @@
 
 // Home overlay: spacer is 0 so the billboard can sit under the bar — push search
 // down explicitly so it starts dropped (not already inside the fixed header).
+// z-index above the logo bar so the field cannot tuck under it while scrolling.
 .home-shell:not(.chrome-stuck) .chrome-search
     margin-top: calc(var(--site-chrome-bar-h) + var(--site-chrome-search-gap))
+    z-index: 110
 
 @media screen and (max-width: 700px)
     .chrome-search
-        width: auto
-        margin-left: 58px
-        margin-right: 3.5rem
+        width: min(640px, calc(100% - 1.5rem))
 
 // Docked into the sticky header between logo (left) and add/profile (right).
 // Left/width/top are set in AppComponent.layoutDockedSearch() from those anchors.
@@ -186,6 +182,7 @@
     transform: none
     --nflx-search-h: 40px
     overflow: visible
+
     ::ng-deep
         // Do NOT enable pointer-events on #searchcontainer / #searchbar — they span the
         // full docked width and would still cover add/profile when measure is late/wide.
@@ -220,6 +217,13 @@
             letter-spacing: 0
             background: var(--nflx-accent, #e8a23a) !important
             color: #111 !important
+
+.home-shell.chrome-stuck .chrome-search--docked
+    left: 50%
+    right: auto
+    width: min(640px, calc(100% - 2.5rem))
+    max-width: min(640px, calc(100vw - 11rem))
+    transform: translateX(-50%)
 
 @media screen and (max-width: 700px)
     .chrome-search--docked

--- a/cultpodcasts/src/app/app.component.sass
+++ b/cultpodcasts/src/app/app.component.sass
@@ -129,8 +129,8 @@
     // collapse ~70px through the slot and yank the hero.
     display: flow-root
 
-// Dropped search (in flow) — centered overlay on the hero. Scrolls until it
-// meets the fixed logo bar, then --docked pins it into the header gap.
+// Dropped search (in flow) — centered overlay on the hero. Home uses position:
+// sticky so the field glides into the logo row; browse uses --docked + JS gap.
 .chrome-search
     --search-bar-control-h: var(--nflx-search-h)
     --mat-form-field-container-height: var(--nflx-search-h)
@@ -153,10 +153,28 @@
 
 // Home overlay: spacer is 0 so the billboard can sit under the bar — push search
 // down explicitly so it starts dropped (not already inside the fixed header).
-// z-index above the logo bar so the field cannot tuck under it while scrolling.
-.home-shell:not(.chrome-stuck) .chrome-search
+// Sticky `top` is the in-bar Y so scrolling slides the field into the logo row
+// instead of swapping relative→fixed (bar-bottom teleport to bar-center).
+.home-shell .chrome-search
+    position: sticky
+    top: calc((var(--site-chrome-bar-h) - var(--nflx-search-h)) / 2)
     margin-top: calc(var(--site-chrome-bar-h) + var(--site-chrome-search-gap))
     z-index: 110
+    max-width: min(640px, calc(100vw - 11rem))
+
+// Once sticky `top` has caught, pin with fixed so the short search slot cannot
+// unstick the field. Same 640px box and Y as the overlay — keep --nflx-search-h.
+.home-shell.chrome-stuck .chrome-search:not(.chrome-search--docked)
+    position: fixed
+    left: 0
+    right: 0
+    top: calc((var(--site-chrome-bar-h) - var(--nflx-search-h)) / 2)
+    width: min(640px, calc(100% - 2.5rem))
+    max-width: min(640px, calc(100vw - 11rem))
+    margin: 0 auto
+    transform: none
+    height: auto
+    pointer-events: auto
 
 @media screen and (max-width: 700px)
     .chrome-search
@@ -218,13 +236,6 @@
             letter-spacing: 0
             background: var(--nflx-accent, #e8a23a) !important
             color: #111 !important
-
-.home-shell.chrome-stuck .chrome-search--docked
-    left: 50%
-    right: auto
-    width: min(640px, calc(100% - 2.5rem))
-    max-width: min(640px, calc(100vw - 11rem))
-    transform: translateX(-50%)
 
 @media screen and (max-width: 700px)
     .chrome-search--docked

--- a/cultpodcasts/src/app/app.component.sass
+++ b/cultpodcasts/src/app/app.component.sass
@@ -129,8 +129,8 @@
     // collapse ~70px through the slot and yank the hero.
     display: flow-root
 
-// Dropped search (in flow) — centered overlay on the hero. Home uses position:
-// sticky so the field glides into the logo row; browse uses --docked + JS gap.
+// Dropped search (in flow) — centered 640px overlay on home. Sticky glides it
+// into the logo row; wide browse uses the same pin. Narrow uses --docked + JS gap.
 .chrome-search
     --search-bar-control-h: var(--nflx-search-h)
     --mat-form-field-container-height: var(--nflx-search-h)
@@ -162,9 +162,9 @@
     z-index: 110
     max-width: min(640px, calc(100vw - 11rem))
 
-// Once sticky `top` has caught, pin with fixed so the short search slot cannot
-// unstick the field. Same 640px box and Y as the overlay — keep --nflx-search-h.
-.home-shell.chrome-stuck .chrome-search:not(.chrome-search--docked)
+// Once sticky `top` has caught (home) — and on every browse/content route —
+// pin with fixed so the field stays 640px in the logo row on wide viewports.
+.chrome-stuck .chrome-search
     position: fixed
     left: 0
     right: 0
@@ -174,6 +174,7 @@
     margin: 0 auto
     transform: none
     height: auto
+    z-index: 110
     pointer-events: auto
 
 @media screen and (max-width: 700px)
@@ -182,7 +183,8 @@
 
 // Docked into the sticky header between logo (left) and add/profile (right).
 // Left/width/top are set in AppComponent.layoutDockedSearch() from those anchors.
-.chrome-search--docked
+// Extra class beats `.chrome-stuck .chrome-search` (same 640px pin) on narrow.
+.chrome-stuck .chrome-search.chrome-search--docked
     position: fixed
     // Fallback before the first measure — leave room for add/profile (JS tightens).
     left: 70px

--- a/cultpodcasts/src/app/app.component.sass
+++ b/cultpodcasts/src/app/app.component.sass
@@ -162,6 +162,16 @@
     z-index: 110
     max-width: min(640px, calc(100vw - 11rem))
 
+@media screen and (max-width: 700px)
+    // Search lives in the header row — do not keep dropped-overlay slot height
+    // (that is the band between the bar and the hero).
+    .home-shell .chrome-search-slot
+        min-height: 0
+        height: 0
+        overflow: hidden
+    .home-shell .chrome-search
+        margin-top: 0
+
 // Once sticky `top` has caught (home) — and on every browse/content route —
 // pin with fixed so the field stays 640px in the logo row on wide viewports.
 .chrome-stuck .chrome-search

--- a/cultpodcasts/src/app/app.component.sass
+++ b/cultpodcasts/src/app/app.component.sass
@@ -35,12 +35,13 @@
                 background: transparent !important
                 border-bottom-color: transparent !important
     .chrome-search
-        width: min(640px, calc(100% - 1.5rem))
+        width: auto
+        margin-left: 58px
+        margin-right: 3.5rem
 
-// Wide home after scroll-dock: restore flow under the fixed bar.
-@media screen and (min-width: 701px)
-    .home-shell.chrome-stuck .site-chrome__bar-spacer
-        height: var(--site-chrome-bar-h)
+// Do not restore .site-chrome__bar-spacer on home dock — that plus position:fixed
+// on .chrome-search collapsed in-flow height and snapped the hero up. Home flow
+// is reserved by .chrome-search-slot (CHROME-DOCK-010).
 
 // (Sticky inside a short .site-chrome parent fails after search docks and leaves flow.)
 .site-chrome
@@ -114,16 +115,32 @@
     background: color-mix(in srgb, var(--nflx-panel, var(--cp-ink-elevated)) 92%, transparent)
     box-shadow: 0 6px 18px rgba(0, 0, 0, 0.28)
 
-// Dropped search (in flow) — scrolls with the page until it meets the fixed logo bar.
+// Holds dropped-search block height on home so docking (position:fixed) cannot
+// collapse document flow and yank the billboard (hero negative-margin pull-up).
+.chrome-search-slot
+    position: relative
+    z-index: 101
+    // Empty after dock — do not intercept billboard clicks under the reserved height.
+    pointer-events: none
+
+.home-shell .chrome-search-slot
+    min-height: var(--site-chrome-h)
+    overflow-anchor: none
+
+// Dropped search (in flow) — same logo↔actions width as the docked header field.
+// Scrolls with the page until it meets the fixed logo bar, then --docked pins it.
 .chrome-search
     --search-bar-control-h: var(--nflx-search-h)
     --mat-form-field-container-height: var(--nflx-search-h)
     --mat-form-field-container-vertical-padding: 0px
     position: relative
     z-index: 101
-    width: min(640px, calc(100% - 2.5rem))
-    margin: var(--site-chrome-search-gap) auto 12px
+    pointer-events: auto
+    width: auto
+    max-width: none
     box-sizing: border-box
+    // Fallback before JS measure — match .chrome-search--docked left/right insets.
+    margin: var(--site-chrome-search-gap) 7rem 12px 70px
     ::ng-deep
         #searchcontainer
             --search-bar-control-h: var(--nflx-search-h)
@@ -141,7 +158,9 @@
 
 @media screen and (max-width: 700px)
     .chrome-search
-        width: min(640px, calc(100% - 1.5rem))
+        width: auto
+        margin-left: 58px
+        margin-right: 3.5rem
 
 // Docked into the sticky header between logo (left) and add/profile (right).
 // Left/width/top are set in AppComponent.layoutDockedSearch() from those anchors.

--- a/cultpodcasts/src/app/app.component.sass
+++ b/cultpodcasts/src/app/app.component.sass
@@ -126,6 +126,9 @@
 .home-shell .chrome-search-slot
     min-height: var(--site-chrome-h)
     overflow-anchor: none
+    // Contain the dropped field's margin-top so docking (position:fixed) cannot
+    // collapse ~70px through the slot and yank the hero.
+    display: flow-root
 
 // Dropped search (in flow) — same logo↔actions width as the docked header field.
 // Scrolls with the page until it meets the fixed logo bar, then --docked pins it.

--- a/cultpodcasts/src/app/app.component.ts
+++ b/cultpodcasts/src/app/app.component.ts
@@ -354,6 +354,10 @@ export class AppComponent implements OnDestroy, AfterViewInit {
     if (searchTop <= barBottom + 2) {
       this.dockAtScrollY = y;
       this.homeScrollDocked.set(true);
+      // Dropped layout used in-flow margin-left. Clear it before --docked
+      // (position:fixed) or leftover margin stacks on left and shifts the field.
+      search.style.marginLeft = '0';
+      search.style.marginRight = '0';
       // Wait for chrome-stuck styles (icon-only logo) before measuring the header gap.
       requestAnimationFrame(() => requestAnimationFrame(() => this.layoutDockedSearch()));
     } else {

--- a/cultpodcasts/src/app/app.component.ts
+++ b/cultpodcasts/src/app/app.component.ts
@@ -98,10 +98,8 @@ export class AppComponent implements OnDestroy, AfterViewInit {
   protected readonly chromeStuck = computed(
     () => !this.isHomePage() || this.homeScrollDocked()
   );
-  /** Browse (and narrow home) stretch search across the logo↔actions gap. Wide home stays 640px sticky. */
-  protected readonly fillHeaderSearchGap = computed(
-    () => !this.isHomePage() || this.narrowChrome()
-  );
+  /** Narrow chrome only: stretch search across the logo↔actions gap. Wide stays 640px. */
+  protected readonly fillHeaderSearchGap = computed(() => this.narrowChrome());
   private scrollRaf = 0;
   private narrowChromeQuery: MediaQueryList | undefined;
   /** Remeasure docked search when toolbar end controls settle (e.g. avatar after auth). */
@@ -322,7 +320,7 @@ export class AppComponent implements OnDestroy, AfterViewInit {
       return;
     }
 
-    // Browse: always docked via chromeStuck computed — just measure the header gap.
+    // Browse: chrome-stuck from first paint. Wide uses the 640px pin; narrow fills the gap.
     if (!this.isHomePage()) {
       if (this.homeScrollDocked()) {
         this.homeScrollDocked.set(false);
@@ -375,16 +373,15 @@ export class AppComponent implements OnDestroy, AfterViewInit {
   }
 
   /**
-   * Pin the search field between the logo mark and add/profile (#socialbuttons)
-   * — or the overflow menu on narrow viewports — inside the sticky header row.
-   * Wide home overlay stays 640px sticky/fixed; browse uses the full header gap.
+   * Narrow chrome: pin search between the logo mark and add/profile (or overflow
+   * menu). Wide viewports keep the 640px centered field — do not stretch the gap.
    */
   private layoutDockedSearch(): void {
     const search = this.chromeSearch?.nativeElement;
     if (!search || !this.chromeStuck()) {
       return;
     }
-    if (this.isHomePage() && !this.isNarrowChrome()) {
+    if (!this.isNarrowChrome()) {
       this.clearDockedSearchLayout(search);
       return;
     }

--- a/cultpodcasts/src/app/app.component.ts
+++ b/cultpodcasts/src/app/app.component.ts
@@ -51,12 +51,6 @@ import { scheduleChromeSync } from './episode-form.util';
 export class AppComponent implements OnDestroy, AfterViewInit {
   private static readonly BACK_TO_TOP_THRESHOLD_PX = 480;
   private static readonly DOCK_INLINE_GAP_PX = 12;
-  /**
-   * Release home search back to the dropped overlay near the top of the page.
-   * Dock itself is geometry (search top meets the logo bar) — do not wait for a
-   * large scroll threshold or the field overlaps the bar then snaps.
-   */
-  private static readonly HOME_UNDOCK_SCROLL_PX = 8;
   /** Match app.component.sass narrow chrome; search stays docked in the header row. */
   private static readonly NARROW_CHROME_MQ = '(max-width: 700px)';
 
@@ -100,11 +94,15 @@ export class AppComponent implements OnDestroy, AfterViewInit {
    * chrome-stuck. Homepage scroll docking uses homeScrollDocked instead.
    */
   private readonly homeScrollDocked = signal(false);
+  private readonly narrowChrome = signal(false);
   protected readonly chromeStuck = computed(
     () => !this.isHomePage() || this.homeScrollDocked()
-  );  private scrollRaf = 0;
-  /** scrollY when search last docked — used to undock without flicker. */
-  private dockAtScrollY = 0;
+  );
+  /** Browse (and narrow home) stretch search across the logo↔actions gap. Wide home stays 640px sticky. */
+  protected readonly fillHeaderSearchGap = computed(
+    () => !this.isHomePage() || this.narrowChrome()
+  );
+  private scrollRaf = 0;
   private narrowChromeQuery: MediaQueryList | undefined;
   /** Remeasure docked search when toolbar end controls settle (e.g. avatar after auth). */
   private chromeEndControlsObserver: ResizeObserver | undefined;
@@ -163,6 +161,7 @@ export class AppComponent implements OnDestroy, AfterViewInit {
   initialiseBrowser() {
     this.addDragListeners();
     this.narrowChromeQuery = window.matchMedia(AppComponent.NARROW_CHROME_MQ);
+    this.narrowChrome.set(this.narrowChromeQuery.matches);
     this.narrowChromeQuery.addEventListener('change', this.onNarrowChromeChange);
     this.addScrollListener();
     window.addEventListener('resize', this.onWindowResize, { passive: true });
@@ -305,11 +304,12 @@ export class AppComponent implements OnDestroy, AfterViewInit {
   };
 
   private readonly onNarrowChromeChange = () => {
+    this.narrowChrome.set(!!this.narrowChromeQuery?.matches);
     this.syncChromeFromScroll();
   };
 
   private isNarrowChrome(): boolean {
-    return !!this.narrowChromeQuery?.matches;
+    return this.narrowChrome();
   }
 
   private syncChromeFromScroll(): void {
@@ -343,27 +343,23 @@ export class AppComponent implements OnDestroy, AfterViewInit {
     }
 
     if (this.homeScrollDocked()) {
-      // Release when the page is back at the top so the field can sit on the hero.
-      if (y < AppComponent.HOME_UNDOCK_SCROLL_PX) {
+      // Release when in-flow overlay would sit below the stick line (same Y as
+      // the pin) — not at a tiny scroll threshold, which teleports the field.
+      if (y < this.homePinAtScrollY(bar, search) - 2) {
         this.homeScrollDocked.set(false);
         this.changeDetector.detectChanges();
         this.layoutDroppedSearch();
       } else {
-        this.layoutDockedSearch();
+        this.clearDockedSearchLayout(search);
       }
       return;
     }
 
-    // Dock when the in-flow search reaches the fixed logo bar (sticky, no jump).
-    const barBottom = bar.getBoundingClientRect().bottom;
-    const searchTop = search.getBoundingClientRect().top;
-    if (searchTop <= barBottom + 2) {
-      this.dockAtScrollY = y;
+    // Pin when sticky `top` has caught — field is already at in-bar Y.
+    if (search.getBoundingClientRect().top <= this.homeStickTop(bar, search) + 1) {
       this.homeScrollDocked.set(true);
-      // Apply --docked in this frame. Waiting 2 rAFs let the in-flow field
-      // scroll under the logo bar (the overlay "disappears").
       this.changeDetector.detectChanges();
-      this.layoutDockedSearch();
+      this.clearDockedSearchLayout(search);
     } else {
       this.layoutDroppedSearch();
     }
@@ -381,15 +377,15 @@ export class AppComponent implements OnDestroy, AfterViewInit {
   /**
    * Pin the search field between the logo mark and add/profile (#socialbuttons)
    * — or the overflow menu on narrow viewports — inside the sticky header row.
-   * Wide home overlay stays 640px centered; browse uses the full header gap.
+   * Wide home overlay stays 640px sticky/fixed; browse uses the full header gap.
    */
   private layoutDockedSearch(): void {
     const search = this.chromeSearch?.nativeElement;
     if (!search || !this.chromeStuck()) {
       return;
     }
-    if (this.homeScrollDocked() && !this.isNarrowChrome()) {
-      this.layoutHomeDockedSearch();
+    if (this.isHomePage() && !this.isNarrowChrome()) {
+      this.clearDockedSearchLayout(search);
       return;
     }
     const gap = this.measureChromeSearchGap();
@@ -399,23 +395,22 @@ export class AppComponent implements OnDestroy, AfterViewInit {
     this.applySearchGapStyles(search, gap);
   }
 
-  /** Pin the 640px overlay into the header without stretching to the logo↔actions gap. */
-  private layoutHomeDockedSearch(): void {
-    const bar = this.chromeBar?.nativeElement;
-    const search = this.chromeSearch?.nativeElement;
-    if (!bar || !search) {
-      return;
-    }
+  /** Viewport Y where the overlay becomes stuck in the logo row (matches Sass `top`). */
+  private homeStickTop(bar: HTMLElement, search: HTMLElement): number {
     const barHeight = Math.max(bar.getBoundingClientRect().height, 52);
-    const searchHeight = Math.min(search.offsetHeight || 40, barHeight - 8);
-    const top = Math.max(0, (barHeight - searchHeight) / 2);
-    search.style.left = '50%';
-    search.style.right = 'auto';
-    search.style.width = '';
-    search.style.marginLeft = '0';
-    search.style.marginRight = '0';
-    search.style.top = `${top}px`;
-    search.style.transform = 'translateX(-50%)';
+    const searchHeight = Math.min(search.offsetHeight || 48, barHeight - 8);
+    return Math.max(0, (barHeight - searchHeight) / 2);
+  }
+
+  /** scrollY at which in-flow overlay Y equals `homeStickTop` (no teleport). */
+  private homePinAtScrollY(bar: HTMLElement, search: HTMLElement): number {
+    const shell = bar.closest('#body');
+    const gapRaw = shell
+      ? getComputedStyle(shell).getPropertyValue('--site-chrome-search-gap')
+      : '';
+    const gap = Number.parseFloat(gapRaw) || 12;
+    const barHeight = Math.max(bar.getBoundingClientRect().height, 52);
+    return barHeight + gap - this.homeStickTop(bar, search);
   }
 
   /** Home at rest: drop docked inline left/width so CSS can center the overlay. */

--- a/cultpodcasts/src/app/app.component.ts
+++ b/cultpodcasts/src/app/app.component.ts
@@ -322,6 +322,9 @@ export class AppComponent implements OnDestroy, AfterViewInit {
 
     // Browse: always docked via chromeStuck computed — just measure the header gap.
     if (!this.isHomePage()) {
+      if (this.homeScrollDocked()) {
+        this.homeScrollDocked.set(false);
+      }
       this.layoutDockedSearch();
       return;
     }
@@ -354,10 +357,8 @@ export class AppComponent implements OnDestroy, AfterViewInit {
     if (searchTop <= barBottom + 2) {
       this.dockAtScrollY = y;
       this.homeScrollDocked.set(true);
-      // Dropped layout used in-flow margin-left. Clear it before --docked
-      // (position:fixed) or leftover margin stacks on left and shifts the field.
-      search.style.marginLeft = '0';
-      search.style.marginRight = '0';
+      // Overlay uses margin:auto; do not leave browse-dock inline width on the field.
+      this.clearDockedSearchLayout(search);
       // Wait for chrome-stuck styles (icon-only logo) before measuring the header gap.
       requestAnimationFrame(() => requestAnimationFrame(() => this.layoutDockedSearch()));
     } else {
@@ -365,7 +366,7 @@ export class AppComponent implements OnDestroy, AfterViewInit {
     }
   }
 
-  /** Docked (fixed in the bar) or dropped (in-flow overlay) — same logo↔actions width. */
+  /** Docked (fixed in the bar) or dropped (centered overlay) — do not keep docked width on the overlay. */
   private layoutChromeSearch(): void {
     if (this.chromeStuck()) {
       this.layoutDockedSearch();
@@ -377,28 +378,50 @@ export class AppComponent implements OnDestroy, AfterViewInit {
   /**
    * Pin the search field between the logo mark and add/profile (#socialbuttons)
    * — or the overflow menu on narrow viewports — inside the sticky header row.
+   * Wide home overlay stays 640px centered; browse uses the full header gap.
    */
   private layoutDockedSearch(): void {
     const search = this.chromeSearch?.nativeElement;
-    const gap = this.measureChromeSearchGap();
-    if (!search || !gap || !this.chromeStuck()) {
+    if (!search || !this.chromeStuck()) {
       return;
     }
-    this.applySearchGapStyles(search, gap, 'docked');
+    if (this.homeScrollDocked() && !this.isNarrowChrome()) {
+      this.layoutHomeDockedSearch();
+      return;
+    }
+    const gap = this.measureChromeSearchGap();
+    if (!gap) {
+      return;
+    }
+    this.applySearchGapStyles(search, gap);
   }
 
-  /** Home at rest: same horizontal gap as docked, still in flow on the hero. */
+  /** Pin the 640px overlay into the header without stretching to the logo↔actions gap. */
+  private layoutHomeDockedSearch(): void {
+    const bar = this.chromeBar?.nativeElement;
+    const search = this.chromeSearch?.nativeElement;
+    if (!bar || !search) {
+      return;
+    }
+    const barHeight = Math.max(bar.getBoundingClientRect().height, 52);
+    const searchHeight = Math.min(search.offsetHeight || 40, barHeight - 8);
+    const top = Math.max(0, (barHeight - searchHeight) / 2);
+    search.style.left = '50%';
+    search.style.right = 'auto';
+    search.style.width = '';
+    search.style.marginLeft = '0';
+    search.style.marginRight = '0';
+    search.style.top = `${top}px`;
+    search.style.transform = 'translateX(-50%)';
+  }
+
+  /** Home at rest: drop docked inline left/width so CSS can center the overlay. */
   private layoutDroppedSearch(): void {
     const search = this.chromeSearch?.nativeElement;
     if (!search || this.chromeStuck()) {
       return;
     }
-    const gap = this.measureChromeSearchGap();
-    if (!gap) {
-      this.clearDockedSearchLayout(search);
-      return;
-    }
-    this.applySearchGapStyles(search, gap, 'dropped');
+    this.clearDockedSearchLayout(search);
   }
 
   private measureChromeSearchGap(): { left: number; width: number; top: number } | null {
@@ -434,25 +457,15 @@ export class AppComponent implements OnDestroy, AfterViewInit {
 
   private applySearchGapStyles(
     search: HTMLElement,
-    gap: { left: number; width: number; top: number },
-    mode: 'docked' | 'dropped'
+    gap: { left: number; width: number; top: number }
   ): void {
     search.style.right = 'auto';
     search.style.width = `${gap.width}px`;
+    search.style.marginLeft = '0';
     search.style.marginRight = '0';
-    if (mode === 'docked') {
-      // position:fixed — viewport left/top.
-      search.style.left = `${gap.left}px`;
-      search.style.marginLeft = '0';
-      search.style.top = `${gap.top}px`;
-      search.style.transform = 'none';
-    } else {
-      // position:relative — in-flow margin, not left (left would shift without shrinking layout).
-      search.style.left = '';
-      search.style.marginLeft = `${gap.left}px`;
-      search.style.top = '';
-      search.style.transform = '';
-    }
+    search.style.left = `${gap.left}px`;
+    search.style.top = `${gap.top}px`;
+    search.style.transform = 'none';
   }
 
   /** Remeasure when add/profile/menu size changes (avatar swap after hydration). */

--- a/cultpodcasts/src/app/app.component.ts
+++ b/cultpodcasts/src/app/app.component.ts
@@ -50,8 +50,12 @@ import { scheduleChromeSync } from './episode-form.util';
 export class AppComponent implements OnDestroy, AfterViewInit {
   private static readonly BACK_TO_TOP_THRESHOLD_PX = 480;
   private static readonly DOCK_INLINE_GAP_PX = 12;
-  /** Don't dock at rest on wide — homepage search must start dropped below the fixed bar. */
-  private static readonly MIN_SCROLL_TO_DOCK_PX = 40;
+  /**
+   * Release home search back to the dropped overlay near the top of the page.
+   * Dock itself is geometry (search top meets the logo bar) — do not wait for a
+   * large scroll threshold or the field overlaps the bar then snaps.
+   */
+  private static readonly HOME_UNDOCK_SCROLL_PX = 8;
   /** Match app.component.sass narrow chrome; search stays docked in the header row. */
   private static readonly NARROW_CHROME_MQ = '(max-width: 700px)';
 
@@ -295,9 +299,7 @@ export class AppComponent implements OnDestroy, AfterViewInit {
   };
 
   private readonly onWindowResize = () => {
-    if (this.chromeStuck()) {
-      this.layoutDockedSearch();
-    }
+    this.layoutChromeSearch();
   };
 
   private readonly onNarrowChromeChange = () => {
@@ -336,22 +338,17 @@ export class AppComponent implements OnDestroy, AfterViewInit {
     }
 
     if (this.homeScrollDocked()) {
-      // Release back to the dropped layout near the top of the homepage.
-      if (y < AppComponent.MIN_SCROLL_TO_DOCK_PX) {
+      // Release when the page is back at the top so the field can sit on the hero.
+      if (y < AppComponent.HOME_UNDOCK_SCROLL_PX) {
         this.homeScrollDocked.set(false);
-        this.clearDockedSearchLayout(search);
+        this.layoutDroppedSearch();
       } else {
         this.layoutDockedSearch();
       }
       return;
     }
 
-    // Keep search dropped at the top of the homepage (hero overlay).
-    if (y < AppComponent.MIN_SCROLL_TO_DOCK_PX) {
-      return;
-    }
-
-    // Dock when the scrolling search meets the fixed logo bar.
+    // Dock when the in-flow search reaches the fixed logo bar (sticky, no jump).
     const barBottom = bar.getBoundingClientRect().bottom;
     const searchTop = search.getBoundingClientRect().top;
     if (searchTop <= barBottom + 2) {
@@ -359,6 +356,17 @@ export class AppComponent implements OnDestroy, AfterViewInit {
       this.homeScrollDocked.set(true);
       // Wait for chrome-stuck styles (icon-only logo) before measuring the header gap.
       requestAnimationFrame(() => requestAnimationFrame(() => this.layoutDockedSearch()));
+    } else {
+      this.layoutDroppedSearch();
+    }
+  }
+
+  /** Docked (fixed in the bar) or dropped (in-flow overlay) — same logo↔actions width. */
+  private layoutChromeSearch(): void {
+    if (this.chromeStuck()) {
+      this.layoutDockedSearch();
+    } else {
+      this.layoutDroppedSearch();
     }
   }
 
@@ -367,10 +375,33 @@ export class AppComponent implements OnDestroy, AfterViewInit {
    * — or the overflow menu on narrow viewports — inside the sticky header row.
    */
   private layoutDockedSearch(): void {
+    const search = this.chromeSearch?.nativeElement;
+    const gap = this.measureChromeSearchGap();
+    if (!search || !gap || !this.chromeStuck()) {
+      return;
+    }
+    this.applySearchGapStyles(search, gap, 'docked');
+  }
+
+  /** Home at rest: same horizontal gap as docked, still in flow on the hero. */
+  private layoutDroppedSearch(): void {
+    const search = this.chromeSearch?.nativeElement;
+    if (!search || this.chromeStuck()) {
+      return;
+    }
+    const gap = this.measureChromeSearchGap();
+    if (!gap) {
+      this.clearDockedSearchLayout(search);
+      return;
+    }
+    this.applySearchGapStyles(search, gap, 'dropped');
+  }
+
+  private measureChromeSearchGap(): { left: number; width: number; top: number } | null {
     const bar = this.chromeBar?.nativeElement;
     const search = this.chromeSearch?.nativeElement;
-    if (!bar || !search || !this.chromeStuck()) {
-      return;
+    if (!bar || !search) {
+      return null;
     }
 
     const site = bar.querySelector('#site') as HTMLElement | null;
@@ -380,26 +411,44 @@ export class AppComponent implements OnDestroy, AfterViewInit {
     const socialVisible = !!social && social.getClientRects().length > 0;
     const end = socialVisible ? social : menu;
     if (!site || !end) {
-      return;
+      return null;
     }
 
     // Anchor to the logo image so a still-visible title span cannot steal the gap.
     const siteAnchor = (site.querySelector('img') as HTMLElement | null) ?? site;
-    const gap = AppComponent.DOCK_INLINE_GAP_PX;
+    const inset = AppComponent.DOCK_INLINE_GAP_PX;
     const siteRect = siteAnchor.getBoundingClientRect();
     const endRect = end.getBoundingClientRect();
     const barHeight = Math.max(bar.getBoundingClientRect().height, 52);
-    const left = Math.max(gap, Math.round(siteRect.right + gap));
-    const right = Math.min(window.innerWidth - gap, Math.round(endRect.left - gap));
+    const left = Math.max(inset, Math.round(siteRect.right + inset));
+    const right = Math.min(window.innerWidth - inset, Math.round(endRect.left - inset));
     const width = Math.max(120, right - left);
     const searchHeight = Math.min(search.offsetHeight || 40, barHeight - 8);
     const top = Math.max(0, (barHeight - searchHeight) / 2);
+    return { left, width, top };
+  }
 
-    search.style.left = `${left}px`;
+  private applySearchGapStyles(
+    search: HTMLElement,
+    gap: { left: number; width: number; top: number },
+    mode: 'docked' | 'dropped'
+  ): void {
     search.style.right = 'auto';
-    search.style.width = `${width}px`;
-    search.style.top = `${top}px`;
-    search.style.transform = 'none';
+    search.style.width = `${gap.width}px`;
+    search.style.marginRight = '0';
+    if (mode === 'docked') {
+      // position:fixed — viewport left/top.
+      search.style.left = `${gap.left}px`;
+      search.style.marginLeft = '0';
+      search.style.top = `${gap.top}px`;
+      search.style.transform = 'none';
+    } else {
+      // position:relative — in-flow margin, not left (left would shift without shrinking layout).
+      search.style.left = '';
+      search.style.marginLeft = `${gap.left}px`;
+      search.style.top = '';
+      search.style.transform = '';
+    }
   }
 
   /** Remeasure when add/profile/menu size changes (avatar swap after hydration). */
@@ -413,9 +462,7 @@ export class AppComponent implements OnDestroy, AfterViewInit {
     }
     this.chromeEndControlsObserver?.disconnect();
     this.chromeEndControlsObserver = new ResizeObserver(() => {
-      if (this.chromeStuck()) {
-        this.layoutDockedSearch();
-      }
+      this.layoutChromeSearch();
     });
     const social = bar.querySelector('#socialbuttons');
     const menu = bar.querySelector('button#menu');
@@ -433,6 +480,8 @@ export class AppComponent implements OnDestroy, AfterViewInit {
     search.style.width = '';
     search.style.top = '';
     search.style.transform = '';
+    search.style.marginLeft = '';
+    search.style.marginRight = '';
   }
 
   private readonly onDocumentDragEnter = (event: DragEvent) => {

--- a/cultpodcasts/src/app/app.component.ts
+++ b/cultpodcasts/src/app/app.component.ts
@@ -1,6 +1,7 @@
 import {
   AfterViewInit,
   ChangeDetectionStrategy,
+  ChangeDetectorRef,
   Component,
   DestroyRef,
   ElementRef,
@@ -117,6 +118,7 @@ export class AppComponent implements OnDestroy, AfterViewInit {
   @ViewChild('chromeSearch')
   private chromeSearch?: ElementRef<HTMLElement>;
 
+  private readonly changeDetector = inject(ChangeDetectorRef);
   private readonly destroyRef = inject(DestroyRef);
   private readonly webPushService = inject(WebPushService);
   private readonly dialog = inject(MatDialog);
@@ -344,6 +346,7 @@ export class AppComponent implements OnDestroy, AfterViewInit {
       // Release when the page is back at the top so the field can sit on the hero.
       if (y < AppComponent.HOME_UNDOCK_SCROLL_PX) {
         this.homeScrollDocked.set(false);
+        this.changeDetector.detectChanges();
         this.layoutDroppedSearch();
       } else {
         this.layoutDockedSearch();
@@ -357,10 +360,10 @@ export class AppComponent implements OnDestroy, AfterViewInit {
     if (searchTop <= barBottom + 2) {
       this.dockAtScrollY = y;
       this.homeScrollDocked.set(true);
-      // Overlay uses margin:auto; do not leave browse-dock inline width on the field.
-      this.clearDockedSearchLayout(search);
-      // Wait for chrome-stuck styles (icon-only logo) before measuring the header gap.
-      requestAnimationFrame(() => requestAnimationFrame(() => this.layoutDockedSearch()));
+      // Apply --docked in this frame. Waiting 2 rAFs let the in-flow field
+      // scroll under the logo bar (the overlay "disappears").
+      this.changeDetector.detectChanges();
+      this.layoutDockedSearch();
     } else {
       this.layoutDroppedSearch();
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Home overlay search is the **centered 640px** field. Scrolling slides it into the logo row (`sticky` then `fixed` at the same Y).
- **Wide browse/podcast/content pages use that same 640px pin** — they no longer stretch search across the logo↔actions gap.
- Narrow chrome (≤700px) still fills the header row between logo and actions.
- **Mobile home: search-slot height is 0** so the hero sits under the bar instead of leaving a band below the search field.
- Slot `min-height` + `flow-root` still reserve dropped-search height on wide home. Slot has no `z-index` so the field cannot paint under the toolbar.
- Includes Cursor Cloud setup notes from #478.

## Config / secrets

- [x] No new secrets / env keys

## Test plan

- [x] Playwright CHROME-HIT-001 (home glide), CHROME-HIT-002 (wide browse ≤640px), CHROME-HIT-003 (narrow slot height 0)
- [x] Chrome dock contract: narrow media query zeros `.home-shell .chrome-search-slot` min-height
- [x] Live 390px: slot height 0, `.nflx` at top 0
- [ ] Cold-load `/` on a phone: hero flush under the header, no band under search
- [ ] Desktop podcast: search still ~640px centered

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-18a04391-baf1-458a-bb79-c6482ddeecc1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-18a04391-baf1-458a-bb79-c6482ddeecc1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

