### PR TITLE
fix(ui): cap search and hero descriptions at 180 chars

### DIFF
--- a/cultpodcasts/package-lock.json
+++ b/cultpodcasts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.112",
+  "version": "1.10.113",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cultpodcasts",
-      "version": "1.10.112",
+      "version": "1.10.113",
       "dependencies": {
         "@angular/cdk": "22.1.0",
         "@angular/common": "22.1.0",

--- a/cultpodcasts/package.json
+++ b/cultpodcasts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultpodcasts",
-  "version": "1.10.112",
+  "version": "1.10.113",
   "scripts": {
     "ng": "ng",
     "start": "node ./tools/start-local.mjs",

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.spec.ts
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.spec.ts
@@ -5,6 +5,7 @@ import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { HomepageHeroComponent } from './homepage-hero.component';
+import { SEARCH_DESCRIPTION_SIZE } from '../search-description';
 import { HomepageEpisode } from '../homepage-episode.interface';
 import { PlayerService } from '../player.service';
 
@@ -258,7 +259,7 @@ describe('HomepageHeroComponent', () => {
     const desc = component['featuredDesc']();
     expect(desc.length).toBeLessThan(long.length);
     expect(desc.endsWith('…')).toBe(true);
-    expect(desc.startsWith('x'.repeat(220).trim())).toBe(true);
+    expect(desc.startsWith('x'.repeat(SEARCH_DESCRIPTION_SIZE).trim())).toBe(true);
   });
 
   it('jumps to a slide when its hero dash is clicked', () => {

--- a/cultpodcasts/src/app/homepage-hero/homepage-hero.component.ts
+++ b/cultpodcasts/src/app/homepage-hero/homepage-hero.component.ts
@@ -25,6 +25,7 @@ import { SubjectChipComponent } from '../subject-chip/subject-chip.component';
 import { canPlayEpisode, playActionLabel, startEpisodePlayback } from '../episode-embed';
 import { displayCatalogName } from '../display-catalog-name';
 import { releaseDateLabel } from '../release-label';
+import { formatSearchDescription } from '../search-description';
 
 @Component({
   selector: 'app-homepage-hero',
@@ -105,10 +106,9 @@ export class HomepageHeroComponent {
     return ep ? episodeImageUrl(ep)?.toString() : undefined;
   });
 
-  protected readonly featuredDesc = computed(() => {
-    const text = this.featured()?.episodeDescription ?? '';
-    return text.length > 220 ? `${text.slice(0, 220).trim()}…` : text;
-  });
+  protected readonly featuredDesc = computed(() =>
+    formatSearchDescription(this.featured()?.episodeDescription)
+  );
 
   protected readonly hasFeaturedDesc = computed(() => this.featuredDesc().trim().length > 0);
 

--- a/cultpodcasts/src/app/search-description.spec.ts
+++ b/cultpodcasts/src/app/search-description.spec.ts
@@ -28,4 +28,12 @@ describe('formatSearchDescription', () => {
 
     expect(formatSearchDescription(hardTruncated)).toBe(`${prefix} Salt\u2026`);
   });
+
+  it('caps homepage-length copy at the search size then mid-word ellipsis', () => {
+    const prefix = 'x'.repeat(SEARCH_DESCRIPTION_SIZE - 9);
+    const fullR2 = `${prefix} Salt Lake City extra homepage copy that exceeds the search cap`;
+    expect(fullR2.length).toBeGreaterThan(SEARCH_DESCRIPTION_SIZE);
+
+    expect(formatSearchDescription(fullR2)).toBe(`${prefix} Salt\u2026`);
+  });
 });

--- a/cultpodcasts/src/app/search-description.ts
+++ b/cultpodcasts/src/app/search-description.ts
@@ -1,5 +1,5 @@
 /** Matches RedditPodcastPoster.Search.Constants.DescriptionSize */
-export const SEARCH_DESCRIPTION_SIZE = 230;
+export const SEARCH_DESCRIPTION_SIZE = 180;
 
 /** Unicode ellipsis (U+2026) — not three ASCII periods. */
 const ELLIPSIS = '\u2026';
@@ -18,6 +18,14 @@ export function formatSearchDescription(description: string | null | undefined):
   if (text.endsWith('...')) {
     text = `${text.slice(0, -3)}${ELLIPSIS}`;
   }
+  if (text.endsWith(ELLIPSIS) && text.length <= SEARCH_DESCRIPTION_SIZE) {
+    return text;
+  }
+
+  if (text.length > SEARCH_DESCRIPTION_SIZE) {
+    text = text.slice(0, SEARCH_DESCRIPTION_SIZE);
+  }
+
   if (text.endsWith(ELLIPSIS)) {
     return text;
   }


### PR DESCRIPTION
## Summary
- Lower `SEARCH_DESCRIPTION_SIZE` from 230 to 180 so client formatting matches the shorter search-index `DescriptionSize`.
- Truncate homepage hero `featuredDesc` with `formatSearchDescription` (word-boundary ellipsis) instead of a hard 220-character slice, so featured copy stays on the same cap as search cards and episode pages.
- Bump the client to 1.10.113.

## Config / secrets
- [ ] Pages Preview: N/A
- [ ] Pages Production: N/A

## Test plan
- [ ] Vitest: `search-description.spec.ts` and `homepage-hero.component.spec.ts` (38 passed locally)
- [ ] Search results show descriptions capped at ~180 with a unicode ellipsis at a word boundary (not mid-word leftover)
- [ ] Homepage hero featured description uses the same cap (HERO-SCR-002/004/005: desc still omitted when empty; short vs long copy does not collapse/blank-band)
- [ ] Episode page `searchDescription` pipe still formats index-truncated copy
- [ ] CI `test:all` (unit + Playwright, including hero layout)